### PR TITLE
Refactor error handling in Algorithm.prepare_key() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 -------------------------------------------------------------------------
 ### Changed
 - Add support for ECDSA public keys in RFC 4253 (OpenSSH) format [#244][244]
+- All Algorithm.prepare_key() calls now return either a valid key value or raise  InvalidKeyError
 - Renamed commandline script `jwt` to `jwt-cli` to avoid issues with the script clobbering the `jwt` module in some circumstances.
 - Better error messages when using an algorithm that requires the cryptography package, but it isn't available [#230][230]
 

--- a/jwt/contrib/algorithms/py_ecdsa.py
+++ b/jwt/contrib/algorithms/py_ecdsa.py
@@ -7,6 +7,7 @@ import ecdsa
 
 from jwt.algorithms import Algorithm
 from jwt.compat import string_types, text_type
+from jwt.exceptions import InvalidAsymmetricKeyError
 
 
 class ECAlgorithm(Algorithm):
@@ -44,7 +45,7 @@ class ECAlgorithm(Algorithm):
                 key = ecdsa.SigningKey.from_pem(key)
 
         else:
-            raise TypeError('Expecting a PEM-formatted key.')
+            raise InvalidAsymmetricKeyError('Expecting a PEM-formatted key.')
 
         return key
 

--- a/jwt/contrib/algorithms/pycrypto.py
+++ b/jwt/contrib/algorithms/pycrypto.py
@@ -7,6 +7,7 @@ from Crypto.Signature import PKCS1_v1_5
 
 from jwt.algorithms import Algorithm
 from jwt.compat import string_types, text_type
+from jwt.exceptions import InvalidAsymmetricKeyError
 
 
 class RSAAlgorithm(Algorithm):
@@ -36,7 +37,7 @@ class RSAAlgorithm(Algorithm):
 
             key = RSA.importKey(key)
         else:
-            raise TypeError('Expecting a PEM- or RSA-formatted key.')
+            raise InvalidAsymmetricKeyError
 
         return key
 

--- a/jwt/exceptions.py
+++ b/jwt/exceptions.py
@@ -26,8 +26,16 @@ class ImmatureSignatureError(InvalidTokenError):
     pass
 
 
-class InvalidKeyError(Exception):
+class InvalidKeyError(ValueError):
     pass
+
+
+class InvalidAsymmetricKeyError(InvalidKeyError):
+    message = 'Invalid key: Keys must be in PEM or RFC 4253 format.'
+
+
+class InvalidJwkError(InvalidKeyError):
+    message = 'Invalid key: Keys must be in JWK format.'
 
 
 class InvalidAlgorithmError(InvalidTokenError):

--- a/tests/contrib/test_algorithms.py
+++ b/tests/contrib/test_algorithms.py
@@ -1,5 +1,6 @@
 import base64
 
+from jwt.exceptions import InvalidAsymmetricKeyError
 from jwt.utils import force_bytes, force_unicode
 
 import pytest
@@ -36,7 +37,7 @@ class TestPycryptoAlgorithms:
     def test_rsa_should_reject_non_string_key(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(InvalidAsymmetricKeyError):
             algo.prepare_key(None)
 
     def test_rsa_sign_should_generate_correct_signature_value(self):
@@ -117,7 +118,7 @@ class TestEcdsaAlgorithms:
     def test_ec_should_reject_non_string_key(self):
         algo = ECAlgorithm(ECAlgorithm.SHA256)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(InvalidAsymmetricKeyError):
             algo.prepare_key(None)
 
     def test_ec_should_accept_unicode_key(self):

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -58,11 +58,11 @@ class TestAlgorithms:
     def test_hmac_should_reject_nonstring_key(self):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
 
-        with pytest.raises(TypeError) as context:
+        with pytest.raises(InvalidKeyError) as context:
             algo.prepare_key(object())
 
         exception = context.value
-        assert str(exception) == 'Expected a string value'
+        assert str(exception) == 'HMAC secret key must be a string type.'
 
     def test_hmac_should_accept_unicode_key(self):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
@@ -144,7 +144,7 @@ class TestAlgorithms:
     def test_rsa_should_reject_non_string_key(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(InvalidKeyError):
             algo.prepare_key(None)
 
     @pytest.mark.skipif(not has_crypto, reason='Not supported without cryptography library')
@@ -358,7 +358,7 @@ class TestAlgorithms:
     def test_ec_should_reject_non_string_key(self):
         algo = ECAlgorithm(ECAlgorithm.SHA256)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(InvalidKeyError):
             algo.prepare_key(None)
 
     @pytest.mark.skipif(not has_crypto, reason='Not supported without cryptography library')


### PR DESCRIPTION
Our error handling in Algorithm.prepare_key() was previously weird and
kind of inconsistent. This change makes a number of improvements:

* Refactors RSA and ECDSA prepare_key() methods to reduce nesting and
  make the code simpler to understand
* All calls to Algorithm.prepare_key() return InvalidKeyError (or a
  subclass) or a valid key instance.
* Created a new InvalidAsymmetricKeyError class that is used to provide
  a standard message when an invalid RSA or ECDSA key is used.