### PR TITLE
enable testing with python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: python
 python:
-  - "3.5"
+  - "3.6"
+addons:
+  apt:
+    sources:
+      - deadsnakes
+    packages:
+      - python3.5 python3.5-dev
 sudo: false
 env:
   - TOXENV=flake8
@@ -9,10 +15,13 @@ env:
   - TOXENV=py33-crypto
   - TOXENV=py34-crypto
   - TOXENV=py35-crypto
+  - TOXENV=py36-crypto
   - TOXENV=py34-nocrypto
   - TOXENV=py35-nocrypto
+  - TOXENV=py36-nocrypto
   - TOXENV=py27-nocrypto
   - TOXENV=py35-contrib_crypto
+  - TOXENV=py36-contrib_crypto
   - TOXENV=py27-contrib_crypto
 install:
   - pip install -U pip

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Utilities',
     ],
     test_suite='tests',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{26,27,33,34,35}-crypto, py{27,35}-contrib_crypto, py{27,35}-nocrypto, flake8
+envlist = py{26,27,33,34,35,36}-crypto, py{27,35,36}-contrib_crypto, py{27,35,36}-nocrypto, flake8
 
 [testenv]
 commands =


### PR DESCRIPTION
Enable running tests against python 3.6 in Travis