### PR TITLE
Added some convenience features

### DIFF
--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -81,9 +81,9 @@ try:
     })
 
     def prepare_RS_key(key):
-        if isinstance(key, basestring) and key.startswith('-----BEGIN '):
+        if isinstance(key, basestring):
             if isinstance(key, unicode):
-                key = key.encode('utf-8')            
+                key = key.encode('utf-8')
             key = RSA.importKey(key)
         elif isinstance(key, RSA._RSAobj):
             pass


### PR DESCRIPTION
I added two features for convenience:
1) datetime conversion for 'iat' and 'nbf' as well.
Previously 'exp' was the only thing supported.
These two claims are the two standard claims also in time format (http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#issDef).

2) key value for RS\* algorithms are converted automatically from a PEM string.
I don't want to fuss around with the details like format conversions, importing packages, etc.
Since Crypto packages is already imported and handled internally, it appears a good idea to have them handle the key conversion as well.
