### PR TITLE
PyJWT.decode: move verify param into options

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -127,7 +127,7 @@ class PyJWS(object):
         else:
             warnings.warn('The verify parameter is deprecated. '
                           'Please use verify_signature in options instead.',
-                          DeprecationWarning)
+                          DeprecationWarning, stacklevel=2)
 
         return payload
 

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -60,8 +60,12 @@ class PyJWT(PyJWS):
                **kwargs):
         payload, signing_input, header, signature = self._load(jwt)
 
-        decoded = super(PyJWT, self).decode(jwt, key, verify, algorithms,
-                                            options, **kwargs)
+        if options is None:
+            options = {'verify_signature': verify}
+        else:
+            options.setdefault('verify_signature', verify)
+        decoded = super(PyJWT, self).decode(jwt, key, algorithms, options,
+                                            **kwargs)
 
         try:
             payload = json.loads(decoded.decode('utf-8'))


### PR DESCRIPTION
Followup to https://github.com/jpadilla/pyjwt/pull/270:

It seems that "verify" is only deprecated with `PyJWS.decode`, which
makes sense, since you would have to override a lot of options to skip
the verification in `PyJWT._validate_claims`.

This makes `PyJWT.decode` use the `verify_signature` option when calling
`PyJWT.decode`, and therefore also allows to use `stacklevel=2` there
then for the DeprecationWarning.