### PR TITLE
Added support for whitelist validation of the `alg` header

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,19 @@ $ pip install cryptography
 
 ```python
 import jwt
-jwt.encode({'some': 'payload'}, 'secret')
+jwt.encode({'some': 'payload'}, 'secret', algorithm='HS256')
 ```
 
 Additional headers may also be specified.
 
 ```python
-jwt.encode({'some': 'payload'}, 'secret', headers={'kid': '230498151c214b788dd97f22b85410a5'})
+jwt.encode({'some': 'payload'}, 'secret', algorithm='HS256', headers={'kid': '230498151c214b788dd97f22b85410a5'})
 ```
 
 Note the resulting JWT will not be encrypted, but verifiable with a secret key.
 
 ```python
-jwt.decode('someJWTstring', 'secret')
+jwt.decode('someJWTstring', 'secret', algorithms=['HS256'])
 ```
 
 If the secret is wrong, it will raise a `jwt.DecodeError` telling you as such.
@@ -83,12 +83,27 @@ currently supports:
 * RS384 - RSASSA-PKCS1-v1_5 signature algorithm using SHA-384 hash algorithm
 * RS512 - RSASSA-PKCS1-v1_5 signature algorithm using SHA-512 hash algorithm
 
-Change the algorithm with by setting it in encode:
+### Encoding
+You can specify which algorithm you would like to use to sign the JWT
+by using the `algorithm` parameter:
 
 ```python
-jwt.encode({'some': 'payload'}, 'secret', 'HS512')
+jwt.encode({'some': 'payload'}, 'secret', algorithm='HS512')
 ```
 
+### Decoding
+When decoding, you can specify which algorithms you would like to permit
+when validating the JWT by using the `algorithms` parameter which takes a list
+of allowed algorithms:
+
+```python
+jwt.decode(some_jwt, 'secret', algorithms=['HS512', 'HS256'])
+```
+
+In the above case, if the JWT has any value for its alg header other than
+HS512 or HS256, the claim will be rejected with an `InvalidAlgorithmError`.
+
+### Asymmetric (Public-key) Algorithms
 Usage of RSA (RS\*) and EC (EC\*) algorithms require a basic understanding
 of how public-key cryptography is used with regards to digital signatures.
 If you are unfamiliar, you may want to read
@@ -102,6 +117,7 @@ be either an RSA public or private key in PEM or SSH format. The type of key
 When using the ECDSA algorithms, the `key` argument is expected to
 be an Elliptic Curve public or private key in PEM format. The type of key
 (private or public) depends on whether you are signing or verifying.
+
 
 ## Support of registered claim names
 

--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -16,7 +16,9 @@ __license__ = 'MIT'
 __copyright__ = 'Copyright 2015 José Padilla'
 
 
-from .api import encode, decode, register_algorithm, PyJWT
+from .api import (
+    encode, decode, register_algorithm, unregister_algorithm, PyJWT
+)
 from .exceptions import (
     InvalidTokenError, DecodeError, ExpiredSignatureError,
     InvalidAudienceError, InvalidIssuerError,

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -18,23 +18,28 @@ except ImportError:
     has_crypto = False
 
 
-def _register_default_algorithms(pyjwt_obj):
+def get_default_algorithms():
     """
-    Registers the algorithms that are implemented by the library.
+    Returns the algorithms that are implemented by the library.
     """
-    pyjwt_obj.register_algorithm('none', NoneAlgorithm())
-    pyjwt_obj.register_algorithm('HS256', HMACAlgorithm(HMACAlgorithm.SHA256))
-    pyjwt_obj.register_algorithm('HS384', HMACAlgorithm(HMACAlgorithm.SHA384))
-    pyjwt_obj.register_algorithm('HS512', HMACAlgorithm(HMACAlgorithm.SHA512))
+    default_algorithms = {
+        'none': NoneAlgorithm(),
+        'HS256': HMACAlgorithm(HMACAlgorithm.SHA256),
+        'HS384': HMACAlgorithm(HMACAlgorithm.SHA384),
+        'HS512': HMACAlgorithm(HMACAlgorithm.SHA512)
+    }
 
     if has_crypto:
-        pyjwt_obj.register_algorithm('RS256', RSAAlgorithm(RSAAlgorithm.SHA256))
-        pyjwt_obj.register_algorithm('RS384', RSAAlgorithm(RSAAlgorithm.SHA384))
-        pyjwt_obj.register_algorithm('RS512', RSAAlgorithm(RSAAlgorithm.SHA512))
+        default_algorithms.update({
+            'RS256': RSAAlgorithm(RSAAlgorithm.SHA256),
+            'RS384': RSAAlgorithm(RSAAlgorithm.SHA384),
+            'RS512': RSAAlgorithm(RSAAlgorithm.SHA512),
+            'ES256': ECAlgorithm(ECAlgorithm.SHA256),
+            'ES384': ECAlgorithm(ECAlgorithm.SHA384),
+            'ES512': ECAlgorithm(ECAlgorithm.SHA512)
+        })
 
-        pyjwt_obj.register_algorithm('ES256', ECAlgorithm(ECAlgorithm.SHA256))
-        pyjwt_obj.register_algorithm('ES384', ECAlgorithm(ECAlgorithm.SHA384))
-        pyjwt_obj.register_algorithm('ES512', ECAlgorithm(ECAlgorithm.SHA512))
+    return default_algorithms
 
 
 class Algorithm(object):

--- a/jwt/api.py
+++ b/jwt/api.py
@@ -216,3 +216,4 @@ _jwt_global_obj = PyJWT()
 encode = _jwt_global_obj.encode
 decode = _jwt_global_obj.decode
 register_algorithm = _jwt_global_obj.register_algorithm
+unregister_algorithm = _jwt_global_obj.unregister_algorithm

--- a/jwt/exceptions.py
+++ b/jwt/exceptions.py
@@ -22,6 +22,10 @@ class InvalidKeyError(Exception):
     pass
 
 
+class InvalidAlgorithmError(InvalidTokenError):
+    pass
+
+
 # Compatibility aliases (deprecated)
 ExpiredSignature = ExpiredSignatureError
 InvalidAudience = InvalidAudienceError


### PR DESCRIPTION
Added an argument on the PyJWT object and on the `decode` method to allow a list of valid values for `alg` to be specified. The value specified in the `decode` method overrides the value for the PyJWT object. In addition, registering and unregistering algorithms adds and removes (respectively) them from the PyJWT object's whitelist.