### PR TITLE
Let `header()` support unicode input, like `decode()`.

### DIFF
--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -143,10 +143,12 @@ def base64url_encode(input):
 
 
 def header(jwt):
+    if isinstance(jwt, unicode):
+        jwt = jwt.encode('utf-8')
     header_segment = jwt.split(b'.', 1)[0]
     try:
-        header_data = base64url_decode(header_segment).decode('utf-8')
-        return json.loads(header_data)
+        header_data = base64url_decode(header_segment)
+        return json.loads(header_data.decode('utf-8'))
     except (ValueError, TypeError):
         raise DecodeError('Invalid header encoding')
 


### PR DESCRIPTION
When invoking `header()` before `decode()` on the same JWT, you could run into `DecodeError("Invalid header encoding")` if the JWT input was unicode. This aligns `header()` with `decode()`.
