### PR TITLE
Don't accept decode(..., algorithm=...)

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -132,7 +132,7 @@ class PyJWS(object):
                verify=True,  # type: bool
                algorithms=None,  # type: List[str]
                options=None,  # type: Dict
-               **kwargs):
+               ):
 
         merged_options = merge_dict(self.options, options)
         verify_signature = merged_options['verify_signature']

--- a/jwt/help.py
+++ b/jwt/help.py
@@ -9,7 +9,7 @@ from . import __version__ as pyjwt_version
 try:
     import cryptography
 except ImportError:
-    cryptography = None
+    cryptography = None  # type: ignore # https://github.com/python/mypy/issues/1297
 
 try:
     import ecdsa


### PR DESCRIPTION
The `api_jws.decode()` function was accepting **kwargs but not using it. From my point of view, it's a lie: you can call `decode` with a typo in a parameter without any warning.

The bad thing is one could do:

    jwt.decode(token, pub_key, algorithm="ES256")

without noticing the `algorithm` is ignored, thus opening a vulnerabiliy.

By not accepting the **kwargs, we're enforing all parameters are "eaten" by the previous class, leading to a nice explicit:

    TypeError: decode() got an unexpected keyword argument 'algorithm'

error being raised.

Tried to run tox but I was having:

    jwt/help.py:12: error: Incompatible types in assignment (expression has type "None", variable has type Module)

before my patch, so it looks like my patch introduced no new errors.

I had to move `**kwargs` out of `_validate_claims`, it should not really change its signature, except that know it does no longer accept verify_expiration directly (but as it's a "private" method, I think it's OK).

I also had to move kwargs poping before calling `super().decode(`, so it won't get unexpected parameters.