### PR TITLE
docs: Add example of encoding and decoding tokens with RSA

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,15 +1,30 @@
 Usage Examples
 ==============
 
-Encoding & Decoding Tokens
+Encoding & Decoding Tokens with HS256
 ---------------------------------
 
 .. code-block:: python
 
     >>import jwt
-    >>encoded = jwt.encode({'some': 'payload'}, 'secret', algorithm='HS256')
+    >>key = 'secret'
+    >>encoded = jwt.encode({'some': 'payload'}, key, algorithm='HS256')
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzb21lIjoicGF5bG9hZCJ9.4twFt5NiznN84AWoo1d7KO1T_yoc0Z6XOpOVswacPZg'
+    >>decoded = jwt.decode(encoded, key, algorithms='HS256')
+    {'some': 'payload'}
 
+Encoding & Decoding Tokens with RS256 (RSA)
+---------------------------------
+
+.. code-block:: python
+
+    >>import jwt
+    >>private_key = b'-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBS...'
+    >>public_key = b'-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEAC...'
+    >>encoded = jwt.encode({'some': 'payload'}, private_key, algorithm='RS256)
+    'eyJhbGciOiJIU...'
+    >>decoded = jwt.decode(encoded, public_key, algorithms='RS256')
+    {'some': 'payload'}
 
 Specifying Additional Headers
 ---------------------------------

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -1,7 +1,6 @@
 import binascii
 import json
 import warnings
-
 from collections import Mapping
 
 from .algorithms import (

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -1,6 +1,5 @@
 import json
 import warnings
-
 from calendar import timegm
 from collections import Mapping
 from datetime import datetime, timedelta

--- a/jwt/contrib/algorithms/pycrypto.py
+++ b/jwt/contrib/algorithms/pycrypto.py
@@ -1,7 +1,6 @@
 import Crypto.Hash.SHA256
 import Crypto.Hash.SHA384
 import Crypto.Hash.SHA512
-
 from Crypto.PublicKey import RSA
 from Crypto.Signature import PKCS1_v1_5
 

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -1,6 +1,5 @@
 
 import json
-
 from decimal import Decimal
 
 from jwt.algorithms import Algorithm

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -1,7 +1,6 @@
 
 import json
 import time
-
 from calendar import timegm
 from datetime import datetime, timedelta
 from decimal import Decimal

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,5 @@
 import os
 import struct
-
 from calendar import timegm
 from datetime import datetime
 


### PR DESCRIPTION
Some users have complained that the docs don't make it very clear that
the private key / public key need to be a byte string. This change makes
that clearer by adding an example to usage.rst.