### PR TITLE
Currently validate iat only checks for iat type, not the date

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,7 +34,7 @@ Exceptions
 
 .. class:: InvalidIssuedAtError
 
-    Raised when a token's ``iat`` claim is in the future
+    Raised when a token's ``iat`` claim value is not an integer
 
 .. class:: ImmatureSignatureError
 


### PR DESCRIPTION
Here's the code:
```
    def _validate_iat(self, payload, now, leeway):
        try:
            int(payload['iat'])
        except ValueError:
            raise InvalidIssuedAtError('Issued At claim (iat) must be an integer.')
```