### PR TITLE
Remove setup.py test command in favor of pytest and tox

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,3 @@ universal = 1
 
 [tool:pytest]
 addopts = --cov-report term-missing --cov-config=.coveragerc --cov .
-
-[aliases]
-test = pytest

--- a/setup.py
+++ b/setup.py
@@ -32,15 +32,6 @@ if sys.argv[-1] == 'publish':
     print(' git push --tags')
     sys.exit()
 
-tests_require = [
-    'pytest>=4.0.1,<5.0.0',
-    'pytest-cov>=2.6.0,<3.0.0',
-    'pytest-runner>=4.2,<5.0.0',
-]
-
-needs_pytest = set(('pytest', 'test', 'ptr')).intersection(sys.argv)
-pytest_runner = ['pytest-runner'] if needs_pytest else []
-
 setup(
     name='PyJWT',
     version=version,
@@ -68,11 +59,11 @@ setup(
         'Topic :: Utilities',
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-    test_suite='tests',
-    setup_requires=pytest_runner,
-    tests_require=tests_require,
     extras_require=dict(
-        test=tests_require,
+        test=[
+            'pytest>=4.0.1,<5.0.0',
+            'pytest-cov>=2.6.0,<3.0.0',
+        ],
         crypto=['cryptography >= 1.4'],
         flake8=[
             'flake8',


### PR DESCRIPTION
Using pytest and tox directly is simpler and more conventional then
going through setup.py. Using setup.py installs packages as eggs where
as tox uses the more typical pip.

Overall simplifies setup.py.

Fixes #415