### PR TITLE
Fix bug if application does not specify audience

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,5 @@ Patches and Suggestions
  - Michael Davis <mike.philip.davis@gmail.com> <mike.davis@workiva.com>
 
  - Vinod Gupta <codervinod@gmail.com>
+ 
+ - Derek Weitzel <djw8605@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Audience parameter throws `InvalidAudienceError` when application does not specify an audience, but the token does. [#336][336]
+
 ### Added
 
 [v1.6.0][1.6.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,3 +224,4 @@ rarely used. Users affected by this should upgrade to 3.3+.
 [315]: https://github.com/jpadilla/pyjwt/pull/315
 [316]: https://github.com/jpadilla/pyjwt/pull/316
 [7c1e61d]: https://github.com/jpadilla/pyjwt/commit/7c1e61dde27bafe16e7d1bb6e35199e778962742
+[336]: https://github.com/jpadilla/pyjwt/pull/336

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -167,7 +167,7 @@ class PyJWT(PyJWS):
             # Application specified an audience, but it could not be
             # verified since the token does not contain a claim.
             raise MissingRequiredClaimError('aud')
-        
+
         if audience is None and 'aud' in payload:
             # Application did not specify an audience, but
             # the token has the 'aud' claim

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -171,7 +171,7 @@ class PyJWT(PyJWS):
         if audience is None and 'aud' in payload:
             # Application did not specify an audience, but
             # the token has the 'aud' claim
-            raise InvalidAudienceError('Audience is specified in the payload, but not the application')
+            raise InvalidAudienceError('Invalid audience')
 
         audience_claims = payload['aud']
 

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -167,6 +167,11 @@ class PyJWT(PyJWS):
             # Application specified an audience, but it could not be
             # verified since the token does not contain a claim.
             raise MissingRequiredClaimError('aud')
+        
+        if audience is None and 'aud' in payload:
+            # Application did not specify an audience, but
+            # the token has the 'aud' claim
+            raise InvalidAudienceError('Audience is specified in the payload, but not the application')
 
         audience_claims = payload['aud']
 

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -288,6 +288,15 @@ class TestJWT:
         token = jwt.encode(payload, 'secret')
         jwt.decode(token, 'secret', audience=['urn:you', 'urn:me'])
 
+    def test_check_audience_none_specified(self, jwt):
+        payload = {
+            'some': 'payload',
+            'aud': 'urn:me'
+        }
+        token = jwt.encode(payload, 'secret')
+        with pytest.raises(InvalidAudienceError):
+            jwt.decode(token, 'secret')
+
     def test_raise_exception_invalid_audience_list(self, jwt):
         payload = {
             'some': 'payload',


### PR DESCRIPTION
If the application does not specify an audience, but the token does, then throw an `InvalidAudienceError`.