### PR TITLE
jwt_encode with ES256

### DIFF
--- a/tests/contrib/test_es256.py
+++ b/tests/contrib/test_es256.py
@@ -1,0 +1,11 @@
+import jwt
+
+
+class TestES256:
+    def test_jwt_encode(self):
+        with open('tests/keys/testkey_rsa', 'r') as rsa_priv_file:
+            priv_rsakey = rsa_priv_file.read()
+            jwt_token = jwt.encode({
+                'some': 'field',
+            }, priv_rsakey, algorithm='ES256')
+            assert jwt_token is not None


### PR DESCRIPTION
jwt_encode using `algorithm=ES256` is currently broken, fails with:

```
jwt/api_jwt.py:65: in encode
    json_payload, key, algorithm, headers, json_encoder
jwt/api_jws.py:114: in encode
    signature = alg_obj.sign(signing_input, key)

---

    def sign(self, msg, key):
>       der_sig = key.sign(msg, ec.ECDSA(self.hash_alg()))
E       TypeError: sign() missing 1 required positional argument: 'algorithm'
```

indeed the signature doesn't match, see
https://github.com/pyca/cryptography/blob/ac1d13f43dea5ebee0506dc229cd431660916c73/src/cryptography/hazmat/backends/openssl/rsa.py#L414-L418

This pull request adds a failing test.