### PR TITLE
Moved flake8 max-line-length option from tox.ini to setup.cfg so that it works when running flake8 from normal CLI as well.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
+[flake8]
+max-line-length = 119
+
 [wheel]
 universal = 1

--- a/tox.ini
+++ b/tox.ini
@@ -37,4 +37,4 @@ deps =
     pep8-naming
     unittest2
 commands =
-    flake8 . --max-line-length=120
+    flake8


### PR DESCRIPTION
This PR adds the proper max-line-length option to the setup.cfg where it will apply in Tox and in the normal CLI.

Right now, the max-line-length option for flake8 is in the tox.ini which makes it apply when the flake8 tox task is run.
However, when running flake8 locally from the CLI, you must specify the "--max-line-length" parameter in order for it to apply.

With the proposed change, `flake8 .` works the same in both environments.