### PR TITLE
Better handle extra algorithms from cryptography

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -241,10 +241,10 @@ class PyJWS(object):
                 raise InvalidSignatureError("Signature verification failed")
 
         except KeyError:
-            if not has_crypto and algorithm in requires_cryptography:
+            if not has_crypto and alg in requires_cryptography:
                 raise InvalidAlgorithmError(
                     "Algorithm '%s' could not be found. Do you have cryptography "
-                    "installed?" % algorithm
+                    "installed?" % alg
                 )
             else:
                 raise InvalidAlgorithmError('Algorithm not supported')

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -117,12 +117,12 @@ class PyJWS(object):
 
         except KeyError:
             if not has_crypto and algorithm in requires_cryptography:
-                raise NotImplementedError(
+                raise InvalidAlgorithmError(
                     "Algorithm '%s' could not be found. Do you have cryptography "
                     "installed?" % algorithm
                 )
             else:
-                raise NotImplementedError("Algorithm not supported")
+                raise InvalidAlgorithmError('Algorithm not supported')
 
         segments.append(base64url_encode(signature))
 
@@ -241,7 +241,13 @@ class PyJWS(object):
                 raise InvalidSignatureError("Signature verification failed")
 
         except KeyError:
-            raise InvalidAlgorithmError("Algorithm not supported")
+            if not has_crypto and algorithm in requires_cryptography:
+                raise InvalidAlgorithmError(
+                    "Algorithm '%s' could not be found. Do you have cryptography "
+                    "installed?" % algorithm
+                )
+            else:
+                raise InvalidAlgorithmError('Algorithm not supported')
 
     def _validate_headers(self, headers):
         if "kid" in headers:

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -167,8 +167,8 @@ class TestJWS:
 
         jws.encode(payload, "secret", algorithm="HS256")
 
-        with pytest.raises(NotImplementedError) as context:
-            jws.encode(payload, None, algorithm="hs256")
+        with pytest.raises(InvalidAlgorithmError) as context:
+            jws.encode(payload, None, algorithm='hs256')
 
         exception = context.value
         assert str(exception) == "Algorithm not supported"
@@ -358,16 +358,16 @@ class TestJWS:
             jws.decode(example_jws, "secret")
 
     def test_invalid_crypto_alg(self, jws, payload):
-        with pytest.raises(NotImplementedError):
-            jws.encode(payload, "secret", algorithm="HS1024")
+        with pytest.raises(InvalidAlgorithmError):
+            jws.encode(payload, 'secret', algorithm='HS1024')
 
     @pytest.mark.skipif(
         has_crypto, reason="Scenario requires cryptography to not be installed"
     )
     def test_missing_crypto_library_better_error_messages(self, jws, payload):
-        with pytest.raises(NotImplementedError) as excinfo:
-            jws.encode(payload, "secret", algorithm="RS256")
-            assert "cryptography" in str(excinfo.value)
+        with pytest.raises(InvalidAlgorithmError) as excinfo:
+            jws.encode(payload, 'secret', algorithm='RS256')
+            assert 'cryptography' in str(excinfo.value)
 
     def test_unicode_secret(self, jws, payload):
         secret = "\xc2"


### PR DESCRIPTION
Two main changes are in this PR:

 - **To use consistent Error type for "algorithm not found/supported" issues.** Currently `NotImplementedError` is used in `encode()` while `InvalidAlgorithmError` is used in `_verify_signature()` (which is invoked by `decode()`). I propose to use `InvalidAlgorithmError` in both locations.

- **Add friendly error message when algorithm is not supported due to `cryptography` missing**. Currently this friendly error message is added for `encode()`, but not added for `_verify_signature()` (which is invoked by `decode()`) (I was caught by this issue and only realized what's happening by checking source code).

**Reference:**
Below is the error I got when I use `RS512`/`ES256` in `decode()` without `cryptography` installed. A more detailed error msg would be useful.

```bash
Traceback (most recent call last):
  File "/Users/xiaodongd/Library/Python/3.5/lib/python/site-packages/jwt/api_jws.py", line 219, in _verify_signature
    alg_obj = self._algorithms[alg]
KeyError: 'ES256'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/xiaodongd/Library/Python/3.5/lib/python/site-packages/flask/app.py", line 2446, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/xiaodongd/Library/Python/3.5/lib/python/site-packages/flask/app.py", line 1951, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/xiaodongd/Library/Python/3.5/lib/python/site-packages/flask/app.py", line 1820, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/xiaodongd/Library/Python/3.5/lib/python/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/Users/xiaodongd/Library/Python/3.5/lib/python/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/xiaodongd/Library/Python/3.5/lib/python/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Users/xiaodongd/Desktop/data-explorer/flaskutils.py", line 47, in _wrapper
    algorithms=['RS512', 'ES256'])
  File "/Users/xiaodongd/Library/Python/3.5/lib/python/site-packages/jwt/api_jwt.py", line 92, in decode
    jwt, key=key, algorithms=algorithms, options=options, **kwargs
  File "/Users/xiaodongd/Library/Python/3.5/lib/python/site-packages/jwt/api_jws.py", line 156, in decode
    key, algorithms)
  File "/Users/xiaodongd/Library/Python/3.5/lib/python/site-packages/jwt/api_jws.py", line 226, in _verify_signature
    raise InvalidAlgorithmError('Algorithm not supported')
jwt.exceptions.InvalidAlgorithmError: Algorithm not supported

```

