### PR TITLE
Fixed a flaky test for EC validation that would fail on OS X

### DIFF
--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -171,13 +171,12 @@ class TestAlgorithms(unittest.TestCase):
 
         jwt_message = ensure_bytes('Hello World!')
 
+        # Mess up the signature by replacing a known byte
         jwt_sig = base64.b64decode(ensure_bytes(
             'MIGIAkIB9vYz+inBL8aOTA4auYz/zVuig7TT1bQgKROIQX9YpViHkFa4DT5'
             '5FuFKn9XzVlk90p6ldEj42DC9YecXHbC2t+cCQgCicY+8f3f/KCNtWK7cif'
             '6vdsVwm6Lrjs0Ag6ZqCf+olN11hVt1qKBC4lXppqB1gNWEmNQaiz1z2QRyc'
-            'zJ8hSJmbw=='))
-
-        jwt_sig += ensure_bytes('123')  # Signature is now invalid
+            'zJ8hSJmbw=='.replace('r', 's')))
 
         with open(key_path('testkey_ec.pub'), 'r') as keyfile:
             jwt_pub_key = algo.prepare_key(keyfile.read())


### PR DESCRIPTION
Previously in this test, we were making the signature invalid by adding "123" to the end of the signature bytes. In Linux, this would result in the test passing but in OS X the test would fail.

According to [JWA](https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40#section-3.4) , the ECDSA signature is composed of two 256-bit unsigned ints that are encoded into octets and concatenated to form the 64-byte JWS signature. It looks like the underlying crypto library on Linux ignored the extra values that I was appending to the signature and OS X did not resulting in the test passing on Linux and failing on OS X.

This PR modifies the test to replace a single known byte contained within the 64-bytes of the EC signature. This works in all environments since it is an invalid signature no matter which way you look at it.

Example failure:
```
======================================================================
FAIL: test_ec_verify_should_return_false_if_signature_invalid (tests.test_algorithms.TestAlgorithms)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/madams/Projects/pyjwt/tests/test_algorithms.py", line 186, in test_ec_verify_should_return_false_if_signature_invalid
    self.assertFalse(result)
AssertionError: True is not false

----------------------------------------------------------------------
```