### PR TITLE
Add decode segment errors

### DIFF
--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -59,12 +59,26 @@ def decode(jwt, key='', verify=True):
         header_segment, payload_segment = signing_input.split('.', 1)
     except ValueError:
         raise DecodeError("Not enough segments")
+
     try:
         header = json.loads(base64url_decode(header_segment))
+    except TypeError:
+        raise DecodeError("Invalid header padding")
+    except ValueError as e:
+        raise DecodeError("Invalid header string: " + e)
+
+    try:
         payload = json.loads(base64url_decode(payload_segment))
+    except TypeError:
+        raise DecodeError("Invalid payload padding")
+    except ValueError as e:
+        raise DecodeError("Invalid payload string: " + e)
+
+    try:
         signature = base64url_decode(crypto_segment)
-    except (ValueError, TypeError):
-        raise DecodeError("Invalid segment encoding")
+    except TypeError:
+        raise DecodeError("Invalid crypto padding")
+
     if verify:
         try:
             if isinstance(key, unicode):

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -62,6 +62,36 @@ class TestJWT(unittest.TestCase):
         decoded_payload = jwt.decode(example_jwt, example_secret)
         self.assertEqual(decoded_payload, example_payload)
 
+    def test_decode_invalid_header_padding(self):
+        example_jwt = unicode("aeyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJoZWxsbyI6ICJ3b3JsZCJ9.tvagLDLoaiJKxOKqpBXSEGy7SYSifZhjntgm9ctpyj8")
+        example_secret = "secret"
+        jwt_message = jwt.decode(example_jwt, example_secret)
+        self.assertRaises(jwt.DecodeError, "Invalid header padding")
+
+    def test_decode_invalid_header_string(self):
+        example_jwt = unicode("eyJhbGciOiAiSFMyNTbpIiwgInR5cCI6ICJKV1QifQ==.eyJoZWxsbyI6ICJ3b3JsZCJ9.tvagLDLoaiJKxOKqpBXSEGy7SYSifZhjntgm9ctpyj8")
+        example_secret = "secret"
+        jwt_message = jwt.decode(example_jwt, example_secret)
+        self.assertRaisesRegexp(jwt.DecodeError, "Invalid header string")
+
+    def test_decode_invalid_payload_padding(self):
+        example_jwt = unicode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.aeyJoZWxsbyI6ICJ3b3JsZCJ9.tvagLDLoaiJKxOKqpBXSEGy7SYSifZhjntgm9ctpyj8")
+        example_secret = "secret"
+        jwt_message = jwt.decode(example_jwt, example_secret)
+        self.assertRaises(jwt.DecodeError, "Invalid payload padding")
+
+    def test_decode_invalid_payload_string(self):
+        example_jwt = unicode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJoZWxsb-kiOiAid29ybGQifQ==.tvagLDLoaiJKxOKqpBXSEGy7SYSifZhjntgm9ctpyj8")
+        example_secret = "secret"
+        jwt_message = jwt.decode(example_jwt, example_secret)
+        self.assertRaisesRegexp(jwt.DecodeError, "Invalid payload string")
+
+    def test_decode_invalid_crypto_padding(self):
+        example_jwt = unicode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJoZWxsbyI6ICJ3b3JsZCJ9.aatvagLDLoaiJKxOKqpBXSEGy7SYSifZhjntgm9ctpyj8")
+        example_secret = "secret"
+        jwt_message = jwt.decode(example_jwt, example_secret)
+        self.assertRaises(jwt.DecodeError, "Invalid crypto padding")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Specify whether error in heading or string
- Add test cases
- TODO: Refactor errors & tests

Notes:

Think this is a good idea, since I'm always having to manually run base64.urlsafe_b64decode / json.loads to see what went wrong.
