### PR TITLE
Improve requiring claims

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: python
 matrix:
   include:
     - python: 3.5
-      env: TOXENV=py35-crypto,py35-nocrypto,py35-contrib_crypto
+      env: TOXENV=py35-crypto,py35-nocrypto,py35-contrib_crypto,py35-contrib_cryptodome
     - python: 3.6
-      env: TOXENV=py36-crypto,py36-nocrypto,py36-contrib_crypto
+      env: TOXENV=py36-crypto,py36-nocrypto,py36-contrib_crypto,py36-contrib_cryptodome
     - python: 3.7
-      env: TOXENV=lint,typing,py37-crypto,py37-nocrypto,py37-contrib_crypto
+      env: TOXENV=lint,typing,py37-crypto,py37-nocrypto,py37-contrib_crypto,py37-contrib_cryptodome
 install:
   - pip install -U pip
   - pip install -U tox coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ matrix:
     - python: 3.6
       env: TOXENV=py36-crypto,py36-nocrypto,py36-contrib_crypto,py36-contrib_cryptodome
     - python: 3.7
-      env: TOXENV=lint,typing,py37-crypto,py37-nocrypto,py37-contrib_crypto,py37-contrib_cryptodome
+      env: TOXENV=py37-crypto,py37-nocrypto,py37-contrib_crypto,py37-contrib_cryptodome
+    - python: 3.8
+      env: TOXENV=lint,typing,py38-crypto,py38-nocrypto,py38-contrib_cryptodome
 install:
   - pip install -U pip
   - pip install -U tox coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-crypto,py37-nocrypto,py37-contrib_crypto,py37-contrib_cryptodome
     - python: 3.8
-      env: TOXENV=lint,typing,py38-crypto,py38-nocrypto,py38-contrib_cryptodome
+      env: TOXENV=docs,lint,typing,py38-crypto,py38-nocrypto,py38-contrib_cryptodome
 install:
   - pip install -U pip
   - pip install -U tox coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - Document (and prefer) pyjwt[crypto] req format #426
 - Set headers when encoding via command line #406
+- Requiring arbitrary claim names with the ``require_`` options
 
 [v1.7.1][1.7.1]
 -------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Prefer https:// links where available #439
 - Fix mypy errors #449
 - Fix simple typo: encododed -> encoded #462
+- Correct test instructions in README
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Fix mypy errors #449
 - Fix simple typo: encododed -> encoded #462
 - Correct test instructions in README
+- Fix algorithm tests
 
 ### Added
 

--- a/README.rst
+++ b/README.rst
@@ -78,4 +78,5 @@ You can run tests from the project root after cloning with:
 
 .. code-block:: sh
 
-    $ python setup.py test
+    $ pip install -e '.[dev]'
+    $ py.test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,9 @@ environment:
     - PYTHON: "C:\\Python37-x64"
       TOX_ENV: "py37-crypto"
 
+    - PYTHON: "C:\\Python38-x64"
+      TOX_ENV: "py38-crypto"
+
 init:
   - SET PATH=%PYTHON%;%PATH%
   - python -c "import sys;sys.stdout.write(sys.version)"

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -215,3 +215,24 @@ Issued At Claim (iat)
 
     jwt.encode({'iat': 1371720939}, 'secret')
     jwt.encode({'iat': datetime.utcnow()}, 'secret')
+
+Requiring Arbitrary Claims
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``decode`` function requires claims by including a Boolean value with the
+claim name prefixed with ``require_`` in the options parameter.  None of the
+supported claim names are required by default.
+
+.. code-block:: pycon
+
+    >>> token = jwt.encode({'aud': 'me', 'sub': 'you'}, 'secret')
+    >>> jwt.decode(token, 'secret', audience='me', options={'require_foo': True})
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File "/.../pyjwt/jwt/api_jwt.py", line 115, in decode
+        self._validate_claims(payload, merged_options, **kwargs)
+      File "/.../pyjwt/jwt/api_jwt.py", line 137, in _validate_claims
+        self._validate_required_claims(payload, options)
+      File "/.../pyjwt/jwt/api_jwt.py", line 164, in _validate_required_claims
+        raise MissingRequiredClaimError(claim_name)
+    jwt.exceptions.MissingRequiredClaimError: Token is missing the "foo" claim

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,7 +2,7 @@ Usage Examples
 ==============
 
 Encoding & Decoding Tokens with HS256
----------------------------------
+-------------------------------------
 
 .. code-block:: python
 
@@ -14,7 +14,7 @@ Encoding & Decoding Tokens with HS256
     {'some': 'payload'}
 
 Encoding & Decoding Tokens with RS256 (RSA)
----------------------------------
+-------------------------------------------
 
 .. code-block:: python
 
@@ -27,7 +27,7 @@ Encoding & Decoding Tokens with RS256 (RSA)
     {'some': 'payload'}
 
 Specifying Additional Headers
----------------------------------
+-----------------------------
 
 .. code-block:: python
 
@@ -36,7 +36,7 @@ Specifying Additional Headers
 
 
 Reading the Claimset without Validation
------------------------------------------
+---------------------------------------
 
 If you wish to read the claimset of a JWT without performing validation of the
 signature or any of the registered claim names, you can set the ``verify``

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -154,14 +154,14 @@ class PyJWT(PyJWS):
             self._validate_aud(payload, audience)
 
     def _validate_required_claims(self, payload, options):
-        if options.get("require_exp") and payload.get("exp") is None:
-            raise MissingRequiredClaimError("exp")
-
-        if options.get("require_iat") and payload.get("iat") is None:
-            raise MissingRequiredClaimError("iat")
-
-        if options.get("require_nbf") and payload.get("nbf") is None:
-            raise MissingRequiredClaimError("nbf")
+        required_claims = (
+            claim_name[8:]
+            for claim_name, is_required in options.items()
+            if claim_name.startswith("require_") and is_required
+        )
+        for claim_name in required_claims:
+            if payload.get(claim_name) is None:
+                raise MissingRequiredClaimError(claim_name)
 
     def _validate_iat(self, payload, now, leeway):
         try:

--- a/jwt/contrib/algorithms/pycrypto.py
+++ b/jwt/contrib/algorithms/pycrypto.py
@@ -7,6 +7,11 @@ from Crypto.Signature import PKCS1_v1_5
 from jwt.algorithms import Algorithm
 from jwt.compat import string_types, text_type
 
+try:
+    RsaKey = RSA._RSAobj  # type: ignore
+except AttributeError:
+    RsaKey = RSA.RsaKey  # type: ignore
+
 
 class RSAAlgorithm(Algorithm):
     """
@@ -27,7 +32,7 @@ class RSAAlgorithm(Algorithm):
 
     def prepare_key(self, key):
 
-        if isinstance(key, RSA._RSAobj):
+        if isinstance(key, RsaKey):
             return key
 
         if isinstance(key, string_types):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,9 @@ EXTRAS_REQUIRE = {
 }
 
 EXTRAS_REQUIRE["dev"] = (
-    EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["crypto"] + ["mypy", "pre-commit"]
+    EXTRAS_REQUIRE["tests"]
+    + EXTRAS_REQUIRE["crypto"]
+    + ["ecdsa", "mypy", "pre-commit", "pycryptodome", "tox"]
 )
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Utilities",
     ],
     python_requires=">=3, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    docs
     lint
     typing
     py{35,36,37,38}-crypto
@@ -28,3 +29,8 @@ commands = mypy --ignore-missing-imports jwt
 extras = dev
 passenv = HOMEPATH  # needed on Windows
 commands = pre-commit run --all-files
+
+[testenv:docs]
+deps =
+    -r docs/requirements-docs.txt
+commands = ./setup.py build_sphinx --all-files --fresh-env

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 envlist =
     lint
     typing
-    py{35,36,37}-crypto
+    py{35,36,37,38}-crypto
     py{35,36,37}-contrib_crypto
-    py{35,36,37}-contrib_cryptodome
-    py{35,36,37}-nocrypto
+    py{35,36,37,38}-contrib_cryptodome
+    py{35,36,37,38}-nocrypto
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     typing
     py{35,36,37}-crypto
     py{35,36,37}-contrib_crypto
+    py{35,36,37}-contrib_cryptodome
     py{35,36,37}-nocrypto
 
 
@@ -14,6 +15,8 @@ deps =
     crypto: cryptography
     contrib_crypto: pycrypto
     contrib_crypto: ecdsa
+    contrib_cryptodome: pycryptodome
+    contrib_cryptodome: ecdsa
 
 
 [testenv:typing]

--- a/tox.ini
+++ b/tox.ini
@@ -33,4 +33,4 @@ commands = pre-commit run --all-files
 [testenv:docs]
 deps =
     -r docs/requirements-docs.txt
-commands = ./setup.py build_sphinx --all-files --fresh-env
+commands = ./setup.py build_sphinx --all-files --fresh-env --warning-is-error --nitpicky


### PR DESCRIPTION
Thanks for implementing and maintaining this library!  This PR changes the processing of required claims so that arbitrary claims may be required by name.  I needed to require that the issuer claim was present without requiring a specific value.  There wasn't a easy way to do this, so I figured that I would add one.

I converted the required claim processing to look at any option starting with `require_` and require that a claim named by the suffix is present in the payload.  Hopefully that explanation makes some sense.  If not, the code is pretty simple.

I also took a stab at fixing the testing against Pycryptodome.  I can remove the test related commits if necessary.