### PR TITLE
Reflect that --no-verify also ignores claims

### DIFF
--- a/jwt/__main__.py
+++ b/jwt/__main__.py
@@ -40,7 +40,7 @@ The exp key is special and can take an offset to current Unix time.\
         action='store_false',
         dest='verify',
         default=True,
-        help='ignore signature verification on decode'
+        help='ignore signature and claims verification on decode'
     )
 
     p.add_option(


### PR DESCRIPTION
The --no-verify option disables both signature verification and claims verification (e.g. expiry); reflect that in the command-line help.