### PR TITLE
`verify_expiration` was removed too soon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased][unreleased]
 -------------------------------------------------------------------------
-### Changed
 ### Fixed
+- Added back `verify_expiration=` argument to `jwt.decode()` that was erroneously removed in [v1.1.0][1.1.0].
+
+
+### Deprecated
+- `verify_expiration=` argument to `jwt.decode()` is now deprecated and will be removed in a future version. Use the `option=` argument instead.
 
 [v1.1.0][1.1.0]
 -------------------------------------------------------------------------

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 from calendar import timegm
 from collections import Mapping
@@ -74,6 +75,12 @@ class PyJWT(PyJWS):
 
     def _validate_claims(self, payload, audience=None, issuer=None, leeway=0,
                          options=None, **kwargs):
+
+        if 'verify_expiration' in kwargs:
+            options['verify_exp'] = kwargs.get('verify_expiration', True)
+            warnings.warn('The verify_expiration parameter is deprecated. '
+                          'Please use options instead.', DeprecationWarning)
+
         if isinstance(leeway, timedelta):
             leeway = timedelta_total_seconds(leeway)
 

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -419,3 +419,23 @@ class TestJWT:
         payload = jwt.decode(token, 'secret')
 
         assert payload == {'some_decimal': 'it worked'}
+
+    def test_decode_with_verify_expiration_kwarg(self, jwt, payload):
+        payload['exp'] = utc_timestamp() - 1
+        secret = 'secret'
+        jwt_message = jwt.encode(payload, secret)
+
+        pytest.deprecated_call(
+            jwt.decode,
+            jwt_message,
+            secret,
+            verify_expiration=False
+        )
+
+        with pytest.raises(ExpiredSignatureError):
+            pytest.deprecated_call(
+                jwt.decode,
+                jwt_message,
+                secret,
+                verify_expiration=True
+            )


### PR DESCRIPTION
Fix for #147

- Merge with `verify_exp` option
- Add deprecation warning

@mark-adams thoughts?