### PR TITLE
Invoke pytest directly.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,16 +3,14 @@ envlist = py{27,34,35,36,37}-crypto, py{27,35,36,37}-contrib_crypto, py{27,35,36
 
 [testenv]
 commands =
-    python setup.py pytest
+    pytest
 deps =
     crypto: cryptography
     contrib_crypto: pycrypto
     contrib_crypto: ecdsa
+extras = test
 
 [testenv:flake8]
 commands =
     flake8
-deps =
-    flake8
-    flake8-import-order
-    pep8-naming
+extras = flake8


### PR DESCRIPTION
Avoids use of easy_install and interaction between flake8 and tests. Fixes #416.