### PR TITLE
Fix alg header parameter case sensitivity

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -74,7 +74,7 @@ class NoneAlgorithm(Algorithm):
     def sign(self, msg, key):
         return b''
 
-    def verify(self, msg, key):
+    def verify(self, msg, key, sig):
         return True
 
 

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -75,7 +75,7 @@ class NoneAlgorithm(Algorithm):
         return b''
 
     def verify(self, msg, key, sig):
-        return True
+        return False
 
 
 class HMACAlgorithm(Algorithm):

--- a/jwt/api.py
+++ b/jwt/api.py
@@ -144,7 +144,7 @@ def verify_signature(payload, signing_input, header, signature, key='',
         raise TypeError('audience must be a string or None')
 
     try:
-        alg_obj = _algorithms[header['alg'].upper()]
+        alg_obj = _algorithms[header['alg']]
         key = alg_obj.prepare_key(key)
 
         if not alg_obj.verify(signing_input, key, signature):

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -14,6 +14,8 @@ from jwt.api import (
     _algorithms as jwt_algorithms
 )
 
+from jwt.exceptions import DecodeError
+
 if sys.version_info >= (2, 7):
     import unittest
 else:
@@ -67,6 +69,28 @@ class TestJWT(unittest.TestCase):
 
         for t in types:
             self.assertRaises(TypeError, lambda: jwt.encode(t, 'secret'))
+
+    def test_encode_algorithm_param_should_be_case_sensitive(self):
+        payload = {'hello': 'world'}
+
+        jwt.encode(payload, 'secret', algorithm='HS256')
+
+        with self.assertRaises(NotImplementedError) as context:
+            jwt.encode(payload, None, algorithm='hs256')
+
+        exception = context.exception
+        self.assertEquals(str(exception), 'Algorithm not supported')
+
+    def test_decode_algorithm_param_should_be_case_sensitive(self):
+        example_jwt = ('eyJhbGciOiJoczI1NiIsInR5cCI6IkpXVCJ9' # alg = hs256
+                       '.eyJoZWxsbyI6IndvcmxkIn0'
+                       '.5R_FEPE7SW2dT9GgIxPgZATjFGXfUDOSwo7TtO_Kd_g')
+
+        with self.assertRaises(DecodeError) as context:
+            jwt.decode(example_jwt, 'secret')
+
+        exception = context.exception
+        self.assertEquals(str(exception), 'Algorithm not supported')
 
     def test_encode_datetime(self):
         secret = 'secret'


### PR DESCRIPTION
The [JWS spec](https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-41#section-4.1.1) says: "The "alg" value is a case-sensitive ASCII string containing a StringOrURI value."

Our implementation currently normalizes case of the alg by uppercasing on decode. This PR resolves that behavior so that, by default, "none" is valid and "NONE" is not. Tests are added as well.

This PR also fixes a small bug with signature verification on the NoneAlgorithm related to the fact the `verify()` method is missing a parameter (whoops!)