### PR TITLE
If non-string passed as JWT, raise DecodeError

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -138,7 +138,7 @@ class PyJWS(object):
         try:
             signing_input, crypto_segment = jwt.rsplit(b'.', 1)
             header_segment, payload_segment = signing_input.split(b'.', 1)
-        except ValueError:
+        except (AttributeError, ValueError):
             raise DecodeError('Not enough segments')
 
         try:


### PR DESCRIPTION
If you pass an integer to jwt.decode, you probably should get a DecodeError. Currently you get an attribute error here:

``AttributeError: 'int' object has no attribute 'rsplit'``