### PR TITLE
Address over-eager fallback to stdin when decoding

### DIFF
--- a/jwt/__main__.py
+++ b/jwt/__main__.py
@@ -54,10 +54,13 @@ def encode_payload(args):
 
 def decode_payload(args):
     try:
-        if sys.stdin.isatty():
-            token = sys.stdin.read()
-        else:
+        if args.token:
             token = args.token
+        else:
+            if sys.stdin.isatty():
+                token = sys.stdin.readline().strip()
+            else:
+                raise IOError('Cannot read from stdin: terminal not a TTY')
 
         token = token.encode('utf-8')
         data = decode(token, key=args.key, verify=args.verify)
@@ -133,7 +136,10 @@ def build_argparser():
 
     # Decode subcommand
     decode_parser = subparsers.add_parser('decode', help='use to decode a supplied JSON web token')
-    decode_parser.add_argument('token', help='JSON web token to decode.')
+    decode_parser.add_argument(
+        'token',
+        help='JSON web token to decode.',
+        nargs='?')
 
     decode_parser.add_argument(
         '-n', '--no-verify',


### PR DESCRIPTION
On MacOS 10.12.6 using iTerm2 and Bash, the condition at https://github.com/jpadilla/pyjwt/blob/master/jwt/__main__.py#L57 appears to always evaluate to `True` regardless of whether the user had passed a JWT on the command line or not. Hence a command such as `pyjwt decode --no-verify json.web.token` (where `json.web.token` is a valid JWT) is not usable.

This change modifies the command-line interface such that the application will only attempt to read from stdin if the input had not been passed.