### PR TITLE
from_jwk for ecdsa

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -425,8 +425,8 @@ if has_crypto:
             if 'x' not in obj or 'y' not in obj:
                 raise InvalidKeyError('Not an Elliptic curve key')
 
-            x = base64.urlsafe_b64decode(obj.get('x'))
-            y = base64.urlsafe_b64decode(obj.get('y'))
+            x = base64.urlsafe_b64decode(force_bytes(obj.get('x')))
+            y = base64.urlsafe_b64decode(force_bytes(obj.get('y')))
 
             curve = obj.get('crv')
             if curve == 'P-256':
@@ -466,7 +466,7 @@ if has_crypto:
                 #     parameters [0] ECParameters {{ NamedCurve }} OPTIONAL,
                 #     publicKey  [1] BIT STRING OPTIONAL
                 #   }
-                d = base64.urlsafe_b64decode(obj.get('d'))
+                d = base64.urlsafe_b64decode(force_bytes(obj.get('d')))
                 if len(d) != len(x):
                     raise InvalidKeyError(
                         "D should be {} bytes for curve {}", len(x), curve

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -1,3 +1,4 @@
+import base64
 import hashlib
 import hmac
 import json
@@ -14,7 +15,8 @@ from .utils import (
 try:
     from cryptography.hazmat.primitives import hashes
     from cryptography.hazmat.primitives.serialization import (
-        load_pem_private_key, load_pem_public_key, load_ssh_public_key
+        load_pem_private_key, load_pem_public_key, load_ssh_public_key,
+        load_der_public_key, load_der_private_key
     )
     from cryptography.hazmat.primitives.asymmetric.rsa import (
         RSAPrivateKey, RSAPublicKey, RSAPrivateNumbers, RSAPublicNumbers,
@@ -371,6 +373,183 @@ if has_crypto:
                 return True
             except InvalidSignature:
                 return False
+
+        @staticmethod
+        def from_jwk(jwk):
+
+            ASN1_TAG_SEQUENCE = 0b10000
+            ASN1_TAG_OBJECT_IDENTIFIER = 0b110
+            ASN1_TAG_INTEGER = 0b10
+            ASN1_TAG_BITSTRING = 0b11
+            ASN1_TAG_OCTETSTRING = 0b100
+            ASN1_CONTEXT_SPECIFIC = 0b10000000
+            ASN1_CONSTRUCTED = 0b100000
+
+            # ASN.1 Object Identifiers for EC public key and curves
+            ASN1_OID_PUBKEY = b'\x2a\x86\x48\xce\x3d\x02\x01'
+            # 1.2.840.10045.2.1
+            ASN1_OID_CURVE_P256 = b'\x2a\x86\x48\xce\x3d\x03\x01\x07'
+            # 1.2.840.10045.3.1.7
+            ASN1_OID_CURVE_P384 = b'\x2b\x81\x04\x00\x22'
+            # 1.3.132.0.34
+            ASN1_OID_CURVE_P521 = b'\x2b\x81\x04\x00\x23'
+            # 1.3.132.0.35
+
+            def encode_length(length):
+                """Object length is encoded as a single octet for lengths <=
+                127 octets and in max 1 + 127 octets for everything > 127
+                octets."""
+                res = bytearray()
+                if length <= 127:
+                    res.append(length)
+                else:
+                    lengthbytes = bytearray()
+                    while length > 0:
+                        lengthbytes.append(length & 0xFF)
+                        length = length >> 8
+                    if len(lengthbytes) > 127:
+                        raise Exception("Cannot encode objects this long in ASN.1")
+                        # Not sure what to raise here
+                    res.append(0b10000000 | len(lengthbytes))
+                    res.extend(lengthbytes)
+                return bytes(res)
+
+            try:
+                obj = json.loads(jwk)
+            except ValueError:
+                raise InvalidKeyError('Key is not valid JSON')
+
+            if obj.get('kty') != 'EC':
+                raise InvalidKeyError('Not an Elliptic curve key')
+
+            if 'x' not in obj or 'y' not in obj:
+                raise InvalidKeyError('Not an Elliptic curve key')
+
+            x = base64.urlsafe_b64decode(obj.get('x'))
+            y = base64.urlsafe_b64decode(obj.get('y'))
+
+            curve = obj.get('crv')
+            if curve == 'P-256':
+                if len(x) == len(y) == 32:
+                    curve_oid = ASN1_OID_CURVE_P256
+                else:
+                    raise InvalidKeyError("X should be 32 bytes for curve P-256")
+            elif curve == 'P-384':
+                if len(x) == len(y) == 48:
+                    curve_oid = ASN1_OID_CURVE_P384
+                else:
+                    raise InvalidKeyError("X should be 48 bytes for curve P-384")
+            elif curve == 'P-521':
+                if len(x) == len(y) == 66:
+                    curve_oid = ASN1_OID_CURVE_P521
+                else:
+                    raise InvalidKeyError("X should be 66 bytes for curve P-521")
+            else:
+                raise InvalidKeyError("Invalid curve: {}".format(curve))
+
+            ec_point = bytearray()
+            ec_point.append(ASN1_TAG_BITSTRING)
+            ec_point.extend(encode_length(2 + len(x)*2))
+            ec_point.append(0)  # no unused bits
+            ec_point.append(4)  # no compression
+            ec_point.extend(x)
+            ec_point.extend(y)
+
+            if 'd' in obj:
+                # Encode as private key.
+                #
+                # Format (https://tools.ietf.org/html/rfc5915#section-3):
+                #
+                #   ECPrivateKey ::= SEQUENCE {
+                #     version        INTEGER { ecPrivkeyVer1(1) } (ecPrivkeyVer1),
+                #     privateKey     OCTET STRING,
+                #     parameters [0] ECParameters {{ NamedCurve }} OPTIONAL,
+                #     publicKey  [1] BIT STRING OPTIONAL
+                #   }
+                d = base64.urlsafe_b64decode(obj.get('d'))
+                if len(d) != len(x):
+                    raise InvalidKeyError(
+                        "D should be {} bytes for curve {}", len(x), curve
+                    )
+
+                version = bytearray()
+                version.append(ASN1_TAG_INTEGER)
+                version.extend(encode_length(0x01))
+                version.append(1)
+
+                privatekey = bytearray()
+                privatekey.append(ASN1_TAG_OCTETSTRING)
+                privatekey.extend(encode_length(len(d)))
+                privatekey.extend(d)
+
+                parameters = bytearray()
+                parameters.append(ASN1_CONTEXT_SPECIFIC | ASN1_CONSTRUCTED)
+                # context specific, constructed because OPTIONAL [0]
+                parameters.extend(encode_length(len(curve_oid) + 2))
+                parameters.append(ASN1_TAG_OBJECT_IDENTIFIER)
+                parameters.extend(encode_length(len(curve_oid)))
+                parameters.extend(curve_oid)
+
+                publickey = bytearray()
+                publickey.append(ASN1_CONTEXT_SPECIFIC | ASN1_CONSTRUCTED | 1)
+                # context specific, constructed because OPTIONAL [1]
+                publickey.extend(encode_length(len(ec_point)))
+                publickey.extend(ec_point)
+
+                sequence_length = len(version) + len(privatekey) + \
+                                  len(parameters) + len(publickey)
+
+                ec_privatekey = bytearray()
+                ec_privatekey.append(ASN1_CONSTRUCTED | ASN1_TAG_SEQUENCE)
+                ec_privatekey.extend(encode_length(sequence_length))
+                ec_privatekey.extend(version)
+                ec_privatekey.extend(privatekey)
+                ec_privatekey.extend(parameters)
+                ec_privatekey.extend(publickey)
+
+                return load_der_private_key(
+                    bytes(ec_privatekey), None, default_backend()
+                )
+
+            # Encode as public key.
+            #
+            # Format (https://tools.ietf.org/html/rfc5480#section-2):
+            #
+            #   PublicKeyInfo ::= SEQUENCE {
+            #     algorithm       AlgorithmIdentifier,
+            #     PublicKey       BIT STRING
+            #   }
+            #
+            #   AlgorithmIdentifier ::= SEQUENCE {
+            #     algorithm       OBJECT IDENTIFIER,
+            #     parameters      ANY DEFINED BY algorithm OPTIONAL
+            #   }
+            algorithm_identifier = bytearray()
+            algorithm_identifier.append(ASN1_TAG_OBJECT_IDENTIFIER)
+            algorithm_identifier.extend(encode_length(len(ASN1_OID_PUBKEY)))
+            algorithm_identifier.extend(ASN1_OID_PUBKEY)
+            algorithm_identifier.append(ASN1_TAG_OBJECT_IDENTIFIER)
+            algorithm_identifier.extend(encode_length(len(curve_oid)))
+            algorithm_identifier.extend(curve_oid)
+
+            algorithm = bytearray()
+            algorithm.append(ASN1_CONSTRUCTED | ASN1_TAG_SEQUENCE)
+            algorithm.extend(encode_length(len(algorithm_identifier)))
+
+            sequence_length = len(algorithm_identifier) + \
+                              len(algorithm) + len(ec_point)
+
+            publickey_info = bytearray()
+            publickey_info.append(ASN1_CONSTRUCTED | ASN1_TAG_SEQUENCE)
+            publickey_info.extend(encode_length(sequence_length))
+            publickey_info.extend(algorithm)
+            publickey_info.extend(algorithm_identifier)
+            publickey_info.extend(ec_point)
+
+            return load_der_public_key(
+                bytes(publickey_info), default_backend()
+            )
+
 
     class RSAPSSAlgorithm(RSAAlgorithm):
         """

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -407,9 +407,6 @@ if has_crypto:
                     while length > 0:
                         lengthbytes.append(length & 0xFF)
                         length = length >> 8
-                    if len(lengthbytes) > 127:
-                        raise Exception("Cannot encode objects this long in ASN.1")
-                        # Not sure what to raise here
                     res.append(0b10000000 | len(lengthbytes))
                     res.extend(lengthbytes)
                 return bytes(res)
@@ -433,17 +430,17 @@ if has_crypto:
                 if len(x) == len(y) == 32:
                     curve_oid = asn1_oid_curve_p256
                 else:
-                    raise InvalidKeyError("X should be 32 bytes for curve P-256")
+                    raise InvalidKeyError("Coords should be 32 bytes for curve P-256")
             elif curve == 'P-384':
                 if len(x) == len(y) == 48:
                     curve_oid = asn1_oid_curve_p384
                 else:
-                    raise InvalidKeyError("X should be 48 bytes for curve P-384")
+                    raise InvalidKeyError("Coords should be 48 bytes for curve P-384")
             elif curve == 'P-521':
                 if len(x) == len(y) == 66:
                     curve_oid = asn1_oid_curve_p521
                 else:
-                    raise InvalidKeyError("X should be 66 bytes for curve P-521")
+                    raise InvalidKeyError("Coords should be 66 bytes for curve P-521")
             else:
                 raise InvalidKeyError("Invalid curve: {}".format(curve))
 

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -377,22 +377,22 @@ if has_crypto:
         @staticmethod
         def from_jwk(jwk):
 
-            ASN1_TAG_SEQUENCE = 0b10000
-            ASN1_TAG_OBJECT_IDENTIFIER = 0b110
-            ASN1_TAG_INTEGER = 0b10
-            ASN1_TAG_BITSTRING = 0b11
-            ASN1_TAG_OCTETSTRING = 0b100
-            ASN1_CONTEXT_SPECIFIC = 0b10000000
-            ASN1_CONSTRUCTED = 0b100000
+            asn1_tag_sequence = 0b10000
+            asn1_tag_object_identifier = 0b110
+            asn1_tag_integer = 0b10
+            asn1_tag_bitstring = 0b11
+            asn1_tag_octetstring = 0b100
+            asn1_context_specific = 0b10000000
+            asn1_constructed = 0b100000
 
             # ASN.1 Object Identifiers for EC public key and curves
-            ASN1_OID_PUBKEY = b'\x2a\x86\x48\xce\x3d\x02\x01'
+            asn1_oid_pubkey = b'\x2a\x86\x48\xce\x3d\x02\x01'
             # 1.2.840.10045.2.1
-            ASN1_OID_CURVE_P256 = b'\x2a\x86\x48\xce\x3d\x03\x01\x07'
+            asn1_oid_curve_p256 = b'\x2a\x86\x48\xce\x3d\x03\x01\x07'
             # 1.2.840.10045.3.1.7
-            ASN1_OID_CURVE_P384 = b'\x2b\x81\x04\x00\x22'
+            asn1_oid_curve_p384 = b'\x2b\x81\x04\x00\x22'
             # 1.3.132.0.34
-            ASN1_OID_CURVE_P521 = b'\x2b\x81\x04\x00\x23'
+            asn1_oid_curve_p521 = b'\x2b\x81\x04\x00\x23'
             # 1.3.132.0.35
 
             def encode_length(length):
@@ -431,24 +431,24 @@ if has_crypto:
             curve = obj.get('crv')
             if curve == 'P-256':
                 if len(x) == len(y) == 32:
-                    curve_oid = ASN1_OID_CURVE_P256
+                    curve_oid = asn1_oid_curve_p256
                 else:
                     raise InvalidKeyError("X should be 32 bytes for curve P-256")
             elif curve == 'P-384':
                 if len(x) == len(y) == 48:
-                    curve_oid = ASN1_OID_CURVE_P384
+                    curve_oid = asn1_oid_curve_p384
                 else:
                     raise InvalidKeyError("X should be 48 bytes for curve P-384")
             elif curve == 'P-521':
                 if len(x) == len(y) == 66:
-                    curve_oid = ASN1_OID_CURVE_P521
+                    curve_oid = asn1_oid_curve_p521
                 else:
                     raise InvalidKeyError("X should be 66 bytes for curve P-521")
             else:
                 raise InvalidKeyError("Invalid curve: {}".format(curve))
 
             ec_point = bytearray()
-            ec_point.append(ASN1_TAG_BITSTRING)
+            ec_point.append(asn1_tag_bitstring)
             ec_point.extend(encode_length(2 + len(x)*2))
             ec_point.append(0)  # no unused bits
             ec_point.append(4)  # no compression
@@ -473,34 +473,34 @@ if has_crypto:
                     )
 
                 version = bytearray()
-                version.append(ASN1_TAG_INTEGER)
+                version.append(asn1_tag_integer)
                 version.extend(encode_length(0x01))
                 version.append(1)
 
                 privatekey = bytearray()
-                privatekey.append(ASN1_TAG_OCTETSTRING)
+                privatekey.append(asn1_tag_octetstring)
                 privatekey.extend(encode_length(len(d)))
                 privatekey.extend(d)
 
                 parameters = bytearray()
-                parameters.append(ASN1_CONTEXT_SPECIFIC | ASN1_CONSTRUCTED)
+                parameters.append(asn1_context_specific | asn1_constructed)
                 # context specific, constructed because OPTIONAL [0]
                 parameters.extend(encode_length(len(curve_oid) + 2))
-                parameters.append(ASN1_TAG_OBJECT_IDENTIFIER)
+                parameters.append(asn1_tag_object_identifier)
                 parameters.extend(encode_length(len(curve_oid)))
                 parameters.extend(curve_oid)
 
                 publickey = bytearray()
-                publickey.append(ASN1_CONTEXT_SPECIFIC | ASN1_CONSTRUCTED | 1)
+                publickey.append(asn1_context_specific | asn1_constructed | 1)
                 # context specific, constructed because OPTIONAL [1]
                 publickey.extend(encode_length(len(ec_point)))
                 publickey.extend(ec_point)
 
                 sequence_length = len(version) + len(privatekey) + \
-                                  len(parameters) + len(publickey)
+                    len(parameters) + len(publickey)
 
                 ec_privatekey = bytearray()
-                ec_privatekey.append(ASN1_CONSTRUCTED | ASN1_TAG_SEQUENCE)
+                ec_privatekey.append(asn1_constructed | asn1_tag_sequence)
                 ec_privatekey.extend(encode_length(sequence_length))
                 ec_privatekey.extend(version)
                 ec_privatekey.extend(privatekey)
@@ -525,22 +525,22 @@ if has_crypto:
             #     parameters      ANY DEFINED BY algorithm OPTIONAL
             #   }
             algorithm_identifier = bytearray()
-            algorithm_identifier.append(ASN1_TAG_OBJECT_IDENTIFIER)
-            algorithm_identifier.extend(encode_length(len(ASN1_OID_PUBKEY)))
-            algorithm_identifier.extend(ASN1_OID_PUBKEY)
-            algorithm_identifier.append(ASN1_TAG_OBJECT_IDENTIFIER)
+            algorithm_identifier.append(asn1_tag_object_identifier)
+            algorithm_identifier.extend(encode_length(len(asn1_oid_pubkey)))
+            algorithm_identifier.extend(asn1_oid_pubkey)
+            algorithm_identifier.append(asn1_tag_object_identifier)
             algorithm_identifier.extend(encode_length(len(curve_oid)))
             algorithm_identifier.extend(curve_oid)
 
             algorithm = bytearray()
-            algorithm.append(ASN1_CONSTRUCTED | ASN1_TAG_SEQUENCE)
+            algorithm.append(asn1_constructed | asn1_tag_sequence)
             algorithm.extend(encode_length(len(algorithm_identifier)))
 
             sequence_length = len(algorithm_identifier) + \
-                              len(algorithm) + len(ec_point)
+                len(algorithm) + len(ec_point)
 
             publickey_info = bytearray()
-            publickey_info.append(ASN1_CONSTRUCTED | ASN1_TAG_SEQUENCE)
+            publickey_info.append(asn1_constructed | asn1_tag_sequence)
             publickey_info.extend(encode_length(sequence_length))
             publickey_info.extend(algorithm)
             publickey_info.extend(algorithm_identifier)
@@ -549,7 +549,6 @@ if has_crypto:
             return load_der_public_key(
                 bytes(publickey_info), default_backend()
             )
-
 
     class RSAPSSAlgorithm(RSAAlgorithm):
         """

--- a/tests/keys/__init__.py
+++ b/tests/keys/__init__.py
@@ -43,11 +43,11 @@ if has_crypto:
 
         return ec.EllipticCurvePrivateNumbers(
             private_value=decode_value(keyobj['d']),
-            public_numbers=load_ec_pub_key().public_numbers()
+            public_numbers=load_ec_pub_key_P_521().public_numbers()
         )
 
-    def load_ec_pub_key():
-        with open(os.path.join(BASE_PATH, 'jwk_ec_pub.json'), 'r') as infile:
+    def load_ec_pub_key_P_521():
+        with open(os.path.join(BASE_PATH, 'jwk_ec_pub_P-521.json'), 'r') as infile:
             keyobj = json.load(infile)
 
         return ec.EllipticCurvePublicNumbers(

--- a/tests/keys/jwk_ec_key.json
+++ b/tests/keys/jwk_ec_key.json
@@ -1,7 +1,6 @@
 {
      "kty": "EC",
      "kid": "bilbo.baggins@hobbiton.example",
-     "use": "sig",
      "crv": "P-521",
      "x": "AHKZLLOsCOzz5cY97ewNUajB957y-C-U88c3v13nmGZx6sYl_oJXu9A5RkTKqjqvjyekWF-7ytDyRXYgCF5cj0Kt",
      "y": "AdymlHvOiLxXkEhayXQnNCvDX4h9htZaCJN34kfmC6pV5OhQHiraVySsUdaQkAgDPrwQrJmbnX9cwlGfP-HqHZR1",

--- a/tests/keys/jwk_ec_key.json
+++ b/tests/keys/jwk_ec_key.json
@@ -1,8 +1,0 @@
-{
-     "kty": "EC",
-     "kid": "bilbo.baggins@hobbiton.example",
-     "crv": "P-521",
-     "x": "AHKZLLOsCOzz5cY97ewNUajB957y-C-U88c3v13nmGZx6sYl_oJXu9A5RkTKqjqvjyekWF-7ytDyRXYgCF5cj0Kt",
-     "y": "AdymlHvOiLxXkEhayXQnNCvDX4h9htZaCJN34kfmC6pV5OhQHiraVySsUdaQkAgDPrwQrJmbnX9cwlGfP-HqHZR1",
-     "d": "AAhRON2r9cqXX1hg-RoI6R1tX5p2rUAYdmpHZoC1XNM56KtscrX6zbKipQrCW9CGZH3T4ubpnoTKLDYJ_fF3_rJt"
-}

--- a/tests/keys/jwk_ec_key_P-256.json
+++ b/tests/keys/jwk_ec_key_P-256.json
@@ -1,0 +1,8 @@
+{
+  "kty": "EC",
+  "kid": "bilbo.baggins.256@hobbiton.example",
+  "crv": "P-256",
+  "x": "PTTjIY84aLtaZCxLTrG_d8I0G6YKCV7lg8M4xkKfwQ4=",
+  "y": "ank6KA34vv24HZLXlChVs85NEGlpg2sbqNmR_BcgyJU=",
+  "d": "9GJquUJf57a9sev-u8-PoYlIezIPqI_vGpIaiu4zyZk="
+}

--- a/tests/keys/jwk_ec_key_P-384.json
+++ b/tests/keys/jwk_ec_key_P-384.json
@@ -1,0 +1,8 @@
+{
+  "kty": "EC",
+  "kid": "bilbo.baggins.384@hobbiton.example",
+  "crv": "P-384",
+  "x": "IDC-5s6FERlbC4Nc_4JhKW8sd51AhixtMdNUtPxhRFP323QY6cwWeIA3leyZhz-J",
+  "y": "eovmN9ocANS8IJxDAGSuC1FehTq5ZFLJU7XSPg36zHpv4H2byKGEcCBiwT4sFJsy",
+  "d": "xKPj5IXjiHpQpLOgyMGo6lg_DUp738SuXkiugCFMxbGNKTyTprYPfJz42wTOXbtd"
+}

--- a/tests/keys/jwk_ec_key_P-521.json
+++ b/tests/keys/jwk_ec_key_P-521.json
@@ -1,0 +1,8 @@
+{
+  "kty": "EC",
+  "kid": "bilbo.baggins.521@hobbiton.example",
+  "crv": "P-521",
+  "x": "AHKZLLOsCOzz5cY97ewNUajB957y-C-U88c3v13nmGZx6sYl_oJXu9A5RkTKqjqvjyekWF-7ytDyRXYgCF5cj0Kt",
+  "y": "AdymlHvOiLxXkEhayXQnNCvDX4h9htZaCJN34kfmC6pV5OhQHiraVySsUdaQkAgDPrwQrJmbnX9cwlGfP-HqHZR1",
+  "d": "AAhRON2r9cqXX1hg-RoI6R1tX5p2rUAYdmpHZoC1XNM56KtscrX6zbKipQrCW9CGZH3T4ubpnoTKLDYJ_fF3_rJt"
+}

--- a/tests/keys/jwk_ec_pub.json
+++ b/tests/keys/jwk_ec_pub.json
@@ -1,7 +1,0 @@
-{
-     "kty": "EC",
-     "kid": "bilbo.baggins@hobbiton.example",
-     "crv": "P-521",
-     "x": "AHKZLLOsCOzz5cY97ewNUajB957y-C-U88c3v13nmGZx6sYl_oJXu9A5RkTKqjqvjyekWF-7ytDyRXYgCF5cj0Kt",
-     "y": "AdymlHvOiLxXkEhayXQnNCvDX4h9htZaCJN34kfmC6pV5OhQHiraVySsUdaQkAgDPrwQrJmbnX9cwlGfP-HqHZR1"
-}

--- a/tests/keys/jwk_ec_pub.json
+++ b/tests/keys/jwk_ec_pub.json
@@ -1,7 +1,6 @@
 {
      "kty": "EC",
      "kid": "bilbo.baggins@hobbiton.example",
-     "use": "sig",
      "crv": "P-521",
      "x": "AHKZLLOsCOzz5cY97ewNUajB957y-C-U88c3v13nmGZx6sYl_oJXu9A5RkTKqjqvjyekWF-7ytDyRXYgCF5cj0Kt",
      "y": "AdymlHvOiLxXkEhayXQnNCvDX4h9htZaCJN34kfmC6pV5OhQHiraVySsUdaQkAgDPrwQrJmbnX9cwlGfP-HqHZR1"

--- a/tests/keys/jwk_ec_pub_P-256.json
+++ b/tests/keys/jwk_ec_pub_P-256.json
@@ -1,0 +1,7 @@
+{
+  "kty": "EC",
+  "kid": "bilbo.baggins.256@hobbiton.example",
+  "crv": "P-256",
+  "x": "PTTjIY84aLtaZCxLTrG_d8I0G6YKCV7lg8M4xkKfwQ4=",
+  "y": "ank6KA34vv24HZLXlChVs85NEGlpg2sbqNmR_BcgyJU="
+}

--- a/tests/keys/jwk_ec_pub_P-384.json
+++ b/tests/keys/jwk_ec_pub_P-384.json
@@ -1,0 +1,7 @@
+{
+  "kty": "EC",
+  "kid": "bilbo.baggins.384@hobbiton.example",
+  "crv": "P-384",
+  "x": "IDC-5s6FERlbC4Nc_4JhKW8sd51AhixtMdNUtPxhRFP323QY6cwWeIA3leyZhz-J",
+  "y": "eovmN9ocANS8IJxDAGSuC1FehTq5ZFLJU7XSPg36zHpv4H2byKGEcCBiwT4sFJsy"
+}

--- a/tests/keys/jwk_ec_pub_P-521.json
+++ b/tests/keys/jwk_ec_pub_P-521.json
@@ -1,0 +1,7 @@
+{
+  "kty": "EC",
+  "kid": "bilbo.baggins.521@hobbiton.example",
+  "crv": "P-521",
+  "x": "AHKZLLOsCOzz5cY97ewNUajB957y-C-U88c3v13nmGZx6sYl_oJXu9A5RkTKqjqvjyekWF-7ytDyRXYgCF5cj0Kt",
+  "y": "AdymlHvOiLxXkEhayXQnNCvDX4h9htZaCJN34kfmC6pV5OhQHiraVySsUdaQkAgDPrwQrJmbnX9cwlGfP-HqHZR1"
+}

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -12,7 +12,7 @@ from .utils import key_path
 
 try:
     from jwt.algorithms import RSAAlgorithm, ECAlgorithm, RSAPSSAlgorithm
-    from .keys import load_rsa_pub_key, load_ec_pub_key
+    from .keys import load_rsa_pub_key, load_ec_pub_key_P_521
     has_crypto = True
 except ImportError:
     has_crypto = False
@@ -178,20 +178,41 @@ class TestAlgorithms:
 
     @pytest.mark.skipif(not has_crypto, reason='Not supported without cryptography library')
     def test_ec_jwk_public_and_private_keys_should_parse_and_verify(self):
-        algo = ECAlgorithm(ECAlgorithm.SHA512)
+        tests = {
+            'P-256': ECAlgorithm.SHA256,
+            'P-384': ECAlgorithm.SHA384,
+            'P-521': ECAlgorithm.SHA512
+        }
+        for (curve, hash) in tests.items():
+            algo = ECAlgorithm(hash)
 
-        with open(key_path('jwk_ec_pub.json'), 'r') as keyfile:
-            pub_key = algo.from_jwk(keyfile.read())
+            with open(key_path('jwk_ec_pub_{}.json'.format(curve)), 'r') as keyfile:
+                pub_key = algo.from_jwk(keyfile.read())
 
-        with open(key_path('jwk_ec_key.json'), 'r') as keyfile:
-            priv_key = algo.from_jwk(keyfile.read())
+            with open(key_path('jwk_ec_key_{}.json'.format(curve)), 'r') as keyfile:
+                priv_key = algo.from_jwk(keyfile.read())
 
-        signature = algo.sign(force_bytes('Hello World!'), priv_key)
-        assert algo.verify(force_bytes('Hello World!'), pub_key, signature)
+            signature = algo.sign(force_bytes('Hello World!'), priv_key)
+            assert algo.verify(force_bytes('Hello World!'), pub_key, signature)
 
     @pytest.mark.skipif(not has_crypto, reason='Not supported without cryptography library')
     def test_ec_jwk_fails_on_invalid_json(self):
         algo = ECAlgorithm(ECAlgorithm.SHA512)
+
+        valid_points = {
+            'P-256': {
+                'x': 'PTTjIY84aLtaZCxLTrG_d8I0G6YKCV7lg8M4xkKfwQ4=',
+                'y': 'ank6KA34vv24HZLXlChVs85NEGlpg2sbqNmR_BcgyJU='
+            },
+            'P-384': {
+                'x': 'IDC-5s6FERlbC4Nc_4JhKW8sd51AhixtMdNUtPxhRFP323QY6cwWeIA3leyZhz-J',
+                'y': 'eovmN9ocANS8IJxDAGSuC1FehTq5ZFLJU7XSPg36zHpv4H2byKGEcCBiwT4sFJsy'
+            },
+            'P-521': {
+                'x': 'AHKZLLOsCOzz5cY97ewNUajB957y-C-U88c3v13nmGZx6sYl_oJXu9A5RkTKqjqvjyekWF-7ytDyRXYgCF5cj0Kt',
+                'y': 'AdymlHvOiLxXkEhayXQnNCvDX4h9htZaCJN34kfmC6pV5OhQHiraVySsUdaQkAgDPrwQrJmbnX9cwlGfP-HqHZR1'
+            }
+        }
 
         # Invalid JSON
         with pytest.raises(InvalidKeyError):
@@ -199,34 +220,39 @@ class TestAlgorithms:
 
         # Bad key type
         with pytest.raises(InvalidKeyError):
-            algo.from_jwk('{kty: "RSA"}')
+            algo.from_jwk('{"kty": "RSA"}')
 
         # Missing data
         with pytest.raises(InvalidKeyError):
-            algo.from_jwk('{kty: "EC"}')
+            algo.from_jwk('{"kty": "EC"}')
         with pytest.raises(InvalidKeyError):
-            algo.from_jwk('{kty: "EC", x: "1"}')
+            algo.from_jwk('{"kty": "EC", "x": "1"}')
         with pytest.raises(InvalidKeyError):
-            algo.from_jwk('{kty: "EC", y: "1"}')
+            algo.from_jwk('{"kty": "EC", "y": "1"}')
 
         # Missing curve
         with pytest.raises(InvalidKeyError):
-            algo.from_jwk('{kty: "EC", x: "1", y: "2"}')
+            algo.from_jwk('{"kty": "EC", "x": "dGVzdA==", "y": "dGVzdA=="}')
 
         # EC coordinates not equally long
         with pytest.raises(InvalidKeyError):
-            algo.from_jwk('{kty: "EC", x: "1", y: "12", crv: "P-256"}')
+            algo.from_jwk('{"kty": "EC", "x": "dGVzdHRlc3Q=", "y": "dGVzdA=="}')
 
         # EC coordinates length invalid
-        with pytest.raises(InvalidKeyError):
-            algo.from_jwk('{kty: "EC", x: "123", y: "123", crv: "P-256"}')
+        for curve in ('P-256', 'P-384', 'P-521'):
+            with pytest.raises(InvalidKeyError):
+                algo.from_jwk(
+                    '{{"kty": "EC", "crv": "{}", "x": "dGVzdA==", '
+                    '"y": "dGVzdA=="}}'.format(curve)
+                )
 
         # EC private key length invalid
-        with pytest.raises(InvalidKeyError):
-            algo.from_jwk('{kty: "EC", d: "123", '
-                          'x: "12345678901234567890123456789012", '
-                          'y: "12345678901234567890123456789012", '
-                          'crv: "P-256"}')
+        for (curve, point) in valid_points.items():
+            with pytest.raises(InvalidKeyError):
+                algo.from_jwk(
+                    '{{"kty": "EC", "crv": "{}", "x": "{}", "y": "{}", '
+                    '"d": "dGVzdA=="}}'.format(curve, point['x'], point['y'])
+                )
 
     @pytest.mark.skipif(not has_crypto, reason='Not supported without cryptography library')
     def test_rsa_jwk_public_and_private_keys_should_parse_and_verify(self):
@@ -628,7 +654,7 @@ class TestAlgorithmsRFC7520:
         ))
 
         algo = ECAlgorithm(ECAlgorithm.SHA512)
-        key = algo.prepare_key(load_ec_pub_key())
+        key = algo.prepare_key(load_ec_pub_key_P_521())
 
         result = algo.verify(signing_input, key, signature)
         assert result


### PR DESCRIPTION
Hi, here's an implementation of from_jwk for ecdsa keys. It DER encodes the given JWK and loads it with `cryptography.hazmat.primitives.serialization.load_der_*_key`. The patch works and has the basic tests in place. What do you think?

Also see my comment on [issue 144](https://github.com/jpadilla/pyjwt/issues/144#issuecomment-342273648)