### PR TITLE
Refactored package information so it only has to be in one place

### DIFF
--- a/jwt/__about__.py
+++ b/jwt/__about__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+__all__ = [
+    "__title__", "__description__", "__url__", "__version__", "__author__",
+    "__email__", "__license__", "__copyright__", "__description__"
+]
+
+__title__ = 'pyjwt'
+__version__ = '0.4.1'
+__author__ = 'José Padilla'
+__email__ = 'hello@jpadilla.com'
+__license__ = 'MIT'
+__copyright__ = 'Copyright 2015 José Padilla'
+__url__ = 'http://github.com/jpadilla/pyjwt'
+__description__ = 'JSON Web Token implementation in Python'

--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # flake8: noqa
 
 """
@@ -9,11 +8,10 @@ http://self-issued.info/docs/draft-jones-json-web-token-01.html
 """
 
 
-__title__ = 'pyjwt'
-__version__ = '0.4.1'
-__author__ = 'José Padilla'
-__license__ = 'MIT'
-__copyright__ = 'Copyright 2015 José Padilla'
+from .__about__ import (
+    __title__, __description__, __url__, __version__, __author__,
+    __email__, __license__, __copyright__, __description__
+)
 
 
 from .api import encode, decode, register_algorithm

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
-import re
 import sys
 
 from setuptools import setup
@@ -19,7 +18,7 @@ if sys.argv[-1] == 'publish':
     os.system("python setup.py sdist upload")
     os.system("python setup.py bdist_wheel upload")
     print("You probably want to also tag the version now:")
-    print("  git tag -a %s -m 'version %s'" % (version, version))
+    print("  git tag -a %s -m 'version %s'" % (about['__version__'], about['__version__']))
     print("  git push --tags")
     sys.exit()
 

--- a/setup.py
+++ b/setup.py
@@ -6,16 +6,10 @@ import sys
 
 from setuptools import setup
 
+about = {}
 
-def get_version(package):
-    """
-    Return package version as listed in `__version__` in `init.py`.
-    """
-    init_py = open(os.path.join(package, '__init__.py')).read()
-    return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
-
-
-version = get_version('jwt')
+with open(os.path.join("jwt", "__about__.py")) as f:
+    exec(f.read(), about)
 
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
     long_description = readme.read()
@@ -31,14 +25,14 @@ if sys.argv[-1] == 'publish':
 
 
 setup(
-    name='PyJWT',
-    version=version,
-    author='José Padilla',
-    author_email='hello@jpadilla.com',
-    description='JSON Web Token implementation in Python',
-    license='MIT',
+    name=about['__title__'],
+    version=about['__version__'],
+    author=about['__author__'],
+    author_email=about['__email__'],
+    description=about['__description__'],
+    license=about['__license__'],
     keywords='jwt json web token security signing',
-    url='http://github.com/jpadilla/pyjwt',
+    url=about['__url__'],
     packages=['jwt'],
     scripts=['bin/jwt'],
     long_description=long_description,


### PR DESCRIPTION
When I saw that the package info was added to __init__.py, I wanted to try and find a way to make it where __init__.py and setup.py used the same source for their information so we only have to change it once anytime that we update anything.

With that in mind, I created __about__.py which contains the package, version, and author information and changed __init__.py and setup.py to pull from there. As a bonus, this let me remove the `get_version()` regex-based function that was previously used in setup.py

cc: @jpadilla 