### PR TITLE
Added possibility to pass a passphrase to a encrypted RSA private key

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -151,7 +151,7 @@ if has_crypto:
         def __init__(self, hash_alg):
             self.hash_alg = hash_alg
 
-        def prepare_key(self, key):
+        def prepare_key(self, key, password=None):
             if isinstance(key, RSAPrivateKey) or \
                isinstance(key, RSAPublicKey):
                 return key
@@ -164,7 +164,7 @@ if has_crypto:
                     if key.startswith(b'ssh-rsa'):
                         key = load_ssh_public_key(key, backend=default_backend())
                     else:
-                        key = load_pem_private_key(key, password=None, backend=default_backend())
+                        key = load_pem_private_key(key, password=password, backend=default_backend())
                 except ValueError:
                     key = load_pem_public_key(key, backend=default_backend())
             else:

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -66,7 +66,7 @@ class PyJWS(object):
         return list(self._valid_algs)
 
     def encode(self, payload, key, algorithm='HS256', headers=None,
-               json_encoder=None):
+               json_encoder=None, **kwargs):
         segments = []
 
         if algorithm is None:
@@ -95,7 +95,7 @@ class PyJWS(object):
         signing_input = b'.'.join(segments)
         try:
             alg_obj = self._algorithms[algorithm]
-            key = alg_obj.prepare_key(key)
+            key = alg_obj.prepare_key(key, **kwargs)
             signature = alg_obj.sign(signing_input, key)
 
         except KeyError:

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -34,7 +34,7 @@ class PyJWT(PyJWS):
         }
 
     def encode(self, payload, key, algorithm='HS256', headers=None,
-               json_encoder=None):
+               json_encoder=None, **kwargs):
         # Check that we get a mapping
         if not isinstance(payload, Mapping):
             raise TypeError('Expecting a mapping object, as JWT only supports '
@@ -53,7 +53,7 @@ class PyJWT(PyJWS):
         ).encode('utf-8')
 
         return super(PyJWT, self).encode(
-            json_payload, key, algorithm, headers, json_encoder
+            json_payload, key, algorithm, headers, json_encoder, **kwargs
         )
 
     def decode(self, jwt, key='', verify=True, algorithms=None, options=None,


### PR DESCRIPTION
I've noticed there is no way to encode a jwt token using encrypted RSA private key.

So I've added a possibility to do so via `**kwargs`:

```
access_token = jwt.encode(data, private_key, "RS256", password="private-key-passphrase")
```
