### PR TITLE
Fix incorrectly named ECDSA algorithm

### DIFF
--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -9,7 +9,7 @@ This library currently supports:
 * HS512 - HMAC using SHA-512 hash algorithm
 * ES256 - ECDSA signature algorithm using SHA-256 hash algorithm
 * ES384 - ECDSA signature algorithm using SHA-384 hash algorithm
-* ES512 - ECDSA signature algorithm using SHA-512 hash algorithm
+* ES521 - ECDSA signature algorithm using SHA-512 hash algorithm
 * RS256 - RSASSA-PKCS1-v1_5 signature algorithm using SHA-256 hash algorithm
 * RS384 - RSASSA-PKCS1-v1_5 signature algorithm using SHA-384 hash algorithm
 * RS512 - RSASSA-PKCS1-v1_5 signature algorithm using SHA-512 hash algorithm

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -43,7 +43,7 @@ def get_default_algorithms():
             'RS512': RSAAlgorithm(RSAAlgorithm.SHA512),
             'ES256': ECAlgorithm(ECAlgorithm.SHA256),
             'ES384': ECAlgorithm(ECAlgorithm.SHA384),
-            'ES512': ECAlgorithm(ECAlgorithm.SHA512),
+            'ES521': ECAlgorithm(ECAlgorithm.SHA512),
             'PS256': RSAPSSAlgorithm(RSAPSSAlgorithm.SHA256),
             'PS384': RSAPSSAlgorithm(RSAPSSAlgorithm.SHA384),
             'PS512': RSAPSSAlgorithm(RSAPSSAlgorithm.SHA512)

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -566,11 +566,11 @@ class TestJWS:
         if has_crypto:
             assert 'ES256' in jws_algorithms
             assert 'ES384' in jws_algorithms
-            assert 'ES512' in jws_algorithms
+            assert 'ES521' in jws_algorithms
         else:
             assert 'ES256' not in jws_algorithms
             assert 'ES384' not in jws_algorithms
-            assert 'ES512' not in jws_algorithms
+            assert 'ES521' not in jws_algorithms
 
     def test_skip_check_signature(self, jws):
         token = ("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -544,7 +544,7 @@ class TestJWS:
         with open('tests/keys/testkey_ec', 'r') as ec_priv_file:
             priv_eckey = load_pem_private_key(ensure_bytes(ec_priv_file.read()),
                                               password=None, backend=default_backend())
-            jws_message = jws.encode(payload, priv_eckey, algorithm='ES512')
+            jws_message = jws.encode(payload, priv_eckey, algorithm='ES521')
 
         with open('tests/keys/testkey_ec.pub', 'r') as ec_pub_file:
             pub_eckey = load_pem_public_key(ensure_bytes(ec_pub_file.read()), backend=default_backend())
@@ -553,7 +553,7 @@ class TestJWS:
         # string-formatted key
         with open('tests/keys/testkey_ec', 'r') as ec_priv_file:
             priv_eckey = ec_priv_file.read()
-            jws_message = jws.encode(payload, priv_eckey, algorithm='ES512')
+            jws_message = jws.encode(payload, priv_eckey, algorithm='ES521')
 
         with open('tests/keys/testkey_ec.pub', 'r') as ec_pub_file:
             pub_eckey = ec_pub_file.read()


### PR DESCRIPTION
Per the [RFC on ECDSA in TLS](https://tools.ietf.org/html/rfc4492#appendix-A), the signing algorithm using the P-521 elliptic curve and SHA-512 is called ES521, instead of ES512.