### PR TITLE
Remove Python 3.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ env:
   - TOXENV=pep8
   - TOXENV=py26
   - TOXENV=py27
-  - TOXENV=py32
   - TOXENV=py33
   - TOXENV=py34
   - TOXENV=py34-nocrypto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added a new `jwt.get_unverified_header()` to parse and return the header portion of a token prior to signature verification.
 
+### Removed
+- Python 3.2 is no longer a supported platform. This version of Python is
+rarely used. Users affected by this should upgrade to 3.3+.
+
 [v1.2.0][1.2.0]
 -------------------------------------------------------------------------
 ### Fixed

--- a/jwt/compat.py
+++ b/jwt/compat.py
@@ -34,7 +34,7 @@ def timedelta_total_seconds(delta):
 try:
     constant_time_compare = hmac.compare_digest
 except AttributeError:
-    # Fallback for Python < 2.7.7 and Python < 3.3
+    # Fallback for Python < 2.7
     def constant_time_compare(val1, val2):
         """
         Returns True if the two strings are equal, False otherwise.
@@ -46,12 +46,7 @@ except AttributeError:
 
         result = 0
 
-        if sys.version_info >= (3, 0, 0):
-            # Bytes are numbers
-            for x, y in zip(val1, val2):
-                result |= x ^ y
-        else:
-            for x, y in zip(val1, val2):
-                result |= ord(x) ^ ord(y)
+        for x, y in zip(val1, val2):
+            result |= ord(x) ^ ord(y)
 
         return result == 0

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Topic :: Utilities',


### PR DESCRIPTION
`cryptography` dropped support for Python 3.2 in v0.9 and I think we should to. Its probably one of the more awkward Python releases and has weird quirks that aren't shared by 3.3+

cc: @jpadilla 