### PR TITLE
Correct type for json_encoder argument

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -3,7 +3,7 @@ import json
 import warnings
 try:
     # import required by mypy to perform type checking, not used for normal execution
-    from typing import Callable, Dict, List, Optional, Union # NOQA
+    from typing import Callable, Dict, List, Optional, Type, Union # NOQA
 except ImportError:
     pass
 
@@ -78,7 +78,7 @@ class PyJWS(object):
                key,  # type: str
                algorithm='HS256',  # type: str
                headers=None,  # type: Optional[Dict]
-               json_encoder=None  # type: Optional[Callable]
+               json_encoder=None  # type: Optional[Type[json.JSONEncoder]]
                ):
         segments = []
 

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -4,7 +4,7 @@ from calendar import timegm
 from datetime import datetime, timedelta
 try:
     # import required by mypy to perform type checking, not used for normal execution
-    from typing import Any, Callable, Dict, List, Optional, Union # NOQA
+    from typing import Any, Callable, Dict, List, Optional, Type, Union # NOQA
 except ImportError:
     pass
 
@@ -42,7 +42,7 @@ class PyJWT(PyJWS):
                key,  # type: str
                algorithm='HS256',  # type: str
                headers=None,  # type: Optional[Dict]
-               json_encoder=None  # type: Optional[Callable]
+               json_encoder=None  # type: Optional[Type[json.JSONEncoder]]
                ):
         # Check that we get a mapping
         if not isinstance(payload, Mapping):


### PR DESCRIPTION
Per recent upstream fix to typeshed, json.dumps() cls argument should be
optional type JSONEncoder.

https://github.com/python/typeshed/commit/8e0d288ea49a34f9bd21b1598ec487414a339a1f

Fixes mypy error:

    jwt/api_jws.py:102: error: Argument "cls" to "dumps" has incompatible type "Optional[Callable[..., Any]]"; expected "Optional[Type[JSONEncoder]]"
    jwt/api_jwt.py:61: error: Argument "cls" to "dumps" has incompatible type "Optional[Callable[..., Any]]"; expected "Optional[Type[JSONEncoder]]"