### PR TITLE
Add sort_keys for json.dumps in jws/jwt encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ develop-eggs/
 dist/
 downloads/
 eggs/
+.eggs/
 lib/
 lib64/
 parts/

--- a/jwt/__main__.py
+++ b/jwt/__main__.py
@@ -46,7 +46,8 @@ def encode_payload(args):
     token = encode(
         payload,
         key=args.key,
-        algorithm=args.algorithm
+        algorithm=args.algorithm,
+        sort_json=args.sort_payload
     )
 
     return token.decode('utf-8')
@@ -129,6 +130,15 @@ def build_argparser():
     pairs separated by equals (=) sign."""
 
     encode_parser.add_argument('payload', nargs='+', help=payload_help)
+
+    encode_parser.add_argument(
+        '-s', '--sort-payload',
+        dest='sort_payload',
+        action='store_true',
+        default=False,
+        help='Enforce lexicographic sorting of payload.'
+    )
+
     encode_parser.set_defaults(func=encode_payload)
 
     # Decode subcommand

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -68,7 +68,7 @@ class PyJWS(object):
         return list(self._valid_algs)
 
     def encode(self, payload, key, algorithm='HS256', headers=None,
-               json_encoder=None):
+               json_encoder=None, sort_json=False):
         segments = []
 
         if algorithm is None:
@@ -88,7 +88,8 @@ class PyJWS(object):
             json.dumps(
                 header,
                 separators=(',', ':'),
-                cls=json_encoder
+                cls=json_encoder,
+                sort_keys=sort_json
             )
         )
 

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -34,7 +34,7 @@ class PyJWT(PyJWS):
         }
 
     def encode(self, payload, key, algorithm='HS256', headers=None,
-               json_encoder=None):
+               json_encoder=None, sort_json=False):
         # Check that we get a mapping
         if not isinstance(payload, Mapping):
             raise TypeError('Expecting a mapping object, as JWT only supports '
@@ -49,11 +49,12 @@ class PyJWT(PyJWS):
         json_payload = json.dumps(
             payload,
             separators=(',', ':'),
-            cls=json_encoder
+            cls=json_encoder,
+            sort_keys=sort_json
         ).encode('utf-8')
 
         return super(PyJWT, self).encode(
-            json_payload, key, algorithm, headers, json_encoder
+            json_payload, key, algorithm, headers, json_encoder, sort_json
         )
 
     def decode(self, jwt, key='', verify=True, algorithms=None, options=None,


### PR DESCRIPTION
PASSporT is a [draft-ietf-stir-passport-11](https://tools.ietf.org/html/draft-ietf-stir-passport-11) uses JWT.
[Section 9](https://tools.ietf.org/html/draft-ietf-stir-passport-11#section-9) of the above document mandates that the JSON objects in the payload and headers must be ordered by key.

I realise this isn't part of the JWT spec, but it's a really basic change.

Changes:

* add sort_json argument for jwt and jws encode() methods
    * simply passes through to existing sort_keys argument in json.dumps()
* add --sort-payload command line argument for encode command