### PR TITLE
Renamed jwt CLI script to jwt-cli to avoid issues with jwt script overlapping with the jwt package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+[Unreleased][unreleased]
+-------------------------------------------------------------------------
+### Changed
+- Renamed commandline script `jwt` to `jwt-cli` to avoid issues with the script clobbering the `jwt` module in some circumstances.
+
+### Fixed
+
 [v1.4.2][1.4.2]
 -------------------------------------------------------------------------
 ### Fixed
@@ -89,7 +96,7 @@ rarely used. Users affected by this should upgrade to 3.3+.
 - Fixed a security vulnerability by adding support for a whitelist of allowed `alg` values `jwt.decode(algorithms=[])`. [#110][110]
 
 
-[unreleased]: https://github.com/jpadilla/pyjwt/compare/1.3.0...HEAD
+[unreleased]: https://github.com/jpadilla/pyjwt/compare/1.4.2...HEAD
 [1.0.0]: https://github.com/jpadilla/pyjwt/compare/0.4.3...1.0.0
 [1.0.1]: https://github.com/jpadilla/pyjwt/compare/1.0.0...1.0.1
 [1.0.1]: https://github.com/jpadilla/pyjwt/compare/1.0.0...1.0.1

--- a/jwt/__main__.py
+++ b/jwt/__main__.py
@@ -31,7 +31,7 @@ The exp key is special and can take an offset to current Unix time.\
 '''
     p = optparse.OptionParser(
         usage=usage,
-        prog=__package__,
+        prog='pyjwt',
         version='%s %s' % (__package__, __version__),
     )
 

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     ),
     entry_points={
         'console_scripts': [
-            'jwt = jwt.__main__:main'
+            'pyjwt = jwt.__main__:main'
         ]
     }
 )


### PR DESCRIPTION
So, instead of getting rid of the jwt CLI script as we discussed in #130, what do you think about just renaming it to jwt-cli so that it doesn't overlap with `jwt` anymore? That should pretty much fix any outstanding issues.

Thoughts @jpadilla? 