### PR TITLE
Include 'algorithms' kwarg in jwt.decode() (documentation)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,10 +22,11 @@ Example Usage
 
     >>> import jwt
 
-    >>> jwt.encode({'some': 'payload'}, 'secret', algorithm='HS256')
+    >>> encoded_jwt = jwt.encode({'some': 'payload'}, 'secret', algorithm='HS256')
+    >>> encoded_jwt
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzb21lIjoicGF5bG9hZCJ9.4twFt5NiznN84AWoo1d7KO1T_yoc0Z6XOpOVswacPZg'
 
-    >>> jwt.decode('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzb21lIjoicGF5bG9hZCJ9.4twFt5NiznN84AWoo1d7KO1T_yoc0Z6XOpOVswacPZg', 'secret', algorithms=['HS256'])
+    >>> jwt.decode(encoded_jwt, 'secret', algorithms=['HS256'])
     {'some': 'payload'}
 
 See :doc:`Usage Examples <usage>` for more examples.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ Example Usage
     >>> jwt.encode({'some': 'payload'}, 'secret', algorithm='HS256')
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzb21lIjoicGF5bG9hZCJ9.4twFt5NiznN84AWoo1d7KO1T_yoc0Z6XOpOVswacPZg'
 
-    >>> jwt.decode('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzb21lIjoicGF5bG9hZCJ9.4twFt5NiznN84AWoo1d7KO1T_yoc0Z6XOpOVswacPZg', 'secret')
+    >>> jwt.decode('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzb21lIjoicGF5bG9hZCJ9.4twFt5NiznN84AWoo1d7KO1T_yoc0Z6XOpOVswacPZg', 'secret', algorithms=['HS256'])
     {'some': 'payload'}
 
 See :doc:`Usage Examples <usage>` for more examples.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -73,7 +73,7 @@ Expiration time is automatically verified in `jwt.decode()` and raises
 .. code-block:: python
 
     try:
-        jwt.decode('JWT_STRING', 'secret')
+        jwt.decode('JWT_STRING', 'secret', algorithms=['HS256'])
     except jwt.ExpiredSignatureError:
         # Signature has expired
 
@@ -99,14 +99,14 @@ you can set a leeway of 10 seconds in order to have some margin:
 
     # JWT payload is now expired
     # But with some leeway, it will still validate
-    jwt.decode(jwt_payload, 'secret', leeway=10)
+    jwt.decode(jwt_payload, 'secret', leeway=10, algorithms=['HS256'])
 
 Instead of specifying the leeway as a number of seconds, a `datetime.timedelta`
 instance can be used. The last line in the example above is equivalent to:
 
 .. code-block:: python
 
-    jwt.decode(jwt_payload, 'secret', leeway=datetime.timedelta(seconds=10))
+    jwt.decode(jwt_payload, 'secret', leeway=datetime.timedelta(seconds=10), algorithms=['HS256'])
 
 Not Before Time Claim (nbf)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -142,7 +142,7 @@ Issuer Claim (iss)
     }
 
     token = jwt.encode(payload, 'secret')
-    decoded = jwt.decode(token, 'secret', issuer='urn:foo')
+    decoded = jwt.decode(token, 'secret', issuer='urn:foo', algorithms=['HS256'])
 
 If the issuer claim is incorrect, `jwt.InvalidIssuerError` will be raised.
 
@@ -169,7 +169,7 @@ Audience Claim (aud)
     }
 
     token = jwt.encode(payload, 'secret')
-    decoded = jwt.decode(token, 'secret', audience='urn:foo')
+    decoded = jwt.decode(token, 'secret', audience='urn:foo', algorithms=['HS256'])
 
 If the audience claim is incorrect, `jwt.InvalidAudienceError` will be raised.
 


### PR DESCRIPTION
11f30c4050a11b6398d38f505578c9dabeba6c78 changes things so that a deprecation warning is raised when algorithms isn't specified in the jwt.decode(). This just updates the documentation to match. It also updates the first encode/decode example in the docs so you don't have to scroll a ways to the right in order to see that you need the `secret` and `algorithms` args.