### PR TITLE
Fixed example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ pip install PyJWT
 >>> encoded = jwt.encode({'some': 'payload'}, 'secret', algorithm='HS256')
 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzb21lIjoicGF5bG9hZCJ9.4twFt5NiznN84AWoo1d7KO1T_yoc0Z6XOpOVswacPZg'
 
->>> jwt.decode(encoded, 'secret'. algorithms=['HS256'])
+>>> jwt.decode(encoded, 'secret', algorithms=['HS256'])
 {'some': 'payload'}
 ```
 


### PR DESCRIPTION
The example contained incorrect syntax, simply swapped the comma for the existing period.