### PR TITLE
Catch BadSignatureError raised by ecdsa 0.13.3 on verification errors

### DIFF
--- a/jwt/contrib/algorithms/py_ecdsa.py
+++ b/jwt/contrib/algorithms/py_ecdsa.py
@@ -56,5 +56,7 @@ class ECAlgorithm(Algorithm):
         try:
             return key.verify(sig, msg, hashfunc=self.hash_alg,
                               sigdecode=ecdsa.util.sigdecode_string)
-        except AssertionError:
+        # ecdsa <= 0.13.2 raises AssertionError on too long signatures,
+        # ecdsa >= 0.13.3 raises BadSignatureError for verification errors.
+        except (AssertionError, ecdsa.BadSignatureError):
             return False


### PR DESCRIPTION
The new ecdsa no longer uses AssertionError when the signature is too long.
This happens in the test suite, where "123" is appended to the signature.

Fixes #447