### PR TITLE
Add support for checking against multiple issuers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,5 @@ Patches and Suggestions
  - Michael Davis <mike.philip.davis@gmail.com> <mike.davis@workiva.com>
 
  - Vinod Gupta <codervinod@gmail.com>
+
+ - Jason Quense <monastic.panic@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Audience parameter now supports iterables [#205][205]
 
+- Issuer parameter now supports iterables [#308][308]
+
 ### Fixed
 
 ### Added
@@ -205,3 +207,6 @@ rarely used. Users affected by this should upgrade to 3.3+.
 [277]: https://github.com/jpadilla/pyjwt/pull/277
 [281]: https://github.com/jpadilla/pyjwt/pull/281
 [7c1e61d]: https://github.com/jpadilla/pyjwt/commit/7c1e61dde27bafe16e7d1bb6e35199e778962742
+[297]: https://github.com/jpadilla/pyjwt/pull/297
+[205]: https://github.com/jpadilla/pyjwt/pull/205
+[308]: https://github.com/jpadilla/pyjwt/pull/308

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -190,7 +190,10 @@ class PyJWT(PyJWS):
         if 'iss' not in payload:
             raise MissingRequiredClaimError('iss')
 
-        if payload['iss'] != issuer:
+        if isinstance(issuer, string_types):
+            issuer = [issuer]
+
+        if payload['iss'] not in issuer:
             raise InvalidIssuerError('Invalid issuer')
 
 

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -361,6 +361,14 @@ class TestJWT:
         token = jwt.encode(payload, 'secret')
         jwt.decode(token, 'secret', issuer=issuer)
 
+    def test_check_issuer_list_when_valid(self, jwt):
+        payload = {
+            'some': 'payload',
+            'iss': 'urn:me'
+        }
+        token = jwt.encode(payload, 'secret')
+        jwt.decode(token, 'secret', issuer=['urn:you', 'urn:me'])
+
     def test_raise_exception_invalid_issuer(self, jwt):
         issuer = 'urn:wrong'
 
@@ -373,6 +381,15 @@ class TestJWT:
 
         with pytest.raises(InvalidIssuerError):
             jwt.decode(token, 'secret', issuer=issuer)
+
+    def test_raise_exception_invalid_issuer_list(self, jwt):
+        payload = {
+            'some': 'payload',
+            'iss': 'urn:me'
+        }
+        token = jwt.encode(payload, 'secret')
+        with pytest.raises(InvalidIssuerError):
+            jwt.decode(token, 'secret', issuer=['urn:you', 'urn:him'])
 
     def test_skip_check_audience(self, jwt):
         payload = {


### PR DESCRIPTION
👋  hey there. This is a compliment to PR https://github.com/jpadilla/pyjwt/pull/306 it adds support for checking against multiple issuers. Our use-case is to enabling rolling migrations from one auth provider to another, where the audience but also the issuer has changed, without breaking verification for already issued tokens.

cc @yodaiken