### PR TITLE
Remove rejection of future 'iat' claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add support for ECDSA public keys in RFC 4253 (OpenSSH) format [#244][244]
 - Renamed commandline script `jwt` to `jwt-cli` to avoid issues with the script clobbering the `jwt` module in some circumstances.
 - Better error messages when using an algorithm that requires the cryptography package, but it isn't available [#230][230]
+- Tokens with future 'iat' values are no longer rejected [#190][190]
 
 ### Fixed
 
@@ -129,5 +130,6 @@ rarely used. Users affected by this should upgrade to 3.3+.
 [174]: https://github.com/jpadilla/pyjwt/pull/174
 [182]: https://github.com/jpadilla/pyjwt/pull/182
 [183]: https://github.com/jpadilla/pyjwt/pull/183
+[190]: https://github.com/jpadilla/pyjwt/pull/190
 [213]: https://github.com/jpadilla/pyjwt/pull/214
 [244]: https://github.com/jpadilla/pyjwt/pull/244

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Renamed commandline script `jwt` to `jwt-cli` to avoid issues with the script clobbering the `jwt` module in some circumstances.
 - Better error messages when using an algorithm that requires the cryptography package, but it isn't available [#230][230]
 - Tokens with future 'iat' values are no longer rejected [#190][190]
+- Non-numeric 'iat' values now raise InvalidIssuedAtError instead of DecodeError
+
 
 ### Fixed
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -180,6 +180,8 @@ Issued At Claim (iat)
     This claim can be used to determine the age of the JWT. Its value MUST be a
     number containing a NumericDate value. Use of this claim is OPTIONAL.
 
+    If the `iat` claim is not a number, an `jwt.InvalidIssuedAtError` exception will be raised.
+
 .. code-block:: python
 
     jwt.encode({'iat': 1371720939}, 'secret')

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -180,9 +180,6 @@ Issued At Claim (iat)
     This claim can be used to determine the age of the JWT. Its value MUST be a
     number containing a NumericDate value. Use of this claim is OPTIONAL.
 
-If the `iat` claim is in the future, an `jwt.InvalidIssuedAtError` exception
-will be raised.
-
 .. code-block:: python
 
     jwt.encode({'iat': 1371720939}, 'secret')

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -123,7 +123,7 @@ class PyJWT(PyJWS):
         try:
             int(payload['iat'])
         except ValueError:
-            raise DecodeError('Issued At claim (iat) must be an integer.')
+            raise InvalidIssuedAtError('Issued At claim (iat) must be an integer.')
 
     def _validate_nbf(self, payload, now, leeway):
         try:

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -121,13 +121,9 @@ class PyJWT(PyJWS):
 
     def _validate_iat(self, payload, now, leeway):
         try:
-            iat = int(payload['iat'])
+            int(payload['iat'])
         except ValueError:
             raise DecodeError('Issued At claim (iat) must be an integer.')
-
-        if iat > (now + leeway):
-            raise InvalidIssuedAtError('Issued At claim (iat) cannot be in'
-                                       ' the future.')
 
     def _validate_nbf(self, payload, now, leeway):
         try:

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -142,7 +142,7 @@ class TestJWT:
                        'eyJpYXQiOiJub3QtYW4taW50In0.'
                        'H1GmcQgSySa5LOKYbzGm--b1OmRbHFkyk8pq811FzZM')
 
-        with pytest.raises(DecodeError):
+        with pytest.raises(InvalidIssuedAtError):
             jwt.decode(example_jwt, 'secret')
 
     def test_decode_raises_exception_if_nbf_is_not_int(self, jwt):

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -154,13 +154,6 @@ class TestJWT:
         with pytest.raises(DecodeError):
             jwt.decode(example_jwt, 'secret')
 
-    def test_decode_raises_exception_if_iat_in_the_future(self, jwt):
-        now = datetime.utcnow()
-        token = jwt.encode({'iat': now + timedelta(days=1)}, key='secret')
-
-        with pytest.raises(InvalidIssuedAtError):
-            jwt.decode(token, 'secret')
-
     def test_encode_datetime(self, jwt):
         secret = 'secret'
         current_datetime = datetime.utcnow()


### PR DESCRIPTION
This change resolves #190 by no longer rejecting future `iat` claims.

RFC 7519 does not require or even mention this type of validation so it seems best to leave this up to applications.

In addition, this PR changes the validation that rejects non-numeric `iat` values to raise `InvalidIssuedAtError` instead of `DecodeError` 