### PR TITLE
Add kid header option to CLI arguments

### DIFF
--- a/jwt/__main__.py
+++ b/jwt/__main__.py
@@ -43,11 +43,19 @@ def encode_payload(args):
 
         payload[k] = v
 
-    token = encode(
-        payload,
-        key=args.key,
-        algorithm=args.algorithm
-    )
+    if args.kid:
+        token = encode(
+            payload,
+            key=args.key,
+            algorithm=args.algorithm,
+            headers={'kid': args.kid}
+        )
+    else:
+        token = encode(
+            payload,
+            key=args.key,
+            algorithm=args.algorithm
+        )
 
     return token.decode('utf-8')
 
@@ -88,6 +96,7 @@ def build_argparser():
 
     %(prog)s --key=secret encode iss=me exp=1302049071
     %(prog)s --key=secret encode foo=bar exp=+10
+    %(prog)s --key=secret encode --kid=mykeyid foo=bar
 
     The exp key is special and can take an offset to current Unix time.
     '''
@@ -131,6 +140,12 @@ def build_argparser():
     payload_help = """Payload to encode. Must be a space separated list of key/value
     pairs separated by equals (=) sign."""
 
+    encode_parser.add_argument(
+        '--kid',
+        dest='kid',
+        metavar='KEYID',
+        default=None,
+        help='set the optional kid header value')
     encode_parser.add_argument('payload', nargs='+', help=payload_help)
     encode_parser.set_defaults(func=encode_payload)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,21 @@ class TestCli:
 
         assert 'Key is required when encoding' in str(excinfo.value)
 
+    def test_encode_kid_header(self):
+        encode_args = ['--key=1234', 'encode', '--kid=0001', 'name=Vader']
+        parser = build_argparser()
+
+        parsed_encode_args = parser.parse_args(encode_args)
+
+        token = encode_payload(parsed_encode_args)
+
+        assert token is not None
+        assert token is not ''
+
+        actual = jwt.get_unverified_header(token)
+
+        assert actual['kid'] == '0001'
+
     def test_decode_payload_raises_decoded_error(self):
         decode_args = ['--key', '1234', 'decode', 'wrong-token']
         parser = build_argparser()


### PR DESCRIPTION
The kid header value is defined by https://tools.ietf.org/html/rfc7515#section-4.1.4. This adds that header value as an encoding argument