### PR TITLE
Update legacy instructions for using pycrypto

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -46,6 +46,9 @@ for RSA with SHA256 and EC with SHA256 signatures.
     from jwt.contrib.algorithms.pycrypto import RSAAlgorithm
     from jwt.contrib.algorithms.py_ecdsa import ECAlgorithm
 
+    jwt.unregister_algorithm('RS256')
+    jwt.unregister_algorithm('ES256')
+    
     jwt.register_algorithm('RS256', RSAAlgorithm(RSAAlgorithm.SHA256))
     jwt.register_algorithm('ES256', ECAlgorithm(ECAlgorithm.SHA256))
 


### PR DESCRIPTION
Related to #181 where users see `ValueError: Algorithm already has a handler.` after trying to register pycrypto algorithms. You must unregister the original handler first.