### PR TITLE
Fix #351 by reverting argument name changes for .decode()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+[v1.6.4][1.6.4]
+-------------------------------------------------------------------------
+### Fixed
+
+- Reverse an unintentional breaking API change to .decode() [#352][352]
+
 [v1.6.3][1.6.3]
 -------------------------------------------------------------------------
 ### Changed
@@ -205,6 +211,7 @@ rarely used. Users affected by this should upgrade to 3.3+.
 [1.6.0]: https://github.com/jpadilla/pyjwt/compare/1.5.3...1.6.0
 [1.6.1]: https://github.com/jpadilla/pyjwt/compare/1.6.0...1.6.1
 [1.6.3]: https://github.com/jpadilla/pyjwt/compare/1.6.1...1.6.3
+[1.6.4]: https://github.com/jpadilla/pyjwt/compare/1.6.3...1.6.4
 
 [109]: https://github.com/jpadilla/pyjwt/pull/109
 [110]: https://github.com/jpadilla/pyjwt/pull/110
@@ -250,5 +257,6 @@ rarely used. Users affected by this should upgrade to 3.3+.
 [340]: https://github.com/jpadilla/pyjwt/pull/340
 [344]: https://github.com/jpadilla/pyjwt/pull/344
 [350]: https://github.com/jpadilla/pyjwt/pull/350
+[352]: https://github.com/jpadilla/pyjwt/pull/352
 [7c1e61d]: https://github.com/jpadilla/pyjwt/commit/7c1e61dde27bafe16e7d1bb6e35199e778962742
 [7ca41e]: https://github.com/jpadilla/pyjwt/commit/7ca41e53b3d7d9f5cd31bdd8a2b832d192006239

--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -10,7 +10,7 @@ http://self-issued.info/docs/draft-jones-json-web-token-01.html
 
 
 __title__ = 'pyjwt'
-__version__ = '1.6.3'
+__version__ = '1.6.4'
 __author__ = 'José Padilla'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2015-2018 José Padilla'

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -128,7 +128,7 @@ class PyJWS(object):
         return b'.'.join(segments)
 
     def decode(self,
-               token,  # type: str
+               jwt,  # type: str
                key='',   # type: str
                verify=True,  # type: bool
                algorithms=None,  # type: List[str]
@@ -146,7 +146,7 @@ class PyJWS(object):
                 DeprecationWarning
             )
 
-        payload, signing_input, header, signature = self._load(token)
+        payload, signing_input, header, signature = self._load(jwt)
 
         if not verify:
             warnings.warn('The verify parameter is deprecated. '

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -67,7 +67,7 @@ class PyJWT(PyJWS):
         )
 
     def decode(self,
-               token,  # type: str
+               jwt,  # type: str
                key='',   # type: str
                verify=True,  # type: bool
                algorithms=None,  # type: List[str]
@@ -82,7 +82,7 @@ class PyJWT(PyJWS):
                 DeprecationWarning
             )
 
-        payload, _, _, _ = self._load(token)
+        payload, _, _, _ = self._load(jwt)
 
         if options is None:
             options = {'verify_signature': verify}
@@ -90,7 +90,7 @@ class PyJWT(PyJWS):
             options.setdefault('verify_signature', verify)
 
         decoded = super(PyJWT, self).decode(
-            token, key=key, algorithms=algorithms, options=options, **kwargs
+            jwt, key=key, algorithms=algorithms, options=options, **kwargs
         )
 
         try:


### PR DESCRIPTION
@jpadilla Can you give a quick review to this so we can get a new release out to fix this breaking API change?