### PR TITLE
Stop padding inputs already divisible by 4

### DIFF
--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -23,7 +23,9 @@ signing_methods = {
 }
 
 def base64url_decode(input):
-    input += '=' * (4 - (len(input) % 4))
+    rem = len(input) % 4
+    if rem > 0:
+        input += '=' * (4 - rem)
     return base64.urlsafe_b64decode(input)
 
 def base64url_encode(input):


### PR DESCRIPTION
Because base64.b64decode is super accommodating nothing was actually broken, but it might confuse people reading it.
