### PR TITLE
Rename [wheel] section to [bdist_wheel] as the former is legacy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ exclude =
     docs/,
     .tox/
 
-[wheel]
+[bdist_wheel]
 universal = 1
 
 [tool:pytest]


### PR DESCRIPTION
Fixes warning when running the `python3 setup.py bdist_wheel` command:

    The [wheel] section is deprecated. Use [bdist_wheel] instead.

For additional details, see:

https://github.com/pypa/wheel/blob/d2f5b43c866295de7b3963da9fd049f1ca4b1194/wheel/bdist_wheel.py#L124-L131

https://pythonwheels.com/