### PR TITLE
Add support for expiration date verification in jwt.decode

### DIFF
--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -77,7 +77,7 @@ def encode(payload, key, algorithm='HS256'):
     return '.'.join(segments)
 
 
-def decode(jwt, key='', verify=True, leeway=0):
+def decode(jwt, key='', verify=True, verify_expiration=True, leeway=0):
     try:
         signing_input, crypto_segment = str(jwt).rsplit('.', 1)
         header_segment, payload_segment = signing_input.split('.', 1)
@@ -112,7 +112,7 @@ def decode(jwt, key='', verify=True, leeway=0):
         except KeyError:
             raise DecodeError("Algorithm not supported")
 
-        if 'exp' in payload:
+        if 'exp' in payload and verify_expiration:
             utc_timestamp = timegm(datetime.utcnow().utctimetuple())
             if payload['exp'] < (utc_timestamp - leeway):
                 raise ExpiredSignature("Signature has expired")

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -119,6 +119,12 @@ class TestJWT(unittest.TestCase):
         with self.assertRaises(jwt.ExpiredSignature):
             jwt.decode(jwt_message, secret)
 
+    def test_decode_skip_expiration_verification(self):
+        self.payload['exp'] = time.time() - 1
+        secret = 'secret'
+        jwt_message = jwt.encode(self.payload, secret)
+        jwt.decode(jwt_message, secret, verify_expiration=False)
+
     def test_decode_with_expiration_with_leeway(self):
         self.payload['exp'] = utc_timestamp() - 2
         secret = 'secret'


### PR DESCRIPTION
In order to avoid replay attacks, we need support expiration date support in pyjwt. Here is a first naive implementation.

Rfc for reference:

```
The exp (expiration time) claim identifies the expiration time on or after
which the JWT MUST NOT be accepted for processing. The processing of the
exp claim requires that the current date/time MUST be before the expiration
date/time listed in the exp claim. Implementers MAY provide for some small
leeway, usually no more than a few minutes, to account for clock skew. Its
value MUST be a number containing an IntDate value. Use of this claim is
OPTIONAL.
```
