### PR TITLE
Refactor tests to remove references to private API methods

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -418,7 +418,6 @@ class TestAPI(unittest.TestCase):
         with self.assertRaisesRegexp(DecodeError, 'Invalid payload padding'):
             self.jwt.decode(example_jwt, example_secret)
 
-
     def test_decode_invalid_payload_string(self):
         example_jwt = (
             'eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9'
@@ -435,7 +434,6 @@ class TestAPI(unittest.TestCase):
             '.eyJoZWxsbyI6ICJ3b3JsZCJ9'
             '.aatvagLDLoaiJKxOKqpBXSEGy7SYSifZhjntgm9ctpyj8')
         example_secret = 'secret'
-
 
         with self.assertRaisesRegexp(DecodeError, 'Invalid crypto padding'):
             self.jwt.decode(example_jwt, example_secret)


### PR DESCRIPTION
One of the biggest advantages to tests is that they allow us to test the public APIs of the library independent of the underlying implementation (private APIs). This allows us to completely change the underlying implementation while having confidence that our library still works.

This PR changes all of our tests that use private APIs and methods and refactors them to focus on public APIs. All of the code is still being tested; its just being tests through only public APIs now.

**NOTE: Please review #122 before this one. (This PR is based off of #122 and will be much less confusing once it is merged)