### PR TITLE
Add Python 3.5 to CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+python:
+  - "3.5"
 sudo: false
 env:
   - TOXENV=flake8
@@ -6,9 +8,11 @@ env:
   - TOXENV=py27-crypto
   - TOXENV=py33-crypto
   - TOXENV=py34-crypto
+  - TOXENV=py35-crypto
   - TOXENV=py34-nocrypto
+  - TOXENV=py35-nocrypto
   - TOXENV=py27-nocrypto
-  - TOXENV=py34-contrib_crypto
+  - TOXENV=py35-contrib_crypto
   - TOXENV=py27-contrib_crypto
 install:
   - pip install -U pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,8 @@ environment:
     - PYTHON: "C:\\Python27-x64"
       TOX_ENV: "py27-crypto"
 
-    - PYTHON: "C:\\Python34-x64"
-      TOX_ENV: "py34-crypto"
+    - PYTHON: "C:\\Python35-x64"
+      TOX_ENV: "py35-crypto"
 
 init:
   - SET PATH=%PYTHON%;%PATH%

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Utilities',
     ],
     test_suite='tests',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{26,27,33,34}-crypto, py{27,34}-contrib_crypto, py{27,34}-nocrypto, flake8
+envlist = py{26,27,33,34,35}-crypto, py{27,35}-contrib_crypto, py{27,35}-nocrypto, flake8
 
 [testenv]
 commands =


### PR DESCRIPTION
Just noticed we don't have Python 3.5 set up for our CI builds. This adds Python 3.5 and changes some of our single version builds to use 3.5 instead of 3.4.