### PR TITLE
fix pycrypto to fit pycryptodome

### DIFF
--- a/jwt/contrib/algorithms/pycrypto.py
+++ b/jwt/contrib/algorithms/pycrypto.py
@@ -26,7 +26,7 @@ class RSAAlgorithm(Algorithm):
 
     def prepare_key(self, key):
 
-        if isinstance(key, RSA._RSAobj):
+        if hasattr(RSA, '_RSAobj') and isinstance(key, RSA._RSAobj):
             return key
 
         if isinstance(key, string_types):


### PR DESCRIPTION
When I use pyjwt with [PyCryptodome](https://pycryptodome.readthedocs.io/en/latest/index.html), I got an error.

```bash
AttributeError: module 'Crypto.PublicKey.RSA' has no attribute '_RSAobj'

Traceback (most recent call last):
  File "tmp.py", line 19, in <module>
    audience='dj00aiZpPW9MRGxxxxxxxxxxxxxxxxxxxxxxx-',
  File "/foo/bar/venv/lib/python3.6/site-packages/jwt/api_jwt.py", line 92, in decode
    jwt, key=key, algorithms=algorithms, options=options, **kwargs
  File "/foo/bar/venv/lib/python3.6/site-packages/jwt/api_jws.py", line 156, in decode
    key, algorithms)
  File "/foo/bar/venv/lib/python3.6/site-packages/jwt/api_jws.py", line 220, in _verify_signature
    key = alg_obj.prepare_key(key)
  File "/foo/bar/venv/lib/python3.6/site-packages/jwt/contrib/algorithms/pycrypto.py", line 29, in prepare_key
    if isinstance(key, RSA._RSAobj):
```

It because of un compatibility between PyCrypto with PyCryptodome.
So I fixed it.