### PR TITLE
Flake8 now ignores .tox

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,8 @@
 [flake8]
 max-line-length = 119
-exclude = docs/
+exclude = 
+    docs/,
+    .tox/
 
 [wheel]
 universal = 1


### PR DESCRIPTION
Apparently a flake8 or tox update caused .tox to be included in the flake8 check. As you can imagine, that turns out badly for everyone involved.

This PR fixes that by excluding .tox from the flake8 check