### PR TITLE
Fixes an issue where the newer versions of Pytest can't detect deprecation warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if sys.argv[-1] == 'publish':
     sys.exit()
 
 tests_require = [
-    'pytest',
+    'pytest==2.7.3',
     'pytest-cov',
     'pytest-runner',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,6 @@ commands =
     python setup.py pytest
 deps =
     crypto: cryptography
-    pytest
-    pytest-cov
-    pytest-runner
     contrib_crypto: pycrypto
     contrib_crypto: ecdsa
 


### PR DESCRIPTION
Current versions of Pytest can't detect deprecation warnings.

This was fixed in https://github.com/pytest-dev/pytest/pull/1081 but is not released yet.