### PR TITLE
Correct README on how to run tests locally

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,4 +78,4 @@ You can run tests from the project root after cloning with:
 
 .. code-block:: sh
 
-    $ python setup.py test
+    $ tox


### PR DESCRIPTION
The command `setup.py test` has been unused since
3a20892442b34c754b26550e05f7f856fb008c94.