### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ $ python setup.py test
 [coveralls-status-image]: https://coveralls.io/repos/jpadilla/pyjwt/badge.svg?branch=master
 [coveralls]: https://coveralls.io/r/jpadilla/pyjwt?branch=master
 [docs-status-image]: https://readthedocs.org/projects/pyjwt/badge/?version=latest
-[docs]: http://pyjwt.readthedocs.org
+[docs]: https://pyjwt.readthedocs.io
 [jwt-spec]: https://tools.ietf.org/html/rfc7519
 [progrium]: https://github.com/progrium


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.