### PR TITLE
fix jwt.encode type annotation(payload parameter)

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -3,7 +3,8 @@ import json
 import warnings
 try:
     # import required by mypy to perform type checking, not used for normal execution
-    from typing import Callable, Dict, List, Optional, Union # NOQA
+    from typing import Any, Callable, Dict, List, Optional, Union # NOQA
+    from typing import Mapping_T  # NOQA
 except ImportError:
     pass
 
@@ -74,7 +75,7 @@ class PyJWS(object):
         return list(self._valid_algs)
 
     def encode(self,
-               payload,  # type: Union[Dict, bytes]
+               payload,  # type: Mapping_T[str, Any]
                key,  # type: str
                algorithm='HS256',  # type: str
                headers=None,  # type: Optional[Dict]

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -3,8 +3,7 @@ import json
 import warnings
 try:
     # import required by mypy to perform type checking, not used for normal execution
-    from typing import Any, Callable, Dict, List, Optional, Union # NOQA
-    from typing import Mapping_T  # NOQA
+    from typing import Callable, Dict, List, Optional, Union # NOQA
 except ImportError:
     pass
 
@@ -75,7 +74,7 @@ class PyJWS(object):
         return list(self._valid_algs)
 
     def encode(self,
-               payload,  # type: Mapping_T[str, Any]
+               payload,  # type: bytes
                key,  # type: str
                algorithm='HS256',  # type: str
                headers=None,  # type: Optional[Dict]

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 try:
     # import required by mypy to perform type checking, not used for normal execution
     from typing import Any, Callable, Dict, List, Optional, Union # NOQA
+    from typing import Mapping as Mapping_T  # NOQA
 except ImportError:
     pass
 
@@ -38,7 +39,7 @@ class PyJWT(PyJWS):
         }
 
     def encode(self,
-               payload,  # type: Union[Dict, bytes]
+               payload,  # type: Mapping_T[str, Any]
                key,  # type: str
                algorithm='HS256',  # type: str
                headers=None,  # type: Optional[Dict]


### PR DESCRIPTION
Using generic version(`Mapping[str, Any]`) of `collections.abc.Mapping` as the `payload`  parameter type in `jwt.encode` method .

And In `jws.encode`, the `payload` parameter type should be `bytes` rather than `Union[Dict, bytes]`. Because in [line#L107](https://github.com/jpadilla/pyjwt/blob/ed28e495f9/jwt/api_jws.py#L107), we call `base64url_encode` and pass the `payload`

```Python
    def encode(self,
               payload,  # type: Union[Dict, bytes]
               key,  # type: str
               algorithm='HS256',  # type: str
               headers=None,  # type: Optional[Dict]
               json_encoder=None  # type: Optional[Callable]
               ):
        segments = []

        if algorithm is None:
            algorithm = 'none'

        if algorithm not in self._valid_algs:
            pass

        # Header
        header = {'typ': self.header_typ, 'alg': algorithm}

        if headers:
            self._validate_headers(headers)
            header.update(headers)

        json_header = force_bytes(
            json.dumps(
                header,
                separators=(',', ':'),
                cls=json_encoder
            )
        )

        segments.append(base64url_encode(json_header))
        segments.append(base64url_encode(payload))
```

`base64url_encode` is defined in utils.py

```
def base64url_encode(input):
    return base64.urlsafe_b64encode(input).replace(b'=', b'')
```

From the [doc](https://docs.python.org/3/library/base64.html#base64.urlsafe_b64encode)

`base64.urlsafe_b64encode`

 > Encode bytes-like object s using the URL- and filesystem-safe alphabet, which substitutes - instead of + and _ instead of / in the standard Base64 alphabet, and return the encoded bytes. The result can still contain =.

So change it to `bytes`.

resolves #394 

