### PR TITLE
Remove time import

### DIFF
--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -7,7 +7,6 @@ import base64
 import hashlib
 import hmac
 
-from time import time
 from datetime import datetime
 from calendar import timegm
 from collections import Mapping


### PR DESCRIPTION
time import removed, seems like it is no longer needed since this change:
https://github.com/progrium/pyjwt/commit/b3c377a1a918ed39f663c699018e1ccb5d8b4ea2
