### PR TITLE
DeprecationWarnings: more helpful message

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -126,7 +126,8 @@ class PyJWS(object):
                                        key, algorithms)
         else:
             warnings.warn('The verify parameter is deprecated. '
-                          'Please use options instead.', DeprecationWarning)
+                          'Please use verify_signature in options instead.',
+                          DeprecationWarning)
 
         return payload
 

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -82,7 +82,8 @@ class PyJWT(PyJWS):
         if 'verify_expiration' in kwargs:
             options['verify_exp'] = kwargs.get('verify_expiration', True)
             warnings.warn('The verify_expiration parameter is deprecated. '
-                          'Please use options instead.', DeprecationWarning)
+                          'Please use verify_exp in options instead.',
+                          DeprecationWarning)
 
         if isinstance(leeway, timedelta):
             leeway = timedelta_total_seconds(leeway)


### PR DESCRIPTION
I've thought about adding `stacklevel=2`, but it is used internally / passed through, so that might not be that helpful.