### PR TITLE
Added a deprecation warning for using verify= instead of options= on decode()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 -------------------------------------------------------------------------
 ### Changed
 - Added flexible and complete verification options during decode #131
+- Deprecated usage of the .decode(..., verify=False) parameter
 - Added support for PS256, PS384, and PS512 algorithms. #132
 - Added this CHANGELOG.md file
 

--- a/jwt/api.py
+++ b/jwt/api.py
@@ -1,5 +1,6 @@
 import binascii
 import json
+import warnings
 
 from calendar import timegm
 from collections import Mapping
@@ -133,6 +134,8 @@ class PyJWT(object):
                                        key, algorithms)
 
             self._validate_claims(payload, options=merged_options, **kwargs)
+        else:
+            warnings.warn("The verify parameter is deprecated. Please use options instead.", DeprecationWarning)
 
         return payload
 


### PR DESCRIPTION
Added a deprecation warning for using verify= instead of options= on decode()

This is mostly to direct users to use `options=` instead of `verify=False` if they need to disable or skip verification so that we can remove this parameter in the next version.