### PR TITLE
Added support for RSASSA-PSS algorithms (PS256, PS384, PS512)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [Unreleased][unreleased]
 -------------------------------------------------------------------------
 ### Changed
+- Added flexible and complete verification options during decode #131
+- Added support for PS256, PS384, and PS512 algorithms. #132
 - Added this CHANGELOG.md file
-- Added flexible and complete verification options. #131
+
 
 ### Fixed
 - Placeholder

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ except jwt.InvalidTokenError:
 ```
 
 You may also override exception checking via an `options` dictionary.  The default
-options are as follows: 
+options are as follows:
 
 ```python
 options = {
@@ -112,6 +112,9 @@ currently supports:
 * RS256 - RSASSA-PKCS1-v1_5 signature algorithm using SHA-256 hash algorithm
 * RS384 - RSASSA-PKCS1-v1_5 signature algorithm using SHA-384 hash algorithm
 * RS512 - RSASSA-PKCS1-v1_5 signature algorithm using SHA-512 hash algorithm
+* PS256 - RSASSA-PSS signature using SHA-256 and MGF1 padding with SHA-256  
+* PS384 - RSASSA-PSS signature using SHA-384 and MGF1 padding with SHA-384
+* PS512 - RSASSA-PSS signature using SHA-512 and MGF1 padding with SHA-512
 
 ### Encoding
 You can specify which algorithm you would like to use to sign the JWT

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -615,10 +615,17 @@ class TestAPI(unittest.TestCase):
             self.assertTrue('RS256' in jwt_algorithms)
             self.assertTrue('RS384' in jwt_algorithms)
             self.assertTrue('RS512' in jwt_algorithms)
+            self.assertTrue('PS256' in jwt_algorithms)
+            self.assertTrue('PS384' in jwt_algorithms)
+            self.assertTrue('PS512' in jwt_algorithms)
+
         else:
             self.assertFalse('RS256' in jwt_algorithms)
             self.assertFalse('RS384' in jwt_algorithms)
             self.assertFalse('RS512' in jwt_algorithms)
+            self.assertFalse('PS256' in jwt_algorithms)
+            self.assertFalse('PS384' in jwt_algorithms)
+            self.assertFalse('PS512' in jwt_algorithms)
 
     @unittest.skipIf(not has_crypto, "Can't run without cryptography library")
     def test_encode_decode_with_ecdsa_sha256(self):


### PR DESCRIPTION
Added support for RSASSA-PSS algorithms (PS256, PS384, PS512)

The JWT spec also mentions optional support for RSASSA-PSS using and MGF1. This is superior to PKCS #1 v1.5 (RS256, RS384, RS512) because it essentially uses a salt to randomize the padding instead of using a completely deterministic algorithm. No good attacks against PKCS #1 v1.5 padding currently exist, but PSS is recommended in new applications since it makes the signature even more random.

More info here: http://www.emc.com/emc-plus/rsa-labs/historical/raising-standard-rsa-signatures-rsa-pss.htm

Also added a test to cover our only uncovered line in `jwt.api`