### PR TITLE
Fixed #183 AttributeError: 'NoneType' object has no attribute 'rsplit'

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -139,7 +139,7 @@ class PyJWS(object):
             signing_input, crypto_segment = jwt.rsplit(b'.', 1)
             header_segment, payload_segment = signing_input.split(b'.', 1)
         except AttributeError:
-            raise DecodeError('Invalid payload type. It should be a {} not {}'.format(
+            raise DecodeError('Invalid payload type. It should be a {0} not {1}'.format(
                 text_type, type(jwt)))
         except ValueError:
             raise DecodeError('Not enough segments')

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -5,7 +5,7 @@ import warnings
 from collections import Mapping
 
 from .algorithms import Algorithm, get_default_algorithms  # NOQA
-from .compat import string_types, text_type
+from .compat import binary_type, string_types, text_type
 from .exceptions import DecodeError, InvalidAlgorithmError, InvalidTokenError
 from .utils import base64url_decode, base64url_encode, merge_dict
 
@@ -135,12 +135,13 @@ class PyJWS(object):
         if isinstance(jwt, text_type):
             jwt = jwt.encode('utf-8')
 
+        if not issubclass(type(jwt), binary_type):
+            raise DecodeError("Invalid token type. Token must be a {0}".format(
+                binary_type))
+
         try:
             signing_input, crypto_segment = jwt.rsplit(b'.', 1)
             header_segment, payload_segment = signing_input.split(b'.', 1)
-        except AttributeError:
-            raise DecodeError('Invalid payload type. It should be a {0} not {1}'.format(
-                text_type, type(jwt)))
         except ValueError:
             raise DecodeError('Not enough segments')
 

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -138,6 +138,9 @@ class PyJWS(object):
         try:
             signing_input, crypto_segment = jwt.rsplit(b'.', 1)
             header_segment, payload_segment = signing_input.split(b'.', 1)
+        except AttributeError:
+            raise DecodeError('Invalid payload type. It should be a {} not {}'.format(
+                text_type, type(jwt)))
         except ValueError:
             raise DecodeError('Not enough segments')
 

--- a/jwt/compat.py
+++ b/jwt/compat.py
@@ -13,9 +13,11 @@ PY3 = sys.version_info[0] == 3
 if PY3:
     string_types = str,
     text_type = str
+    binary_type = bytes
 else:
     string_types = basestring,
     text_type = unicode
+    binary_type = str
 
 
 def timedelta_total_seconds(delta):

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -122,6 +122,24 @@ class TestJWS:
         exception = context.value
         assert str(exception) == 'Not enough segments'
 
+    def test_decode_invalid_payload_type_is_none(self, jws):
+        example_jws = None
+        example_secret = 'secret'
+
+        with pytest.raises(DecodeError) as context:
+            jws.decode(example_jws, example_secret)
+
+        assert 'Invalid payload type' in str(context.value)
+
+    def test_decode_invalid_payload_type_is_int(self, jws):
+        example_jws = 123
+        example_secret = 'secret'
+
+        with pytest.raises(DecodeError) as context:
+            jws.decode(example_jws, example_secret)
+
+        assert 'Invalid payload type' in str(context.value)
+
     def test_decode_with_non_mapping_header_throws_exception(self, jws):
         secret = 'secret'
         example_jws = ('MQ'  # == 1

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -122,23 +122,25 @@ class TestJWS:
         exception = context.value
         assert str(exception) == 'Not enough segments'
 
-    def test_decode_invalid_payload_type_is_none(self, jws):
+    def test_decode_invalid_token_type_is_none(self, jws):
         example_jws = None
         example_secret = 'secret'
 
         with pytest.raises(DecodeError) as context:
             jws.decode(example_jws, example_secret)
 
-        assert 'Invalid payload type' in str(context.value)
+        exception = context.value
+        assert 'Invalid token type' in str(exception)
 
-    def test_decode_invalid_payload_type_is_int(self, jws):
+    def test_decode_invalid_token_type_is_int(self, jws):
         example_jws = 123
         example_secret = 'secret'
 
         with pytest.raises(DecodeError) as context:
             jws.decode(example_jws, example_secret)
 
-        assert 'Invalid payload type' in str(context.value)
+        exception = context.value
+        assert 'Invalid token type' in str(exception)
 
     def test_decode_with_non_mapping_header_throws_exception(self, jws):
         secret = 'secret'


### PR DESCRIPTION
Fixed #183 AttributeError: 'NoneType' object has no attribute 'rsplit'

The issue also occurs when payload is int raising:
    AttributeError: 'int' object has no attribute 'rsplit'
Test for None and int payload added