### PR TITLE
Configurable JSON separator

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -78,7 +78,8 @@ class PyJWS(object):
                key,  # type: str
                algorithm='HS256',  # type: str
                headers=None,  # type: Optional[Dict]
-               json_encoder=None  # type: Optional[Callable]
+               json_encoder=None,  # type: Optional[Callable]
+               json_separators=(',', ':')
                ):
         segments = []
 
@@ -98,7 +99,7 @@ class PyJWS(object):
         json_header = force_bytes(
             json.dumps(
                 header,
-                separators=(',', ':'),
+                separators=json_separators,
                 cls=json_encoder
             )
         )

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -42,7 +42,8 @@ class PyJWT(PyJWS):
                key,  # type: str
                algorithm='HS256',  # type: str
                headers=None,  # type: Optional[Dict]
-               json_encoder=None  # type: Optional[Callable]
+               json_encoder=None,  # type: Optional[Callable]
+               json_separators=(',', ':')
                ):
         # Check that we get a mapping
         if not isinstance(payload, Mapping):
@@ -57,12 +58,12 @@ class PyJWT(PyJWS):
 
         json_payload = json.dumps(
             payload,
-            separators=(',', ':'),
+            separators=json_separators,
             cls=json_encoder
         ).encode('utf-8')
 
         return super(PyJWT, self).encode(
-            json_payload, key, algorithm, headers, json_encoder
+            json_payload, key, algorithm, headers, json_encoder, json_separators
         )
 
     def decode(self,

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -11,6 +11,7 @@ from jwt.exceptions import (
     InvalidAudienceError, InvalidIssuedAtError, InvalidIssuerError,
     MissingRequiredClaimError
 )
+from jwt.utils import base64url_decode
 
 import pytest
 
@@ -477,6 +478,14 @@ class TestJWT:
         payload = jwt.decode(token, 'secret')
 
         assert payload == {'some_decimal': 'it worked'}
+
+    def test_custom_json_separator(self, jwt):
+        payload = {'some_string': 'test'}
+        token = jwt.encode(payload, 'secret', json_separators=('y','x'))
+        token_header = base64url_decode(token.split('.')[0])
+        token_payload = base64url_decode(token.split('.')[1])
+        assert token_header == '{"alg"x"HS256"y"typ"x"JWT"}'
+        assert token_payload == '{"some_string"x"test"}'
 
     def test_decode_with_verify_expiration_kwarg(self, jwt, payload):
         payload['exp'] = utc_timestamp() - 1

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -21,3 +21,16 @@ def test_encode_decode():
     decoded_payload = jwt.decode(jwt_message, secret)
 
     assert decoded_payload == payload
+
+
+
+def test_encode_header_only():
+
+    payload = {
+
+    }
+    secret = 'secret'
+    jwt_message = jwt.encode(payload, secret)
+    print(jwt_message)
+
+    #assert decoded_payload == payload


### PR DESCRIPTION
 - make json_separator configurable for encode to support applications that can't verify compressed version of json.