### PR TITLE
Fix a part of test_encode_decode_with_ecdsa_sha384 so that it actually uses the right key when testing passing a SSH public key as a string argument to decode()

### DIFF
--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1,12 +1,12 @@
 from __future__ import unicode_literals
 
+import json
+import sys
+import time
+
 from calendar import timegm
 from datetime import datetime
 from decimal import Decimal
-
-import sys
-import time
-import json
 
 import jwt
 
@@ -630,7 +630,7 @@ class TestJWT(unittest.TestCase):
                                      algorithm='ES384')
 
         with open('tests/testkey_ec.pub', 'r') as ec_pub_file:
-            pub_rsakey = ec_pub_file.read()
+            pub_eckey = ec_pub_file.read()
             assert jwt.decode(jwt_message, pub_eckey)
 
             load_output = jwt.load(jwt_message)


### PR DESCRIPTION
Fixed a bug in the `test_encode_decode_with_ecdsa_sha384` test where the public key that was generated from using `load_pem_public_key()` at an earlier phase of the test is accidentally used instead of the string that is read from `ec_pub_file` which kind of defeats the point of that stage of the test.

Tests still pass though... so that's good! :-)
