### PR TITLE
Add a check in jwt.encode for data type.

### DIFF
--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -10,6 +10,7 @@ import hmac
 from time import time
 from datetime import datetime
 from calendar import timegm
+from collections import Mapping
 
 try:
     import json
@@ -55,6 +56,11 @@ def header(jwt):
 
 def encode(payload, key, algorithm='HS256'):
     segments = []
+
+    # Check that we get a mapping
+    if not isinstance(payload, Mapping):
+        raise TypeError("Expecting a mapping object, as json web token only"
+                        "support json objects.")
 
     # Header
     header = {"typ": "JWT", "alg": algorithm}

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -22,6 +22,14 @@ class TestJWT(unittest.TestCase):
         decoded_payload = jwt.decode(jwt_message, secret)
         self.assertEqual(decoded_payload, self.payload)
 
+    def test_encode_bad_type(self):
+
+        types = ['string', tuple(), list(), 42, set()]
+
+        for t in types:
+            with self.assertRaises(TypeError):
+                jwt.encode(t, 'secret')
+
     def test_encode_expiration_datetime(self):
         secret = "secret"
         current_datetime = datetime.utcnow()


### PR DESCRIPTION
When using latest version of pyjwt, I get some strange errors because I was trying to encode strings with pyjwt. As JWT rfc explicitly refers to json object, I added a check in jwt.encode for raising an exception if we try to pass something else than a mapping.
