### PR TITLE
Enable testing with Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ matrix:
       env: TOXENV=flake8,py35-crypto,py35-nocrypto,py35-contrib_crypto
     - python: 3.6
       env: TOXENV=flake8,py36-crypto,py36-nocrypto,py36-contrib_crypto
+    - python: 3.7
+      env: TOXENV=flake8,py37-crypto,py37-nocrypto,py37-contrib_crypto
+      dist: xenial
 before_install:
   - sudo apt-get install python3-pip # required to install mypy
 install:

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Utilities',
     ],
     test_suite='tests',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}-crypto, py{27,35,36}-contrib_crypto, py{27,35,36}-nocrypto, flake8
+envlist = py{27,34,35,36,37}-crypto, py{27,35,36,37}-contrib_crypto, py{27,35,36,37}-nocrypto, flake8
 
 [testenv]
 commands =


### PR DESCRIPTION
Enable running tests against Python 3.7 in Travis