### PR TITLE
Only parse jwk data as json when passing in a string

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -121,14 +121,14 @@ class Algorithm(object):
     @staticmethod
     def to_jwk(key_obj):
         """
-        Serializes a given RSA key into a JWK
+        Serializes a given key into a JWK
         """
         raise NotImplementedError
 
     @staticmethod
     def from_jwk(jwk):
         """
-        Deserializes a given RSA key from JWK back into a PublicKey or PrivateKey object
+        Deserializes a given key from JWK back into a PublicKey or PrivateKey object
         """
         raise NotImplementedError
 
@@ -197,7 +197,13 @@ class HMACAlgorithm(Algorithm):
 
     @staticmethod
     def from_jwk(jwk):
-        obj = json.loads(jwk)
+        if isinstance(jwk, string_types):
+            try:
+                obj = json.loads(jwk)
+            except ValueError:
+                raise InvalidKeyError("Key is not valid JSON")
+        else:
+            obj = jwk
 
         if obj.get("kty") != "oct":
             raise InvalidKeyError("Not an HMAC key")
@@ -291,10 +297,13 @@ if has_crypto:  # noqa: C901
 
         @staticmethod
         def from_jwk(jwk):
-            try:
-                obj = json.loads(jwk)
-            except ValueError:
-                raise InvalidKeyError("Key is not valid JSON")
+            if isinstance(jwk, string_types):
+                try:
+                    obj = json.loads(jwk)
+                except ValueError:
+                    raise InvalidKeyError("Key is not valid JSON")
+            else:
+                obj = jwk
 
             if obj.get("kty") != "RSA":
                 raise InvalidKeyError("Not an RSA key")

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -417,6 +417,17 @@ class TestAlgorithms:
     @pytest.mark.skipif(
         not has_crypto, reason="Not supported without cryptography library"
     )
+    def test_rsa_from_jwk_skips_json_if_not_given_string(self):
+        algo = RSAAlgorithm(RSAAlgorithm.SHA256)
+
+        with open(key_path("jwk_rsa_pub.json"), "r") as keyfile:
+            data = json.loads(keyfile.read())
+            result = algo.from_jwk(data)
+            assert result
+
+    @pytest.mark.skipif(
+        not has_crypto, reason="Not supported without cryptography library"
+    )
     def test_ec_should_reject_non_string_key(self):
         algo = ECAlgorithm(ECAlgorithm.SHA256)
 


### PR DESCRIPTION
This allows a user to request the `/.well-known/jwks.json` file from a server, parse it, look up the appropriate key, and load it without having to dump the key to json again.

I realize this will be superseded by version 2.0 as that introduces better support for JWKs in general, but this fixes the given use case for us until that releases.