### PR TITLE
Add flexible and complete verification options

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,5 @@ Patches and Suggestions
  - Mark Adams <mark@markadams.me>
 
  - Wouter Bolsterlee <uws@xs4all.nl>
+
+ - Michael Davis <mike.philip.davis@gmail.com> <mike.davis@workiva.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 -------------------------------------------------------------------------
 ### Changed
 - Added this CHANGELOG.md file
+- Added flexible and complete verification options. #131
 
 ### Fixed
 - Placeholder

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ options = {
 }
 ```
 
+NOTE: Changing the default behavior is done at your own risk, and almost certainly will make your
+application less secure.  Doing so should only be done with a very clear understanding of what you
+are doing.
+
 You can skip individual checks by passing an `options` dictionary with certain keys set to `False`.
 For example, if you want to verify the signature of a JWT that has already expired.
 

--- a/README.md
+++ b/README.md
@@ -75,10 +75,6 @@ options = {
 }
 ```
 
-NOTE: Changing the default behavior is done at your own risk, and almost certainly will make your
-application less secure.  Doing so should only be done with a very clear understanding of what you
-are doing.
-
 You can skip individual checks by passing an `options` dictionary with certain keys set to `False`.
 For example, if you want to verify the signature of a JWT that has already expired.
 
@@ -89,6 +85,10 @@ options = {
 
 jwt.decode('someJWTstring', 'secret', options=options)
 ```
+
+**NOTE**: *Changing the default behavior is done at your own risk, and almost certainly will make your
+application less secure.  Doing so should only be done with a very clear understanding of what you
+are doing.*
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,30 @@ except jwt.InvalidTokenError:
     pass  # do something sensible here, e.g. return HTTP 403 status code
 ```
 
+You may also override exception checking via an `options` dictionary.  The default
+options are as follows: 
+
+```python
+options = {
+   'verify_signature': True,
+   'verify_exp': True,
+   'verify_nbf': True,
+   'verify_iat': True,
+   'verify_aud`: True
+}
+```
+
+You can skip individual checks by passing an `options` dictionary with certain keys set to `False`.
+For example, if you want to verify the signature of a JWT that has already expired.
+
+```python
+options = {
+   'verify_exp': True,
+}
+
+jwt.decode('someJWTstring', 'secret', options=options)
+```
+
 ## Tests
 
 You can run tests from the project root after cloning with:

--- a/jwt/api.py
+++ b/jwt/api.py
@@ -37,8 +37,11 @@ class PyJWT(object):
         }
 
         try:
-            self.options = {k: options[k] if k in options else v for k, v in self.default_options.items()}
-        except (ValueError, TypeError) as e:
+            merged_options = dict()
+            for k, v in self.default_options.items():
+                merged_options[k] = options.get(k, v)
+            self.options = merged_options
+        except AttributeError as e:
             raise TypeError('options must be a dictionary: %s' % e)
 
     def register_algorithm(self, alg_id, alg_obj):
@@ -254,11 +257,15 @@ class PyJWT(object):
     def _merge_options(self, override_options=None):
         if not override_options:
             override_options = {}
+
         try:
-            options = {k: override_options[k] if k in override_options else v for k, v in self.options.items()}
-        except (ValueError, TypeError) as e:
+            merged_options = dict()
+            for k, v in self.options.items():
+                merged_options[k] = override_options.get(k, v)
+        except AttributeError as e:
             raise TypeError('options must be a dictionary: %s' % e)
-        return options
+
+        return merged_options
 
 
 _jwt_global_obj = PyJWT()

--- a/jwt/api.py
+++ b/jwt/api.py
@@ -36,13 +36,7 @@ class PyJWT(object):
             'verify_aud': True,
         }
 
-        try:
-            merged_options = dict()
-            for k, v in self.default_options.items():
-                merged_options[k] = options.get(k, v)
-            self.options = merged_options
-        except AttributeError as e:
-            raise TypeError('options must be a dictionary: %s' % e)
+        self.options = self._merge_options(self.default_options, options)
 
     def register_algorithm(self, alg_id, alg_obj):
         """
@@ -254,15 +248,17 @@ class PyJWT(object):
             if payload.get('iss') != issuer:
                 raise InvalidIssuerError('Invalid issuer')
 
-    def _merge_options(self, override_options=None):
+    def _merge_options(self, default_options=None, override_options=None):
+        if not default_options:
+            default_options = {}
+
         if not override_options:
             override_options = {}
 
         try:
-            merged_options = dict()
-            for k, v in self.options.items():
-                merged_options[k] = override_options.get(k, v)
-        except AttributeError as e:
+            merged_options = self.default_options.copy()
+            merged_options.update(override_options)
+        except (AttributeError, ValueError) as e:
             raise TypeError('options must be a dictionary: %s' % e)
 
         return merged_options

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -90,6 +90,7 @@ class TestAPI(unittest.TestCase):
 
     def test_options_must_be_dict(self):
         self.assertRaises(TypeError, PyJWT, options=object())
+        self.assertRaises(TypeError, PyJWT, options=('something'))
 
     def test_encode_decode(self):
         secret = 'secret'
@@ -829,6 +830,7 @@ class TestAPI(unittest.TestCase):
         }
         token = self.jwt.encode(payload, 'secret')
         self.assertRaises(TypeError, self.jwt.decode, token, 'secret', options=object())
+        self.assertRaises(TypeError, self.jwt.decode, token, 'secret', options='something')
 
     def test_custom_json_encoder(self):
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -81,12 +81,12 @@ class TestAPI(unittest.TestCase):
         expected_options['verify_nbf'] = False
         self.assertEqual(expected_options, self.jwt.options)
 
-    def test_non_existant_options_dont_exist(self):
+    def test_non_default_options_persist(self):
         self.jwt = PyJWT(options={'verify_iat': False, 'foobar': False})
         expected_options = self.jwt.default_options
         expected_options['verify_iat'] = False
+        expected_options['foobar'] = False
         self.assertEqual(expected_options, self.jwt.options)
-        self.assertNotIn('foobar', self.jwt.options)
 
     def test_options_must_be_dict(self):
         self.assertRaises(TypeError, PyJWT, options=object())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -71,6 +71,26 @@ class TestAPI(unittest.TestCase):
         self.assertNotIn('none', self.jwt.get_algorithms())
         self.assertIn('HS256', self.jwt.get_algorithms())
 
+    def test_default_options(self):
+        self.assertEqual(self.jwt.default_options, self.jwt.options)
+
+    def test_override_options(self):
+        self.jwt = PyJWT(options={'verify_exp': False, 'verify_nbf': False})
+        expected_options = self.jwt.default_options
+        expected_options['verify_exp'] = False
+        expected_options['verify_nbf'] = False
+        self.assertEqual(expected_options, self.jwt.options)
+
+    def test_non_existant_options_dont_exist(self):
+        self.jwt = PyJWT(options={'verify_iat': False, 'foobar': False})
+        expected_options = self.jwt.default_options
+        expected_options['verify_iat'] = False
+        self.assertEqual(expected_options, self.jwt.options)
+        self.assertNotIn('foobar', self.jwt.options)
+
+    def test_options_must_be_dict(self):
+        self.assertRaises(TypeError, PyJWT, options=object())
+
     def test_encode_decode(self):
         secret = 'secret'
         jwt_message = self.jwt.encode(self.payload, secret)
@@ -467,14 +487,14 @@ class TestAPI(unittest.TestCase):
         secret = 'secret'
         jwt_message = self.jwt.encode(self.payload, secret)
 
-        self.jwt.decode(jwt_message, secret, verify_expiration=False)
+        self.jwt.decode(jwt_message, secret, options={'verify_exp': False})
 
     def test_decode_skip_notbefore_verification(self):
         self.payload['nbf'] = time.time() + 10
         secret = 'secret'
         jwt_message = self.jwt.encode(self.payload, secret)
 
-        self.jwt.decode(jwt_message, secret, verify_expiration=False)
+        self.jwt.decode(jwt_message, secret, options={'verify_nbf': False})
 
     def test_decode_with_expiration_with_leeway(self):
         self.payload['exp'] = utc_timestamp() - 2
@@ -764,6 +784,51 @@ class TestAPI(unittest.TestCase):
 
         with self.assertRaises(InvalidIssuerError):
             self.jwt.decode(token, 'secret', issuer=issuer)
+
+    def test_skip_check_audience(self):
+        payload = {
+            'some': 'payload',
+            'aud': 'urn:me',
+        }
+        token = self.jwt.encode(payload, 'secret')
+        self.jwt.decode(token, 'secret', options={'verify_aud': False})
+
+    def test_skip_check_exp(self):
+        payload = {
+            'some': 'payload',
+            'exp': datetime.utcnow() - timedelta(days=1)
+        }
+        token = self.jwt.encode(payload, 'secret')
+        self.jwt.decode(token, 'secret', options={'verify_exp': False})
+
+    def test_skip_check_signature(self):
+        token = ("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+                 ".eyJzb21lIjoicGF5bG9hZCJ9"
+                 ".4twFt5NiznN84AWoo1d7KO1T_yoc0Z6XOpOVswacPZA")
+        self.jwt.decode(token, 'secret', options={'verify_signature': False})
+
+    def test_skip_check_iat(self):
+        payload = {
+            'some': 'payload',
+            'iat': datetime.utcnow() + timedelta(days=1)
+        }
+        token = self.jwt.encode(payload, 'secret')
+        self.jwt.decode(token, 'secret', options={'verify_iat': False})
+
+    def test_skip_check_nbf(self):
+        payload = {
+            'some': 'payload',
+            'nbf': datetime.utcnow() + timedelta(days=1)
+        }
+        token = self.jwt.encode(payload, 'secret')
+        self.jwt.decode(token, 'secret', options={'verify_nbf': False})
+
+    def test_decode_options_must_be_dict(self):
+        payload = {
+            'some': 'payload',
+        }
+        token = self.jwt.encode(payload, 'secret')
+        self.assertRaises(TypeError, self.jwt.decode, token, 'secret', options=object())
 
     def test_custom_json_encoder(self):
 


### PR DESCRIPTION
This adds the ability to use a more flexible option dictionary.  The options dictionary can be specified at the PyJWT object level or as an override passed directly into `decode()`

Attempts to fix #127