### PR TITLE
Not specifying an audience to decode() causes an InvalidAudienceError

### DIFF
--- a/jwt/api.py
+++ b/jwt/api.py
@@ -214,7 +214,12 @@ class PyJWT(object):
             if exp < (now - leeway):
                 raise ExpiredSignatureError('Signature has expired')
 
-        if 'aud' in payload:
+        if audience is not None:
+            # Application specified an audience, but it could not be
+            # verified since the token does not contain a claim.
+            if 'aud' not in payload:
+                raise InvalidAudienceError('No audience claim in token')
+
             audience_claims = payload['aud']
             if isinstance(audience_claims, string_types):
                 audience_claims = [audience_claims]
@@ -224,10 +229,6 @@ class PyJWT(object):
                 raise InvalidAudienceError('Invalid claim format in token')
             if audience not in audience_claims:
                 raise InvalidAudienceError('Invalid audience')
-        elif audience is not None:
-            # Application specified an audience, but it could not be
-            # verified since the token does not contain a claim.
-            raise InvalidAudienceError('No audience claim in token')
 
         if issuer is not None:
             if payload.get('iss') != issuer:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -692,6 +692,14 @@ class TestAPI(unittest.TestCase):
         token = self.jwt.encode(payload, 'secret')
         self.jwt.decode(token, 'secret', audience='urn:me')
 
+    def test_check_audience_when_default(self):
+        payload = {
+            'some': 'payload',
+            'aud': 'urn:me'
+        }
+        token = self.jwt.encode(payload, 'secret')
+        self.jwt.decode(token, 'secret')
+
     def test_check_audience_in_array_when_valid(self):
         payload = {
             'some': 'payload',


### PR DESCRIPTION
When I attempt to decode an access token that contains an `'aud'` claim without passing an audience into the decode method, the `_verify_claims()` method raises an `InvalidAudienceError`.

There wasn't a test that covered this case, so I'm not sure if it is intended behavior or not.  If it is, feel free to ignore me.  I can work around it easily enough.  If it isn't, I made the change and added a test to cover it.

#### Example:
```
>>> j = jwt.encode({'test':'something','aud':'test'}, 'secret')
>>> jwt.decode(j, 'secret')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/michael/.virtualenvs/webfilings/wf-oauthtwo-pyserver/lib/python2.7/site-packages/jwt/api.py", line 117, in decode
    key, algorithms, **kwargs)
  File "/Users/michael/.virtualenvs/webfilings/wf-oauthtwo-pyserver/lib/python2.7/site-packages/jwt/api.py", line 208, in _verify_signature
    # verified since the token does not contain a claim.
jwt.exceptions.InvalidAudienceError: Invalid audience
```