### PR TITLE
Fix mypy errors

### DIFF
--- a/jwt/help.py
+++ b/jwt/help.py
@@ -7,14 +7,14 @@ import sys
 from . import __version__ as pyjwt_version
 
 try:
-    import cryptography
+    import cryptography  # type: ignore
 except ImportError:
-    cryptography = None
+    cryptography = None  # type: ignore
 
 try:
-    import ecdsa
+    import ecdsa  # type: ignore
 except ImportError:
-    ecdsa = None
+    ecdsa = None  # type: ignore
 
 
 def info():


### PR DESCRIPTION
```
mypy create: /home/travis/build/jpadilla/pyjwt/.tox/mypy
mypy inst: /home/travis/build/jpadilla/pyjwt/.tox/.tmp/package/1/PyJWT-1.7.1.zip
mypy installed: mypy==0.740,mypy-extensions==0.4.3,PyJWT==1.7.1,typed-ast==1.4.0,typing-extensions==3.7.4
mypy run-test-pre: PYTHONHASHSEED='2425519668'
mypy run-test: commands[0] | mypy --ignore-missing-imports jwt
jwt/help.py:12: error: Incompatible types in assignment (expression has type "None", variable has type Module)
Found 1 error in 1 file (checked 13 source files)
ERROR: InvocationError for command /home/travis/build/jpadilla/pyjwt/.tox/mypy/bin/mypy --ignore-missing-imports jwt (exited with code 1)
```