### PR TITLE
Fix case where payload audience is empty array

### DIFF
--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -175,7 +175,7 @@ class PyJWT(PyJWS):
             raise ExpiredSignatureError('Signature has expired')
 
     def _validate_aud(self, payload, audience):
-        if audience is None and 'aud' not in payload:
+        if audience is None and ('aud' not in payload or not payload['aud']):
             return
 
         if audience is not None and 'aud' not in payload:


### PR DESCRIPTION
This PR fixes the case where an InvalidAudienceError is thrown when the application does not specify an audience but the token contains an audience that is an empty array.  Thanks 😄!