### PR TITLE
Add checks to int claims (nbf, iat, exp) to verify they are actually ints

### DIFF
--- a/jwt/api.py
+++ b/jwt/api.py
@@ -188,6 +188,11 @@ class PyJWT(object):
                 raise ExpiredSignatureError('Signature not yet valid')
 
         if 'exp' in payload and verify_expiration:
+            try:
+                exp = int(payload['exp'])
+            except ValueError:
+                raise DecodeError('Expiration claim (exp) must be an integer.')
+
             utc_timestamp = timegm(datetime.utcnow().utctimetuple())
 
             if payload['exp'] < (utc_timestamp - leeway):

--- a/jwt/api.py
+++ b/jwt/api.py
@@ -195,7 +195,7 @@ class PyJWT(object):
 
             utc_timestamp = timegm(datetime.utcnow().utctimetuple())
 
-            if payload['nbf'] > (utc_timestamp + leeway):
+            if nbf > (utc_timestamp + leeway):
                 raise ExpiredSignatureError('Signature not yet valid')
 
         if 'exp' in payload and verify_expiration:
@@ -206,7 +206,7 @@ class PyJWT(object):
 
             utc_timestamp = timegm(datetime.utcnow().utctimetuple())
 
-            if payload['exp'] < (utc_timestamp - leeway):
+            if exp < (utc_timestamp - leeway):
                 raise ExpiredSignatureError('Signature has expired')
 
         if 'aud' in payload:

--- a/jwt/api.py
+++ b/jwt/api.py
@@ -188,6 +188,11 @@ class PyJWT(object):
                 raise DecodeError('Issued At claim (iat) must be an integer.')
 
         if 'nbf' in payload and verify_expiration:
+            try:
+                nbf = int(payload['nbf'])
+            except ValueError:
+                raise DecodeError('Not Before claim (nbf) must be an integer.')
+
             utc_timestamp = timegm(datetime.utcnow().utctimetuple())
 
             if payload['nbf'] > (utc_timestamp + leeway):

--- a/jwt/api.py
+++ b/jwt/api.py
@@ -181,6 +181,12 @@ class PyJWT(object):
         except KeyError:
             raise InvalidAlgorithmError('Algorithm not supported')
 
+        if 'iat' in payload:
+            try:
+                int(payload['iat'])
+            except ValueError:
+                raise DecodeError('Issued At claim (iat) must be an integer.')
+
         if 'nbf' in payload and verify_expiration:
             utc_timestamp = timegm(datetime.utcnow().utctimetuple())
 
@@ -191,7 +197,7 @@ class PyJWT(object):
             try:
                 exp = int(payload['exp'])
             except ValueError:
-                raise DecodeError('Expiration claim (exp) must be an integer.')
+                raise DecodeError('Expiration Time claim (exp) must be an integer.')
 
             utc_timestamp = timegm(datetime.utcnow().utctimetuple())
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -213,6 +213,15 @@ class TestAPI(unittest.TestCase):
         with self.assertRaisesRegexp(DecodeError, 'iat'):
             self.jwt.decode(example_jwt, 'secret')
 
+    def test_decode_raises_exception_if_nbf_is_not_int(self):
+        # >>> jwt.encode({'nbf': 'not-an-int'}, 'secret')
+        example_jwt = ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
+                       'eyJuYmYiOiJub3QtYW4taW50In0.'
+                       'c25hldC8G2ZamC8uKpax9sYMTgdZo3cxrmzFHaAAluw')
+
+        with self.assertRaisesRegexp(DecodeError, 'nbf'):
+            self.jwt.decode(example_jwt, 'secret')
+
     def test_encode_datetime(self):
         secret = 'secret'
         current_datetime = datetime.utcnow()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -198,12 +198,20 @@ class TestAPI(unittest.TestCase):
     def test_decode_raises_exception_if_exp_is_not_int(self):
         # >>> jwt.encode({'exp': 'not-an-int'}, 'secret')
         example_jwt = ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
-                      'eyJleHAiOiJub3QtYW4taW50In0.'
-                      'P65iYgoHtBqB07PMtBSuKNUEIPPPfmjfJG217cEE66s')
+                       'eyJleHAiOiJub3QtYW4taW50In0.'
+                       'P65iYgoHtBqB07PMtBSuKNUEIPPPfmjfJG217cEE66s')
 
         with self.assertRaisesRegexp(DecodeError, 'exp'):
             self.jwt.decode(example_jwt, 'secret')
 
+    def test_decode_raises_exception_if_iat_is_not_int(self):
+        # >>> jwt.encode({'iat': 'not-an-int'}, 'secret')
+        example_jwt = ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
+                       'eyJpYXQiOiJub3QtYW4taW50In0.'
+                       'H1GmcQgSySa5LOKYbzGm--b1OmRbHFkyk8pq811FzZM')
+
+        with self.assertRaisesRegexp(DecodeError, 'iat'):
+            self.jwt.decode(example_jwt, 'secret')
 
     def test_encode_datetime(self):
         secret = 'secret'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -195,6 +195,16 @@ class TestAPI(unittest.TestCase):
         exception = context.exception
         self.assertEquals(str(exception), 'Algorithm not supported')
 
+    def test_decode_raises_exception_if_exp_is_not_int(self):
+        # >>> jwt.encode({'exp': 'not-an-int'}, 'secret')
+        example_jwt = ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
+                      'eyJleHAiOiJub3QtYW4taW50In0.'
+                      'P65iYgoHtBqB07PMtBSuKNUEIPPPfmjfJG217cEE66s')
+
+        with self.assertRaisesRegexp(DecodeError, 'exp'):
+            self.jwt.decode(example_jwt, 'secret')
+
+
     def test_encode_datetime(self):
         secret = 'secret'
         current_datetime = datetime.utcnow()


### PR DESCRIPTION
If `iat`, `nbf`, or `exp` are not valid int values, a DecodeError will be raised.

This fixes #121 