### PR TITLE
Fixes example invocations in README.rst and index/docs.rst.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,8 +59,8 @@ Usage::
 
 Decoding examples::
 
-    pyjwt --key=secret TOKEN
-    pyjwt --no-verify TOKEN
+    pyjwt --key=secret decode TOKEN
+    pyjwt decode --no-verify TOKEN
 
 See more options executing ``pyjwt --help``.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,8 +51,8 @@ Usage::
 
 Decoding examples::
 
-    pyjwt --key=secret TOKEN
-    pyjwt --no-verify TOKEN
+    pyjwt --key=secret decode TOKEN
+    pyjwt decode --no-verify TOKEN
 
 See more options executing ``pyjwt --help``.
 


### PR DESCRIPTION
The example invocations for decoding JWT tokens in the README appear to be incorrect. This PR, if applied, will fix the same.