### PR TITLE
fix issuer bug

### DIFF
--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -166,10 +166,10 @@ class PyJWT(PyJWS):
             raise InvalidAudienceError('Invalid audience')
 
     def _validate_iss(self, payload, issuer):
-        if issuer is None:
+        if issuer is None and 'iss' not in payload:
             return
 
-        if 'iss' not in payload:
+        if issuer is not None and 'iss' not in payload:
             raise MissingRequiredClaimError('iss')
 
         if payload['iss'] != issuer:


### PR DESCRIPTION
`encoded = jwt.encode({'name': 'jack', 'exp': datetime.datetime.utcnow(), 'iss': 'urn:foo'}, 'welcome', algorithm='HS256')`

it's ok
```
jwt.decode(encoded, 'welcome', algorithm='HS256', leeway=100, issuer='23432')
InvalidIssuerError: Invalid issuer
```
but:
```
jwt.decode(encoded, 'welcome', algorithm='HS256', leeway=100)
{u'exp': 1497512206, u'iss': u'urn:foo', u'name': u'jack'}
```