### PR TITLE
Warn about missing algorithms arg only when verify is True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [Unreleased][unreleased]
 -------------------------------------------------------------------------
 ### Changed
+
 - Increase required version of the cryptography package to >=1.4.0.
+
 ### Fixed
+
 - Remove uses of deprecated functions from the cryptography package.
+- Warn about missing `algorithms` param to `decode()` only when `verify` param is `True` [#281][281]
+
 ### Added
 
 [v1.5.2][1.5.2]
@@ -187,4 +192,5 @@ rarely used. Users affected by this should upgrade to 3.3+.
 [270]: https://github.com/jpadilla/pyjwt/pull/270
 [271]: https://github.com/jpadilla/pyjwt/pull/271
 [277]: https://github.com/jpadilla/pyjwt/pull/277
+[281]: https://github.com/jpadilla/pyjwt/pull/281
 [7c1e61d]: https://github.com/jpadilla/pyjwt/commit/7c1e61dde27bafe16e7d1bb6e35199e778962742

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -118,7 +118,10 @@ class PyJWS(object):
     def decode(self, jws, key='', verify=True, algorithms=None, options=None,
                **kwargs):
 
-        if not algorithms:
+        merged_options = merge_dict(self.options, options)
+        verify_signature = merged_options['verify_signature']
+
+        if verify_signature and not algorithms:
             warnings.warn(
                 'It is strongly recommended that you pass in a ' +
                 'value for the "algorithms" argument when calling decode(). ' +
@@ -128,15 +131,13 @@ class PyJWS(object):
 
         payload, signing_input, header, signature = self._load(jws)
 
-        if verify:
-            merged_options = merge_dict(self.options, options)
-            if merged_options.get('verify_signature'):
-                self._verify_signature(payload, signing_input, header, signature,
-                                       key, algorithms)
-        else:
+        if not verify:
             warnings.warn('The verify parameter is deprecated. '
                           'Please use verify_signature in options instead.',
                           DeprecationWarning, stacklevel=2)
+        elif verify_signature:
+            self._verify_signature(payload, signing_input, header, signature,
+                                   key, algorithms)
 
         return payload
 

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -59,7 +59,7 @@ class PyJWT(PyJWS):
     def decode(self, jwt, key='', verify=True, algorithms=None, options=None,
                **kwargs):
 
-        if not algorithms:
+        if verify and not algorithms:
             warnings.warn(
                 'It is strongly recommended that you pass in a ' +
                 'value for the "algorithms" argument when calling decode(). ' +

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -275,6 +275,24 @@ class TestJWS:
 
         pytest.deprecated_call(jws.decode, example_jws, key=example_secret)
 
+    def test_decode_no_algorithms_verify_signature_false(self, jws):
+        example_secret = 'secret'
+        example_jws = (
+            b'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
+            b'aGVsbG8gd29ybGQ.'
+            b'SIr03zM64awWRdPrAM_61QWsZchAtgDV3pphfHPPWkI'
+        )
+
+        try:
+            pytest.deprecated_call(
+                jws.decode, example_jws, key=example_secret,
+                options={'verify_signature': False},
+            )
+        except AssertionError:
+            pass
+        else:
+            assert False, "Unexpected DeprecationWarning raised."
+
     def test_load_no_verification(self, jws, payload):
         right_secret = 'foo'
         jws_message = jws.encode(payload, right_secret)

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -482,3 +482,16 @@ class TestJWT:
             jwt_message,
             secret
         )
+
+    def test_decode_no_algorithms_verify_false(self, jwt, payload):
+        secret = 'secret'
+        jwt_message = jwt.encode(payload, secret)
+
+        try:
+            pytest.deprecated_call(
+                jwt.decode, jwt_message, secret, verify=False,
+            )
+        except AssertionError:
+            pass
+        else:
+            assert False, "Unexpected DeprecationWarning raised."


### PR DESCRIPTION
Since no signature verification will occur, passing in `algorithms` does
not make much sense.