### PR TITLE
Added new options for requiring exp, iat, and nbf claims.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Exclude Python cache files from PyPI releases.
 
+### Added
+- Added new options to require certain claims
+  (require_nbf, require_iat, require_exp) and raise `MissingRequiredClaimError`
+  if they are not present.
+- If `audience=` or `issuer=` is specified but the claim is not present,
+  `MissingRequiredClaimError` is now raised instead of `InvalidAudienceError`
+  and `InvalidIssuerError`
 
 [v1.3][1.3.0]
 -------------------------------------------------------------------------

--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -24,5 +24,6 @@ from .api_jws import PyJWS
 from .exceptions import (
     InvalidTokenError, DecodeError, InvalidAudienceError,
     ExpiredSignatureError, ImmatureSignatureError, InvalidIssuedAtError,
-    InvalidIssuerError, ExpiredSignature, InvalidAudience, InvalidIssuer
+    InvalidIssuerError, ExpiredSignature, InvalidAudience, InvalidIssuer,
+    MissingRequiredClaimError
 )

--- a/jwt/exceptions.py
+++ b/jwt/exceptions.py
@@ -34,6 +34,14 @@ class InvalidAlgorithmError(InvalidTokenError):
     pass
 
 
+class MissingRequiredClaimError(InvalidTokenError):
+    def __init__(self, claim):
+        self.claim = claim
+
+    def __str__(self):
+        return 'Token is missing the "%s" claim' % self.claim
+
+
 # Compatibility aliases (deprecated)
 ExpiredSignature = ExpiredSignatureError
 InvalidAudience = InvalidAudienceError

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,7 @@
+from jwt.exceptions import MissingRequiredClaimError
+
+
+def test_missing_required_claim_error_has_proper_str():
+    exc = MissingRequiredClaimError('abc')
+
+    assert str(exc) == 'Token is missing the "abc" claim'


### PR DESCRIPTION
Added the require_exp, require_iat, and require_nbf claims so that applications can indicate that they expect these claims to be present. If they are not present. These options are set to false by default.

A new exception type, MissingRequiredClaimError, is introduced. The `claim` property indicates which claim is missing. When `audience=` or `issuer=` is present on `decode()`, MissingRequiredClaimError is now raised instead of the previous exceptions.
 
Thanks to @dbaxa from @Atlassian for the suggestion.