### PR TITLE
Require cryptography >= 1.0, replace deprecated functions

### DIFF
--- a/jwt/utils.py
+++ b/jwt/utils.py
@@ -6,7 +6,7 @@ from .compat import binary_type, bytes_from_int, text_type
 
 try:
     from cryptography.hazmat.primitives.asymmetric.utils import (
-        decode_rfc6979_signature, encode_rfc6979_signature
+        decode_dss_signature, encode_dss_signature
     )
 except ImportError:
     pass
@@ -95,7 +95,7 @@ def der_to_raw_signature(der_sig, curve):
     num_bits = curve.key_size
     num_bytes = (num_bits + 7) // 8
 
-    r, s = decode_rfc6979_signature(der_sig)
+    r, s = decode_dss_signature(der_sig)
 
     return number_to_bytes(r, num_bytes) + number_to_bytes(s, num_bytes)
 
@@ -110,4 +110,4 @@ def raw_to_der_signature(raw_sig, curve):
     r = bytes_to_number(raw_sig[:num_bytes])
     s = bytes_to_number(raw_sig[num_bytes:])
 
-    return encode_rfc6979_signature(r, s)
+    return encode_dss_signature(r, s)

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     tests_require=tests_require,
     extras_require=dict(
         test=tests_require,
-        crypto=['cryptography'],
+        crypto=['cryptography >= 1.0'],
         flake8=[
             'flake8',
             'flake8-import-order',


### PR DESCRIPTION
The functions `decode_rfc6979_signature` and `encode_rfc6979_signature`
were deprecated in cryptography 1.0:
    https://github.com/pyca/cryptography/blob/master/CHANGELOG.rst#10---2015-08-12
and raise a DeprecationWarning now. The replacements are exactly the same.