### PR TITLE
Introduce a way to use custom time source for time validation (issue #364)

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -215,3 +215,13 @@ Issued At Claim (iat)
 
     jwt.encode({'iat': 1371720939}, 'secret')
     jwt.encode({'iat': datetime.utcnow()}, 'secret')
+
+Custom UTC Current Time
+-----------------------
+
+    During the verification of `exp`, `nbf` and `iat` that is possible to set a custom UTC current time value
+    instead of using built-in `datetime.datetime.utcnow()`.
+
+    Function to provide custom UTC current time is set through `utcnow` parameter in the options argument.
+
+    if the `utcnow` option is not callable or does not return `datetime.datetime` type, an `TypeError` exception will be raised.

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -123,7 +123,15 @@ class PyJWT(PyJWS):
 
         self._validate_required_claims(payload, options)
 
-        now = timegm(datetime.utcnow().utctimetuple())
+        utcnow_func = options.get('utcnow', datetime.utcnow)
+        if not callable(utcnow_func):
+            raise TypeError('utcnow must be a callable, returning datetime')
+
+        current_utc_time = utcnow_func()
+        if not isinstance(current_utc_time, datetime):
+            raise TypeError('time returned by utcnow must be a datetime')
+
+        now = timegm(current_utc_time.utctimetuple())
 
         if 'iat' in payload and options.get('verify_iat'):
             self._validate_iat(payload, now, leeway)

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -540,11 +540,11 @@ class TestJWT:
     def test_decode_with_non_callable_custom_utcnow_throws_exception(self, jwt, payload):
         token = jwt.encode(payload, 'secret')
 
-        with pytest.raises(TypeError) as context:
+        with pytest.raises(TypeError):
             jwt.decode(token, 'secret', options={'utcnow': datetime.utcnow()})
 
     def test_decode_with_invalid_returning_type_custom_utcnow_throws_exception(self, jwt, payload):
         token = jwt.encode(payload, 'secret')
 
-        with pytest.raises(TypeError) as context:
+        with pytest.raises(TypeError):
             jwt.decode(token, 'secret', options={'utcnow': utc_timestamp})


### PR DESCRIPTION
 `decode()` is extended with an option to use custom UTC current time value to solve #364. Tests are provided.

I decided to use an approach to specify a custom UTC current time's value through using `options` argument; since it looks more organic for the current implementation. Another possible approach could be is passing `utcnow()` function through a setter function like `register_algorithm()`.