### PR TITLE
Updated CHANGELOG and README to reflect removal of verify_expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ### Deprecated
-- Deprecated usage of the .decode(..., verify=False) parameter.
-
+- Deprecated usage of the `verify` parameters to `PyJWT.decode()` in favor of the new options parameter
+- Removed the `verify_expiration` parameters to `PyJWT.decode()` in favor of then new options parameter
 
 ### Fixed
 - Fixed command line encoding. [#128][128]

--- a/README.md
+++ b/README.md
@@ -207,8 +207,7 @@ Expiration time will be compared to the current UTC time (as given by
 `timegm(datetime.utcnow().utctimetuple())`), so be sure to use a UTC timestamp
 or datetime in encoding.
 
-You can turn off expiration time verification with the `verify_expiration`
-argument.
+You can turn off expiration time verification with the `verify_exp` parameter in the options argument.
 
 PyJWT also supports the leeway part of the expiration time definition, which
 means you can validate a expiration time which is in the past but not very far.


### PR DESCRIPTION
We forgot to document the fact we removed verify_expiration from decode()