### PR TITLE
travis cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,20 @@
 language: python
-python:
-  - "3.6"
-addons:
-  apt:
-    sources:
-      - deadsnakes
-    packages:
-      - python3.5 python3.5-dev
-sudo: false
-env:
-  - TOXENV=flake8
-  - TOXENV=py27-crypto
-  - TOXENV=py34-crypto
-  - TOXENV=py35-crypto
-  - TOXENV=py36-crypto
-  - TOXENV=py34-nocrypto
-  - TOXENV=py35-nocrypto
-  - TOXENV=py36-nocrypto
-  - TOXENV=py27-nocrypto
-  - TOXENV=py35-contrib_crypto
-  - TOXENV=py36-contrib_crypto
-  - TOXENV=py27-contrib_crypto
-  
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=flake8,py27-crypto,py27-nocrypto,py27-contrib_crypto
+    - python: 3.4
+      env: TOXENV=flake8,py34-crypto,py34-nocrypto
+    - python: 3.5
+      env: TOXENV=flake8,py35-crypto,py35-nocrypto,py35-contrib_crypto
+    - python: 3.6
+      env: TOXENV=flake8,py36-crypto,py36-nocrypto,py36-contrib_crypto
+before_install:
+  - sudo apt-get install python3-pip # required to install mypy
 install:
   - pip install -U pip
   - pip install -U tox coveralls
-  - pip install -U mypy
+  - sudo python3 -m pip install -U mypy # python3.4+ required to run mypy
 script:
   - tox
   - mypy --ignore-missing-imports jwt


### PR DESCRIPTION
- remove workaround for running tests with python 3.5
- switch to using travis build matrix for testing different python versions, docs [here](https://docs.travis-ci.com/user/customizing-the-build#Build-Matrix)

In [this PR](https://github.com/jpadilla/pyjwt/pull/262) a workaround was added in order to enable CI testing with python 3.6 due to python3.5 not being available in the test environment by default. See comments on the PR for details.

The workaround is no longer needed and can be removed. This code change is intended as cleanup and to facilitate testing with Python 3.7 which is going to be released shortly.