### PR TITLE
Add support for the OIDC at_hash claim

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -67,6 +67,18 @@ class PyJWS(object):
         """
         return list(self._valid_algs)
 
+    def get_algo_by_name(self, algorithm):
+        try:
+            return self._algorithms[algorithm]
+        except KeyError:
+            if not has_crypto and algorithm in requires_cryptography:
+                raise NotImplementedError(
+                    "Algorithm '%s' could not be found. Do you have cryptography "
+                    "installed?" % algorithm
+                )
+            else:
+                raise NotImplementedError('Algorithm not supported')
+
     def encode(self, payload, key, algorithm='HS256', headers=None,
                json_encoder=None):
         segments = []
@@ -97,19 +109,10 @@ class PyJWS(object):
 
         # Segments
         signing_input = b'.'.join(segments)
-        try:
-            alg_obj = self._algorithms[algorithm]
-            key = alg_obj.prepare_key(key)
-            signature = alg_obj.sign(signing_input, key)
 
-        except KeyError:
-            if not has_crypto and algorithm in requires_cryptography:
-                raise NotImplementedError(
-                    "Algorithm '%s' could not be found. Do you have cryptography "
-                    "installed?" % algorithm
-                )
-            else:
-                raise NotImplementedError('Algorithm not supported')
+        alg_obj = self.get_algo_by_name(algorithm)
+        key = alg_obj.prepare_key(key)
+        signature = alg_obj.sign(signing_input, key)
 
         segments.append(base64url_encode(signature))
 

--- a/jwt/exceptions.py
+++ b/jwt/exceptions.py
@@ -22,6 +22,10 @@ class InvalidIssuedAtError(InvalidTokenError):
     pass
 
 
+class InvalidAccessTokenHashError(InvalidTokenError):
+    pass
+
+
 class ImmatureSignatureError(InvalidTokenError):
     pass
 

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -9,8 +9,8 @@ from decimal import Decimal
 from jwt.api_jwt import PyJWT
 from jwt.exceptions import (
     DecodeError, ExpiredSignatureError, ImmatureSignatureError,
-    InvalidAudienceError, InvalidIssuedAtError, InvalidIssuerError,
-    MissingRequiredClaimError
+    InvalidAccessTokenHashError, InvalidAudienceError, InvalidIssuedAtError,
+    InvalidIssuerError, MissingRequiredClaimError
 )
 
 import pytest
@@ -57,6 +57,14 @@ class TestJWT:
         decoded_payload = jwt.decode(example_jwt, key=example_secret)
 
         assert decoded_payload == example_payload
+
+    def test_verify_fails_missing_athash(self, jwt, payload):
+        secret = 'secret'
+        jwt_message = jwt.encode(payload, secret)
+
+        with pytest.raises(MissingRequiredClaimError) as exc:
+            jwt.decode(jwt_message, key=secret, access_token='foobar')
+        assert 'at_hash' in str(exc.value)
 
     def test_decode_invalid_payload_string(self, jwt):
         example_jwt = (
@@ -117,6 +125,19 @@ class TestJWT:
 
         exception = context.value
         assert str(exception) == 'Invalid claim format in token'
+
+    def test_decode_with_wrong_access_token_throws_exception(self, jwt, payload):
+        secret = 'secret'
+        jwt_message = jwt.encode(payload, secret, access_token='foobar')
+
+        with pytest.raises(InvalidAccessTokenHashError):
+            jwt.decode(jwt_message, key=secret, access_token='foobar2')
+
+    def test_decode_with_no_access_token_skips_at_hash(self, jwt, payload):
+        secret = 'secret'
+        jwt_message = jwt.encode(payload, secret, access_token='foobar')
+
+        jwt.decode(jwt_message, key=secret)
 
     def test_encode_bad_type(self, jwt):
 
@@ -495,3 +516,26 @@ class TestJWT:
             pass
         else:
             assert False, "Unexpected DeprecationWarning raised."
+
+    @pytest.mark.skipif(not has_crypto,
+                        reason="Can't run without cryptography library")
+    def test_at_hashes_match(self, jwt):
+        """
+        Check that HS256 and RS256 at_hash values match.
+        These are different implementations of the at_hash computation, one in
+        terms of hashlib.sha256 and one in terms of cryptography..hashes.SHA256
+
+        They should produce identical values, and both should evaluate
+        successfully.
+
+        Checks
+        - Evaluation works for both methods (doesn't crash)
+        - Evaluation of cryptography hash digests is accurate (use of
+          finalize()). Assumes that the simpler hashlib evaluation is
+          "obviously correct"
+        """
+        # this is just garbage to feed in
+        token = "abc123" * 20
+
+        assert (jwt.compute_at_hash(token, 'HS256') ==
+                jwt.compute_at_hash(token, 'RS256'))


### PR DESCRIPTION
Use PyJWT to compute the at_hash value for OpenID Connect:
http://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken

This makes more sense in PyJWT than its client code because of the tight coupling between the chosen signing algorithm and the computation of the at_hash. Any client code would have to jump through hoops to get this to work nicely based on the algorithm being fed to PyJWT.

Closes #295

Primary changes:

Add support for access_token=... as a param to PyJWT.encode and PyJWT.decode . On encode, the at_hash claim is computed and added to the payload. On decode, unpacks the at_hash value, raising a missing claim error if its missing, and compares it to a freshly computed at_hash. Raises a new error type if they don't match. Does not use the verification options dict, as it's redundant with the caller supplying access_token in this case.

Supporting changes:
- Add tests for the above
- Let PyJWT and PyJWS get an algorithm object from a string as a method
- Add a method, compute_at_hash, to PyJWT objects
- PyJWT._validate_claims now takes the header as an arg (needed to get algo)