### PR TITLE
Bump pytest version to latest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,13 @@
 [flake8]
 max-line-length = 119
-exclude = 
+exclude =
     docs/,
     .tox/
 
 [wheel]
 universal = 1
 
-[pytest]
+[tool:pytest]
 addopts = --cov-report term-missing --cov-config=.coveragerc --cov .
 
 [aliases]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if sys.argv[-1] == 'publish':
     sys.exit()
 
 tests_require = [
-    'pytest==2.7.3',
+    'pytest >3,<4',
     'pytest-cov',
     'pytest-runner',
 ]


### PR DESCRIPTION
Previously, pytest was pinned to an old version because of a bug in
pytest that has since been fixed. This change now puts us back to using
the latest version of pytest.

This fixes #253.