### PR TITLE
Make jwt consistent with different environment(language)

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -15,7 +15,7 @@ from .exceptions import (
     DecodeError, InvalidAlgorithmError, InvalidSignatureError,
     InvalidTokenError
 )
-from .utils import base64url_decode, base64url_encode, force_bytes, merge_dict
+from .utils import base64url_decode, base64url_encode, force_bytes, merge_dict, order_dict
 
 
 class PyJWS(object):
@@ -80,6 +80,7 @@ class PyJWS(object):
                headers=None,  # type: Optional[Dict]
                json_encoder=None  # type: Optional[Callable]
                ):
+        payload = order_dict(payload)
         segments = []
 
         if algorithm is None:
@@ -89,7 +90,7 @@ class PyJWS(object):
             pass
 
         # Header
-        header = {'typ': self.header_typ, 'alg': algorithm}
+        header = order_dict({'typ': self.header_typ, 'alg': algorithm})
 
         if headers:
             self._validate_headers(headers)

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -16,7 +16,7 @@ from .exceptions import (
     InvalidAudienceError, InvalidIssuedAtError,
     InvalidIssuerError, MissingRequiredClaimError
 )
-from .utils import merge_dict
+from .utils import merge_dict, order_dict
 
 
 class PyJWT(PyJWS):
@@ -44,6 +44,9 @@ class PyJWT(PyJWS):
                headers=None,  # type: Optional[Dict]
                json_encoder=None  # type: Optional[Callable]
                ):
+        payload = order_dict(payload)
+        if headers is not None:
+            headers = order_dict(headers)
         # Check that we get a mapping
         if not isinstance(payload, Mapping):
             raise TypeError('Expecting a mapping object, as JWT only supports '

--- a/jwt/utils.py
+++ b/jwt/utils.py
@@ -1,6 +1,7 @@
 import base64
 import binascii
 import struct
+from collections import OrderedDict
 
 from .compat import binary_type, bytes_from_int, text_type
 
@@ -111,3 +112,12 @@ def raw_to_der_signature(raw_sig, curve):
     s = bytes_to_number(raw_sig[num_bytes:])
 
     return encode_dss_signature(r, s)
+
+
+def order_dict(d):
+    if d.__class__ is list:
+        return [order_dict(e) for e in d]
+    elif d.__class__ is dict:
+        return OrderedDict([(k, order_dict(v)) for k, v in sorted(d.items(), key=lambda x: str(x[0]))])
+    else:
+        return d


### PR DESCRIPTION
The dict is inconsistent, some are in hash order, and some are in the order of definition. The inconsistent order of the dict will cause inconsistencies in all aspects of jwt, which is inconvenient to pass in different systems and implementations.

1. add order_dict to confirm dict with agreed order
2. fix problem: the same argument with different result between python2 and python3 (because python2 dict will reorder with hash order)
3. order payload