### PR TITLE
#468 | Added support of lists

### DIFF
--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -112,7 +112,7 @@ class PyJWT(PyJWS):
             payload = json.loads(decoded.decode("utf-8"))
         except ValueError as e:
             raise DecodeError("Invalid payload string: %s" % e)
-        if not isinstance(payload, dict):
+        if not isinstance(payload, dict) and not isinstance(payload, list):
             raise DecodeError("Invalid payload string: must be a json object")
 
         if verify:

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -51,7 +51,7 @@ class PyJWT(PyJWS):
         json_encoder=None,  # type: Optional[Type[json.JSONEncoder]]
     ):
         # Check that we get a mapping
-        if not isinstance(payload, Mapping):
+        if not isinstance(payload, Mapping) and not isinstance(payload, list):
             raise TypeError(
                 "Expecting a mapping object, as JWT only supports "
                 "JSON objects as payloads."
@@ -59,8 +59,13 @@ class PyJWT(PyJWS):
 
         # Payload
         for time_claim in ["exp", "iat", "nbf"]:
+            try:
+                payload_time_claim = payload[time_claim]
+            except:
+                payload_time_claim = None
+
             # Convert datetime to a intDate value in known time-format claims
-            if isinstance(payload.get(time_claim), datetime):
+            if isinstance(payload_time_claim, datetime):
                 payload[time_claim] = timegm(
                     payload[time_claim].utctimetuple()
                 )  # type: ignore

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -44,7 +44,7 @@ class PyJWT(PyJWS):
 
     def encode(
         self,
-        payload,  # type: Union[Dict, bytes]
+        payload,  # type: Union[list, Dict, bytes]
         key,  # type: str
         algorithm="HS256",  # type: str
         headers=None,  # type: Optional[Dict]

--- a/jwt/compat.py
+++ b/jwt/compat.py
@@ -7,7 +7,7 @@ import hmac
 
 text_type = str
 binary_type = bytes
-string_types = (str, bytes)
+string_types = (str, bytes, list)
 
 try:
     # Importing ABCs from collections will be removed in PY3.8

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -131,7 +131,7 @@ class TestJWT:
 
     def test_encode_bad_type(self, jwt):
 
-        types = ["string", tuple(), list(), 42, set()]
+        types = ["string", tuple(), 42, set()]
 
         for t in types:
             pytest.raises(TypeError, lambda: jwt.encode(t, "secret"))


### PR DESCRIPTION
As in #468 was mentioned, list is valid JSON object (empty or non empty)
So I added support of lists.
- Edited encode and decode function
- Removed lists from test as bad type

Result - 
```
>>> import jwt
>>> 
>>> encoded = jwt.encode([], 'secret', algorithm='HS256')
>>> jwt.decode(encoded, 'secret', algorithms=['HS256'])
[]

>>> encoded = jwt.encode(["some", "ranom", "list", "values"], 'secret', algorithm='HS256')
>>> jwt.decode(encoded, 'secret', algorithms=['HS256'])
['some', 'ranom', 'list', 'values']
```
