### PR TITLE
Change optparse for argparse.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,4 +4,4 @@ omit =
     .tox/*
     setup.py
     *.egg/*
-    */__main__.py
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
   - TOXENV=py35-contrib_crypto
   - TOXENV=py36-contrib_crypto
   - TOXENV=py27-contrib_crypto
+  
 install:
   - pip install -U pip
   - pip install -U tox coveralls

--- a/jwt/__main__.py
+++ b/jwt/__main__.py
@@ -148,20 +148,16 @@ def build_argparser():
     return arg_parser
 
 
-def main(args):
+def main():
     arg_parser = build_argparser()
 
     try:
-        arguments = arg_parser.parse_args(args)
+        arguments = arg_parser.parse_args(sys.argv[1:])
 
-        return arguments.func(arguments)
+        output = arguments.func(arguments)
+
+        print(output)
     except Exception as e:
         print('There was an unforseen error: ', e)
         arg_parser.print_help()
         sys.exit(1)
-
-
-if __name__ == '__main__':
-    output = main(sys.argv[1:])
-
-    print(output)

--- a/jwt/__main__.py
+++ b/jwt/__main__.py
@@ -160,4 +160,3 @@ def main():
     except Exception as e:
         print('There was an unforseen error: ', e)
         arg_parser.print_help()
-        sys.exit(1)

--- a/jwt/__main__.py
+++ b/jwt/__main__.py
@@ -153,6 +153,7 @@ def build_argparser():
 
     return arg_parser
 
+
 def main(args):
     arg_parser = build_argparser()
 

--- a/jwt/__main__.py
+++ b/jwt/__main__.py
@@ -60,6 +60,7 @@ def encode_payload(args):
         print(e)
         sys.exit(1)
 
+
 def decode_payload(args):
     try:
         if not sys.stdin.isatty():
@@ -75,6 +76,7 @@ def decode_payload(args):
     except DecodeError as e:
         print(e)
         sys.exit(1)
+
 
 def main():
 
@@ -161,6 +163,7 @@ def main():
         print('There was an unforseen error: ', e)
         arg_parser.print_help()
         sys.exit(1)
+
 
 if __name__ == '__main__':
     main()

--- a/jwt/__main__.py
+++ b/jwt/__main__.py
@@ -2,8 +2,8 @@
 
 from __future__ import absolute_import, print_function
 
-import json
 import argparse
+import json
 import sys
 import time
 

--- a/jwt/__main__.py
+++ b/jwt/__main__.py
@@ -3,47 +3,112 @@
 from __future__ import absolute_import, print_function
 
 import json
-import optparse
+import argparse
 import sys
 import time
 
-from . import DecodeError, __package__, __version__, decode, encode
+from . import DecodeError, __version__, decode, encode
 
+
+def encode_payload(args):
+    # Try to encode
+    if args.key is None:
+        print('Key is required when encoding. See --help for usage.')
+        sys.exit(1)
+
+    # Build payload object to encode
+    payload = {}
+
+    for arg in args.payload:
+        try:
+            k, v = arg.split('=', 1)
+
+            # exp +offset special case?
+            if k == 'exp' and v[0] == '+' and len(v) > 1:
+                v = str(int(time.time()+int(v[1:])))
+
+            # Cast to integer?
+            if v.isdigit():
+                v = int(v)
+            else:
+                # Cast to float?
+                try:
+                    v = float(v)
+                except ValueError:
+                    pass
+
+            # Cast to true, false, or null?
+            constants = {'true': True, 'false': False, 'null': None}
+
+            if v in constants:
+                v = constants[v]
+
+            payload[k] = v
+        except ValueError:
+            print('Invalid encoding input at {}'.format(arg))
+            sys.exit(1)
+
+    try:
+        token = encode(
+            payload,
+            key=args.key,
+            algorithm=args.algorithm
+        )
+
+        return token.decode('utf-8')
+    except Exception as e:
+        print(e)
+        sys.exit(1)
+
+def decode_payload(args):
+    try:
+        if not sys.stdin.isatty():
+            token = sys.stdin.read()
+        else:
+            token = args.token
+
+        token = token.encode('utf-8')
+        data = decode(token, key=args.key, verify=args.verify)
+
+        return json.dumps(data)
+
+    except DecodeError as e:
+        print(e)
+        sys.exit(1)
 
 def main():
 
-    usage = '''Encodes or decodes JSON Web Tokens based on input.
+    usage = '''
+    Encodes or decodes JSON Web Tokens based on input.
 
-  %prog [options] input
+    %(prog)s [options] <command> [options] input
 
-Decoding examples:
+    Decoding examples:
 
-  %prog --key=secret json.web.token
-  %prog --no-verify json.web.token
+    %(prog)s --key=secret decode json.web.token
+    %(prog)s decode --no-verify json.web.token
 
-Encoding requires the key option and takes space separated key/value pairs
-separated by equals (=) as input. Examples:
+    Encoding requires the key option and takes space separated key/value pairs
+    separated by equals (=) as input. Examples:
 
-  %prog --key=secret iss=me exp=1302049071
-  %prog --key=secret foo=bar exp=+10
+    %(prog)s --key=secret encode iss=me exp=1302049071
+    %(prog)s --key=secret encode foo=bar exp=+10
 
-The exp key is special and can take an offset to current Unix time.\
-'''
-    p = optparse.OptionParser(
-        usage=usage,
+    The exp key is special and can take an offset to current Unix time.
+    '''
+
+    arg_parser = argparse.ArgumentParser(
         prog='pyjwt',
-        version='%s %s' % (__package__, __version__),
+        usage=usage
     )
 
-    p.add_option(
-        '-n', '--no-verify',
-        action='store_false',
-        dest='verify',
-        default=True,
-        help='ignore signature and claims verification on decode'
+    arg_parser.add_argument(
+        '-v', '--version',
+        action='version',
+        version='%(prog)s ' + __version__
     )
 
-    p.add_option(
+    arg_parser.add_argument(
         '--key',
         dest='key',
         metavar='KEY',
@@ -51,7 +116,7 @@ The exp key is special and can take an offset to current Unix time.\
         help='set the secret key to sign with'
     )
 
-    p.add_option(
+    arg_parser.add_argument(
         '--alg',
         dest='algorithm',
         metavar='ALG',
@@ -59,78 +124,43 @@ The exp key is special and can take an offset to current Unix time.\
         help='set crypto algorithm to sign with. default=HS256'
     )
 
-    options, arguments = p.parse_args()
+    subparsers = arg_parser.add_subparsers(
+        title='PyJWT subcommands',
+        description='valid subcommands',
+        help='additional help'
+    )
 
-    if len(arguments) > 0 or not sys.stdin.isatty():
-        if len(arguments) == 1 and (not options.verify or options.key):
-            # Try to decode
-            try:
-                if not sys.stdin.isatty():
-                    token = sys.stdin.read()
-                else:
-                    token = arguments[0]
+    # Encode subcommand
+    encode_parser = subparsers.add_parser('encode', help='use to encode a supplied payload')
 
-                token = token.encode('utf-8')
-                data = decode(token, key=options.key, verify=options.verify)
+    payload_help = """Payload to encode. Must be a space separated list of key/value
+    pairs separated by equals (=) sign."""
 
-                print(json.dumps(data))
-                sys.exit(0)
-            except DecodeError as e:
-                print(e)
-                sys.exit(1)
+    encode_parser.add_argument('payload', nargs='+', help=payload_help)
+    encode_parser.set_defaults(func=encode_payload)
 
-        # Try to encode
-        if options.key is None:
-            print('Key is required when encoding. See --help for usage.')
-            sys.exit(1)
+    # Decode subcommand
+    decode_parser = subparsers.add_parser('decode', help='use to decode a supplied JSON web token')
+    decode_parser.add_argument('token', help='JSON web token to decode.')
 
-        # Build payload object to encode
-        payload = {}
+    decode_parser.add_argument(
+        '-n', '--no-verify',
+        action='store_false',
+        dest='verify',
+        default=True,
+        help='ignore signature and claims verification on decode'
+    )
 
-        for arg in arguments:
-            try:
-                k, v = arg.split('=', 1)
+    decode_parser.set_defaults(func=decode_payload)
 
-                # exp +offset special case?
-                if k == 'exp' and v[0] == '+' and len(v) > 1:
-                    v = str(int(time.time()+int(v[1:])))
-
-                # Cast to integer?
-                if v.isdigit():
-                    v = int(v)
-                else:
-                    # Cast to float?
-                    try:
-                        v = float(v)
-                    except ValueError:
-                        pass
-
-                # Cast to true, false, or null?
-                constants = {'true': True, 'false': False, 'null': None}
-
-                if v in constants:
-                    v = constants[v]
-
-                payload[k] = v
-            except ValueError:
-                print('Invalid encoding input at {}'.format(arg))
-                sys.exit(1)
-
-        try:
-            token = encode(
-                payload,
-                key=options.key,
-                algorithm=options.algorithm
-            )
-
-            print(token)
-            sys.exit(0)
-        except Exception as e:
-            print(e)
-            sys.exit(1)
-    else:
-        p.print_help()
-
+    try:
+        arguments = arg_parser.parse_args()
+        print(arguments.func(arguments))
+        sys.exit(0)
+    except Exception as e:
+        print('There was an unforseen error: ', e)
+        arg_parser.print_help()
+        sys.exit(1)
 
 if __name__ == '__main__':
     main()

--- a/jwt/__main__.py
+++ b/jwt/__main__.py
@@ -44,7 +44,7 @@ def encode_payload(args):
 
             payload[k] = v
         except ValueError:
-            raise ValueError('Invalid encoding input at {}'.format(arg))
+            raise ValueError('Invalid encoding input at %s' % arg)
 
     try:
         token = encode(
@@ -71,7 +71,7 @@ def decode_payload(args):
         return json.dumps(data)
 
     except DecodeError as e:
-        raise DecodeError('There was an error decoding the token: {}'.format(e))
+        raise DecodeError('There was an error decoding the token: %s' % e)
 
 
 def build_argparser():

--- a/jwt/__main__.py
+++ b/jwt/__main__.py
@@ -19,43 +19,37 @@ def encode_payload(args):
     payload = {}
 
     for arg in args.payload:
-        try:
-            k, v = arg.split('=', 1)
+        k, v = arg.split('=', 1)
 
-            # exp +offset special case?
-            if k == 'exp' and v[0] == '+' and len(v) > 1:
-                v = str(int(time.time()+int(v[1:])))
+        # exp +offset special case?
+        if k == 'exp' and v[0] == '+' and len(v) > 1:
+            v = str(int(time.time()+int(v[1:])))
 
-            # Cast to integer?
-            if v.isdigit():
-                v = int(v)
-            else:
-                # Cast to float?
-                try:
-                    v = float(v)
-                except ValueError:
-                    pass
+        # Cast to integer?
+        if v.isdigit():
+            v = int(v)
+        else:
+            # Cast to float?
+            try:
+                v = float(v)
+            except ValueError:
+                pass
 
-            # Cast to true, false, or null?
-            constants = {'true': True, 'false': False, 'null': None}
+        # Cast to true, false, or null?
+        constants = {'true': True, 'false': False, 'null': None}
 
-            if v in constants:
-                v = constants[v]
+        if v in constants:
+            v = constants[v]
 
-            payload[k] = v
-        except ValueError:
-            raise ValueError('Invalid encoding input at %s' % arg)
+        payload[k] = v
 
-    try:
-        token = encode(
-            payload,
-            key=args.key,
-            algorithm=args.algorithm
-        )
+    token = encode(
+        payload,
+        key=args.key,
+        algorithm=args.algorithm
+    )
 
-        return token.decode('utf-8')
-    except Exception as e:
-        raise Exception(e)
+    return token.decode('utf-8')
 
 
 def decode_payload(args):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,16 +1,22 @@
+
 import json
-import pytest
 from jwt import DecodeError
 from jwt.__main__ import build_argparser, decode_payload, encode_payload, main
+import pytest
 
 
 @pytest.fixture
 def token():
-    return 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiVmFkZXIiLCJqb2IiOiJTaXRoIn0.eS5n_fxbLSpzHNY19fcEXj4GCU7c4Pog4jv2qq-cKgo'
+    return '{}.{}.{}'.format(
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9',
+        'eyJuYW1lIjoiVmFkZXIiLCJqb2IiOiJTaXRoIn0',
+        'eS5n_fxbLSpzHNY19fcEXj4GCU7c4Pog4jv2qq-cKgo')
+
 
 @pytest.fixture
 def decode_args(token):
     return ['--key', '1234', 'decode', token]
+
 
 class TestCli:
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,4 @@
 
-# from __future__ import unicode_literals
-
 import json
 
 import sys

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,64 @@
+import json
+import pytest
+from jwt import DecodeError
+from jwt.__main__ import build_argparser, decode_payload, encode_payload, main
+
+
+@pytest.fixture
+def token():
+    return 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiVmFkZXIiLCJqb2IiOiJTaXRoIn0.eS5n_fxbLSpzHNY19fcEXj4GCU7c4Pog4jv2qq-cKgo'
+
+@pytest.fixture
+def decode_args(token):
+    return ['--key', '1234', 'decode', token]
+
+class TestCli:
+
+    def test_build_argparse(self):
+        args = ['--key', '1234', 'encode', 'name=Vader']
+        parser = build_argparser()
+        parsed_args = parser.parse_args(args)
+
+        assert parsed_args.key == '1234'
+
+    def test_encode_payload(self, token):
+        encode_args = ['--key', '1234', 'encode', 'name=Vader', 'job=Sith']
+        parser = build_argparser()
+
+        args = parser.parse_args(encode_args)
+
+        assert encode_payload(args) == token
+
+    def test_encode_payload_raises_value_error_key_is_required(self):
+        encode_args = ['encode', 'name=Vader', 'job=Sith']
+        parser = build_argparser()
+
+        args = parser.parse_args(encode_args)
+
+        with pytest.raises(ValueError) as excinfo:
+            encode_payload(args)
+
+        assert 'Key is required when encoding' in str(excinfo.value)
+
+    def test_decode_payload(self, decode_args):
+        parser = build_argparser()
+
+        args = parser.parse_args(decode_args)
+
+        assert decode_payload(args) == json.dumps({'name': 'Vader', 'job': 'Sith'})
+
+    def test_decode_payload_raises_decoded_error(self):
+        decode_args = ['--key', '1234', 'decode', 'wrong-token']
+        parser = build_argparser()
+
+        args = parser.parse_args(decode_args)
+
+        with pytest.raises(DecodeError) as excinfo:
+            decode_payload(args)
+
+        assert 'There was an error decoding the token' in str(excinfo.value)
+
+    def test_main_run(self, token):
+        args = ['--key', '1234', 'encode', 'name=Vader', 'job=Sith']
+
+        assert main(args) == token

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,9 @@
 
-from  __future__ import unicode_literals
-import time
+from __future__ import unicode_literals
 
 import jwt
 from jwt.__main__ import build_argparser, decode_payload, encode_payload, main
+
 import pytest
 
 
@@ -46,8 +46,8 @@ class TestCli:
         args = [
             '--key', key,
             'encode',
-            'name={}'.format(name),
-            'job={}'.format(job)
+            'name={0}'.format(name),
+            'job={0}'.format(job)
         ]
 
         token = main(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,12 @@
 
 import argparse
 import json
-import pytest
 import sys
 
 import jwt
 from jwt.__main__ import build_argparser, decode_payload, encode_payload, main
+
+import pytest
 
 
 class TestCli:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,16 +1,17 @@
 
 import json
+
 from jwt import DecodeError
 from jwt.__main__ import build_argparser, decode_payload, encode_payload, main
+
 import pytest
 
 
 @pytest.fixture
 def token():
-    return '{}.{}.{}'.format(
-        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9',
-        'eyJuYW1lIjoiVmFkZXIiLCJqb2IiOiJTaXRoIn0',
-        'eS5n_fxbLSpzHNY19fcEXj4GCU7c4Pog4jv2qq-cKgo')
+    return '%s.%s.%s' % ('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9',
+                         'eyJuYW1lIjoiVmFkZXIiLCJqb2IiOiJTaXRoIn0',
+                         'eS5n_fxbLSpzHNY19fcEXj4GCU7c4Pog4jv2qq-cKgo')
 
 
 @pytest.fixture


### PR DESCRIPTION
- Change optparse for the more modern argparse.
- Refactored main() to fit new argparse code.
- Added two subcommands: encode and decode
- Added default functions for encode and decode subcommands
- Replaced implicit arguments with standard Python syntax in usage text.