### PR TITLE
Improve documentation for audience usage

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -211,6 +211,19 @@ a single case-sensitive string containing a StringOrURI value.
     token = jwt.encode(payload, 'secret')
     decoded = jwt.decode(token, 'secret', audience='urn:foo', algorithms=['HS256'])
 
+If multiple audiences are accepted, the ``audience`` parameter for
+``jwt.decode`` can also be an iterable
+
+.. code-block:: python
+
+    payload = {
+        'some': 'payload',
+        'aud': 'urn:foo'
+    }
+
+    token = jwt.encode(payload, 'secret')
+    decoded = jwt.decode(token, 'secret', audience=['urn:foo', 'urn:bar'], algorithms=['HS256'])
+
 The interpretation of audience values is generally application specific.
 Use of this claim is OPTIONAL.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -183,12 +183,23 @@ Audience Claim (aud)
     identify itself with a value in the audience claim.  If the principal
     processing the claim does not identify itself with a value in the
     "aud" claim when this claim is present, then the JWT MUST be
-    rejected.  In the general case, the "aud" value is an array of case-
-    sensitive strings, each containing a StringOrURI value.  In the
-    special case when the JWT has one audience, the "aud" value MAY be a
-    single case-sensitive string containing a StringOrURI value.  The
-    interpretation of audience values is generally application specific.
-    Use of this claim is OPTIONAL.
+    rejected.
+
+In the general case, the "aud" value is an array of case-
+sensitive strings, each containing a StringOrURI value.
+
+.. code-block:: python
+
+    payload = {
+        'some': 'payload',
+        'aud': ['urn:foo', 'urn:bar']
+    }
+
+    token = jwt.encode(payload, 'secret')
+    decoded = jwt.decode(token, 'secret', audience='urn:foo', algorithms=['HS256'])
+
+In the special case when the JWT has one audience, the "aud" value MAY be
+a single case-sensitive string containing a StringOrURI value.
 
 .. code-block:: python
 
@@ -199,6 +210,9 @@ Audience Claim (aud)
 
     token = jwt.encode(payload, 'secret')
     decoded = jwt.decode(token, 'secret', audience='urn:foo', algorithms=['HS256'])
+
+The interpretation of audience values is generally application specific.
+Use of this claim is OPTIONAL.
 
 If the audience claim is incorrect, `jwt.InvalidAudienceError` will be raised.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,7 +2,7 @@ Usage Examples
 ==============
 
 Encoding & Decoding Tokens with HS256
----------------------------------
+--------------------------------------
 
 .. code-block:: python
 
@@ -14,7 +14,7 @@ Encoding & Decoding Tokens with HS256
     {'some': 'payload'}
 
 Encoding & Decoding Tokens with RS256 (RSA)
----------------------------------
+-------------------------------------------
 
 .. code-block:: python
 


### PR DESCRIPTION
Hello `pyjwt` maintainers,

I've recently been using the `pyjwt` codebase to decode JWT tokens originating from [Keycloak](https://www.keycloak.org/) servers, where the JWT `aud` claim is an array by default, and I'm dealing with a `python` `API` server that supports multiple `audiences`.

The edits I've made in this PR hope to improve the documentation for users who are not as familiar with the specific details surrounding the `audience` claim, like I was until I started digging into using `pyjwt` more.

#### ddc1dc1

Makes an explicit code block example for the `aud` claim being an `array`. It was mentioned in the text, but I think making a code block demonstrating it helps make it more clear.

#### 46d1940

Adds an example of the `audience` param for `jwt.decode` supporting an iterable argument, as implemented in https://github.com/jpadilla/pyjwt/pull/306.

Note that I'm not stuck to the placement of this example, but I was unsuccessful at locating documentation specific to the `jwt.decode` implementation

#### f01df86

Is a simple `.rst` formatting change where the linter I was using was throwing a warning:

![image](https://user-images.githubusercontent.com/16601729/80239559-4ea39500-8615-11ea-9dc9-8b3cc74f1f84.png)

