### PR TITLE
all exceptions inherit from PyJwtError

### DIFF
--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -27,4 +27,5 @@ from .exceptions import (
     InvalidIssuedAtError, InvalidIssuerError, ExpiredSignature,
     InvalidAudience, InvalidIssuer, MissingRequiredClaimError,
     InvalidSignatureError,
+    PyJWTError,
 )

--- a/jwt/exceptions.py
+++ b/jwt/exceptions.py
@@ -1,11 +1,11 @@
-class PyJwtError(Exception):
+class PyJWTError(Exception):
     """
     Base class for all exceptions
     """
     pass
 
 
-class InvalidTokenError(PyJwtError):
+class InvalidTokenError(PyJWTError):
     pass
 
 
@@ -37,7 +37,7 @@ class ImmatureSignatureError(InvalidTokenError):
     pass
 
 
-class InvalidKeyError(PyJwtError):
+class InvalidKeyError(PyJWTError):
     pass
 
 

--- a/jwt/exceptions.py
+++ b/jwt/exceptions.py
@@ -1,4 +1,11 @@
-class InvalidTokenError(Exception):
+class PyJwtError(Exception):
+    """
+    Base class for all exceptions
+    """
+    pass
+
+
+class InvalidTokenError(PyJwtError):
     pass
 
 
@@ -30,7 +37,7 @@ class ImmatureSignatureError(InvalidTokenError):
     pass
 
 
-class InvalidKeyError(Exception):
+class InvalidKeyError(PyJwtError):
     pass
 
 


### PR DESCRIPTION
I was trying to use pyjwt in some (connexion/flask) apps. I wanted to have all the jwt-related errors be converted into something (a `connexion.exceptions.ProblemException`  subclass) which my app could recognize as an auth failure & thus respond with 401. Maybe some of the exceptions should be treated as 5xx (I haven't actually tried to figure out exactly what they all mean yet), but nevermind.

It's not obvious from the API dox or even the code how to catch all the pyjwt exceptions. So I had what turn out to be the two base classes inherit from `PyJwtError` and made a comment explaining the purpose.

If this was my repo, I'd make the comment say "All exceptions _MUST_ inherit from `PyJwtError`" and reject any pr which adds an exception which doesn't, but it's not so that seems kinda impertinent.