### PR TITLE
Test improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-python: 2.7
 sudo: false
 env:
   - TOXENV=py26

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: python
 python: 2.7
 sudo: false
 env:
-  - TOX_ENV=py26
-  - TOX_ENV=py27
-  - TOX_ENV=py32
-  - TOX_ENV=py33
+  - TOXENV=py26
+  - TOXENV=py27
+  - TOXENV=py32
+  - TOXENV=py33
+  - TOXENV=py34
 install:
   - pip install tox coveralls
 script:
-  - coverage erase
-  - tox -e $TOX_ENV
+  - tox
 after_success:
   - coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,11 @@
 envlist = py26, py27, py32, py33, py34
 
 [testenv]
-commands = coverage run setup.py test
+commands = 
+    coverage erase
+    coverage run setup.py test
+    coverage report -m
 deps =
     cryptography
     unittest2
+    coverage


### PR DESCRIPTION
I was looking at the builds in Travis and noticed two things that looked odd:
First, the version number listed under the Python column was "2.7" for all of our builds. This is misleading and is caused by the `python: 2.7` directive in the Travis configuration.
![version-numbers](https://cloud.githubusercontent.com/assets/472350/5889524/89c29278-a3f1-11e4-940a-f8522ecb5833.png)

Second, the cryptography-related tests were being skipped on ALL of the builds!
![skipped-tests](https://cloud.githubusercontent.com/assets/472350/5889523/877c2182-a3f1-11e4-8b68-85283be3bc2b.png)

I fixed the first part by removing the python version directive from travis.yml.

The second problem was caused by the fact that coverage was being installed as part of the travis config so whenever coverage was being executed by tox, it was being invoked using the Travis-provided Python interpreter and therefore ignored the virtual environment that tox created. Installing coverage as part of the tox.ini seems to have solved that problem. 

(Bonus: This increased our coverage by 20%+!)

In the process of finding that fix, I also discovered that we weren't running tests on travis for py34 even though it is in tox.ini so I added it to the Travis config and simplified the config by changing the environment variables referenced from `TOX_ENV` to `TOXENV`. As it turns out, tox automatically pulls in `TOXENV` so the `-e` flag is no longer required.

Lastly, just for the heck of it... (and because its useful when running tox locally), I added `coverage report -m` to tox.ini so that it outputs coverage statistics to the console when tox is run.
