### PR TITLE
Import collection ABC's from correct module

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -1,7 +1,6 @@
 import binascii
 import json
 import warnings
-from collections import Mapping
 try:
     # import required by mypy to perform type checking, not used for normal execution
     from typing import Callable, Dict, List, Optional, Union # NOQA
@@ -11,7 +10,7 @@ except ImportError:
 from .algorithms import (
     Algorithm, get_default_algorithms, has_crypto, requires_cryptography  # NOQA
 )
-from .compat import binary_type, string_types, text_type
+from .compat import Mapping, binary_type, string_types, text_type
 from .exceptions import (
     DecodeError, InvalidAlgorithmError, InvalidSignatureError,
     InvalidTokenError

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -3,11 +3,6 @@ import warnings
 from calendar import timegm
 from datetime import datetime, timedelta
 try:
-    # Importing ABCs from collections will be removed in PY3.8
-    from collections.abc import Iterable, Mapping
-except ImportError:
-    from collections import Iterable, Mapping
-try:
     # import required by mypy to perform type checking, not used for normal execution
     from typing import Callable, Dict, List, Optional, Union # NOQA
 except ImportError:
@@ -15,7 +10,7 @@ except ImportError:
 
 from .api_jws import PyJWS
 from .algorithms import Algorithm, get_default_algorithms  # NOQA
-from .compat import string_types
+from .compat import Iterable, Mapping, string_types
 from .exceptions import (
     DecodeError, ExpiredSignatureError, ImmatureSignatureError,
     InvalidAudienceError, InvalidIssuedAtError,

--- a/jwt/compat.py
+++ b/jwt/compat.py
@@ -20,6 +20,11 @@ else:
 
 string_types = (text_type, binary_type)
 
+try:
+    # Importing ABCs from collections will be removed in PY3.8
+    from collections.abc import Iterable, Mapping
+except ImportError:
+    from collections import Iterable, Mapping
 
 try:
     constant_time_compare = hmac.compare_digest


### PR DESCRIPTION
The issue and the solution are the same with #375.

```py
from collections import Mapping
```

The above line at `jwt/api_jws.py` would also be expected to import from `collections.abc` on Python 3.7 or later. This PR fix the import.
Move existing compatible imports in `jwt/api_jwt.py` to `jst/compat.py` and reuse it at `jwt/api_jws.py`.
