### PR TITLE
Run pyupgrade across project to use modern Python 3 conventions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # PyJWT documentation build configuration file, created by
 # sphinx-quickstart on Thu Oct 22 18:11:10 2015.
 #
@@ -51,9 +49,9 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"PyJWT"
-copyright = u"2015, José Padilla"
-author = u"José Padilla"
+project = "PyJWT"
+copyright = "2015, José Padilla"
+author = "José Padilla"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -244,8 +242,8 @@ latex_documents = [
     (
         master_doc,
         "PyJWT.tex",
-        u"PyJWT Documentation",
-        u"José Padilla",
+        "PyJWT Documentation",
+        "José Padilla",
         "manual",
     )
 ]
@@ -275,7 +273,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "pyjwt", u"PyJWT Documentation", [author], 1)]
+man_pages = [(master_doc, "pyjwt", "PyJWT Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -290,7 +288,7 @@ texinfo_documents = [
     (
         master_doc,
         "PyJWT",
-        u"PyJWT Documentation",
+        "PyJWT Documentation",
         author,
         "PyJWT",
         "One line description of project.",

--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # flake8: noqa
 
 """

--- a/jwt/__main__.py
+++ b/jwt/__main__.py
@@ -68,7 +68,7 @@ def decode_payload(args):
             if sys.stdin.isatty():
                 token = sys.stdin.readline().strip()
             else:
-                raise IOError("Cannot read from stdin: terminal not a TTY")
+                raise OSError("Cannot read from stdin: terminal not a TTY")
 
         token = token.encode("utf-8")
         data = decode(token, key=args.key, verify=args.verify)

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -45,8 +45,7 @@ except ImportError:
     has_crypto = False
     has_ed25519 = False
 
-requires_cryptography = set(
-    [
+requires_cryptography = {
         "RS256",
         "RS384",
         "RS512",
@@ -58,8 +57,7 @@ requires_cryptography = set(
         "PS384",
         "PS512",
         "EdDSA",
-    ]
-)
+}
 
 
 def get_default_algorithms():
@@ -104,7 +102,7 @@ def get_default_algorithms():
     return default_algorithms
 
 
-class Algorithm(object):
+class Algorithm:
     """
     The interface for an algorithm used to sign and verify tokens.
     """

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -20,7 +20,7 @@ except ImportError:
     pass
 
 
-class PyJWS(object):
+class PyJWS:
     header_typ = "JWT"
 
     def __init__(self, algorithms=None, options=None):
@@ -182,7 +182,7 @@ class PyJWS(object):
 
         if not issubclass(type(jwt), binary_type):
             raise DecodeError(
-                "Invalid token type. Token must be a {0}".format(binary_type)
+                "Invalid token type. Token must be a {}".format(binary_type)
             )
 
         try:

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -68,7 +68,7 @@ class PyJWT(PyJWS):
             payload, separators=(",", ":"), cls=json_encoder
         ).encode("utf-8")
 
-        return super(PyJWT, self).encode(
+        return super().encode(
             json_payload, key, algorithm, headers, json_encoder
         )
 
@@ -98,7 +98,7 @@ class PyJWT(PyJWS):
         else:
             options.setdefault("verify_signature", verify)
 
-        decoded = super(PyJWT, self).decode(
+        decoded = super().decode(
             jwt, key=key, algorithms=algorithms, options=options, **kwargs
         )
 
@@ -138,7 +138,7 @@ class PyJWT(PyJWS):
             if options[opt]:
                 require_options.append(opt_claim)
             warnings.warn(
-                "The {0} parameter is deprecated. Please add {1} to"
+                "The {} parameter is deprecated. Please add {} to"
                 " the require list in options instead".format(opt, opt_claim),
                 DeprecationWarning,
             )

--- a/jwt/help.py
+++ b/jwt/help.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import json
 import platform
 import sys
@@ -27,7 +25,7 @@ def info():
             "system": platform.system(),
             "release": platform.release(),
         }
-    except IOError:
+    except OSError:
         platform_info = {"system": "Unknown", "release": "Unknown"}
 
     implementation = platform.python_implementation()
@@ -35,7 +33,7 @@ def info():
     if implementation == "CPython":
         implementation_version = platform.python_version()
     elif implementation == "PyPy":
-        implementation_version = "%s.%s.%s" % (
+        implementation_version = "{}.{}.{}".format(
             sys.pypy_version_info.major,
             sys.pypy_version_info.minor,
             sys.pypy_version_info.micro,

--- a/tests/contrib/test_algorithms.py
+++ b/tests/contrib/test_algorithms.py
@@ -36,13 +36,13 @@ class TestPycryptoAlgorithms:
     def test_rsa_should_parse_pem_public_key(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("testkey2_rsa.pub.pem"), "r") as pem_key:
+        with open(key_path("testkey2_rsa.pub.pem")) as pem_key:
             algo.prepare_key(pem_key.read())
 
     def test_rsa_should_accept_unicode_key(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("testkey_rsa"), "r") as rsa_key:
+        with open(key_path("testkey_rsa")) as rsa_key:
             algo.prepare_key(force_unicode(rsa_key.read()))
 
     def test_rsa_should_reject_non_string_key(self):
@@ -67,10 +67,10 @@ class TestPycryptoAlgorithms:
             )
         )
 
-        with open(key_path("testkey_rsa"), "r") as keyfile:
+        with open(key_path("testkey_rsa")) as keyfile:
             jwt_key = algo.prepare_key(keyfile.read())
 
-        with open(key_path("testkey_rsa.pub"), "r") as keyfile:
+        with open(key_path("testkey_rsa.pub")) as keyfile:
             jwt_pub_key = algo.prepare_key(keyfile.read())
 
         algo.sign(jwt_message, jwt_key)
@@ -95,7 +95,7 @@ class TestPycryptoAlgorithms:
 
         jwt_sig += force_bytes("123")  # Signature is now invalid
 
-        with open(key_path("testkey_rsa.pub"), "r") as keyfile:
+        with open(key_path("testkey_rsa.pub")) as keyfile:
             jwt_pub_key = algo.prepare_key(keyfile.read())
 
         result = algo.verify(jwt_message, jwt_pub_key, jwt_sig)
@@ -117,7 +117,7 @@ class TestPycryptoAlgorithms:
             )
         )
 
-        with open(key_path("testkey_rsa.pub"), "r") as keyfile:
+        with open(key_path("testkey_rsa.pub")) as keyfile:
             jwt_pub_key = algo.prepare_key(keyfile.read())
 
         result = algo.verify(jwt_message, jwt_pub_key, jwt_sig)
@@ -126,7 +126,7 @@ class TestPycryptoAlgorithms:
     def test_rsa_prepare_key_should_be_idempotent(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("testkey_rsa.pub"), "r") as keyfile:
+        with open(key_path("testkey_rsa.pub")) as keyfile:
             jwt_pub_key_first = algo.prepare_key(keyfile.read())
             jwt_pub_key_second = algo.prepare_key(jwt_pub_key_first)
 
@@ -146,7 +146,7 @@ class TestEcdsaAlgorithms:
     def test_ec_should_accept_unicode_key(self):
         algo = ECAlgorithm(ECAlgorithm.SHA256)
 
-        with open(key_path("testkey_ec"), "r") as ec_key:
+        with open(key_path("testkey_ec")) as ec_key:
             algo.prepare_key(force_unicode(ec_key.read()))
 
     def test_ec_sign_should_generate_correct_signature_value(self):
@@ -162,10 +162,10 @@ class TestEcdsaAlgorithms:
             )
         )
 
-        with open(key_path("testkey_ec"), "r") as keyfile:
+        with open(key_path("testkey_ec")) as keyfile:
             jwt_key = algo.prepare_key(keyfile.read())
 
-        with open(key_path("testkey_ec.pub"), "r") as keyfile:
+        with open(key_path("testkey_ec.pub")) as keyfile:
             jwt_pub_key = algo.prepare_key(keyfile.read())
 
         algo.sign(jwt_message, jwt_key)
@@ -187,7 +187,7 @@ class TestEcdsaAlgorithms:
 
         jwt_sig += force_bytes("123")  # Signature is now invalid
 
-        with open(key_path("testkey_ec.pub"), "r") as keyfile:
+        with open(key_path("testkey_ec.pub")) as keyfile:
             jwt_pub_key = algo.prepare_key(keyfile.read())
 
         result = algo.verify(jwt_message, jwt_pub_key, jwt_sig)
@@ -206,7 +206,7 @@ class TestEcdsaAlgorithms:
             )
         )
 
-        with open(key_path("testkey_ec.pub"), "r") as keyfile:
+        with open(key_path("testkey_ec.pub")) as keyfile:
             jwt_pub_key = algo.prepare_key(keyfile.read())
 
         result = algo.verify(jwt_message, jwt_pub_key, jwt_sig)
@@ -215,7 +215,7 @@ class TestEcdsaAlgorithms:
     def test_ec_prepare_key_should_be_idempotent(self):
         algo = ECAlgorithm(ECAlgorithm.SHA256)
 
-        with open(key_path("testkey_ec.pub"), "r") as keyfile:
+        with open(key_path("testkey_ec.pub")) as keyfile:
             jwt_pub_key_first = algo.prepare_key(keyfile.read())
             jwt_pub_key_second = algo.prepare_key(jwt_pub_key_first)
 
@@ -235,16 +235,16 @@ class TestEd25519Algorithms:
         with pytest.raises(TypeError):
             algo.prepare_key(None)
 
-        with open(key_path("testkey_ed25519"), "r") as keyfile:
+        with open(key_path("testkey_ed25519")) as keyfile:
             jwt_key = algo.prepare_key(keyfile.read())
 
-        with open(key_path("testkey_ed25519.pub"), "r") as keyfile:
+        with open(key_path("testkey_ed25519.pub")) as keyfile:
             jwt_pub_key = algo.prepare_key(keyfile.read())
 
     def test_ed25519_should_accept_unicode_key(self):
         algo = Ed25519Algorithm()
 
-        with open(key_path("testkey_ed25519"), "r") as ec_key:
+        with open(key_path("testkey_ed25519")) as ec_key:
             algo.prepare_key(force_unicode(ec_key.read()))
 
     def test_ed25519_sign_should_generate_correct_signature_value(self):
@@ -254,10 +254,10 @@ class TestEd25519Algorithms:
     
         expected_sig = base64.b64decode(force_bytes(self.hello_world_sig))
 
-        with open(key_path("testkey_ed25519"), "r") as keyfile:
+        with open(key_path("testkey_ed25519")) as keyfile:
             jwt_key = algo.prepare_key(keyfile.read())
 
-        with open(key_path("testkey_ed25519.pub"), "r") as keyfile:
+        with open(key_path("testkey_ed25519.pub")) as keyfile:
             jwt_pub_key = algo.prepare_key(keyfile.read())
     
         algo.sign(jwt_message, jwt_key)
@@ -272,7 +272,7 @@ class TestEd25519Algorithms:
     
         jwt_sig += force_bytes("123")  # Signature is now invalid
 
-        with open(key_path("testkey_ed25519.pub"), "r") as keyfile:
+        with open(key_path("testkey_ed25519.pub")) as keyfile:
             jwt_pub_key = algo.prepare_key(keyfile.read())
     
         result = algo.verify(jwt_message, jwt_pub_key, jwt_sig)
@@ -284,7 +284,7 @@ class TestEd25519Algorithms:
         jwt_message = self.hello_world
         jwt_sig = base64.b64decode(force_bytes(self.hello_world_sig))
 
-        with open(key_path("testkey_ed25519.pub"), "r") as keyfile:
+        with open(key_path("testkey_ed25519.pub")) as keyfile:
             jwt_pub_key = algo.prepare_key(keyfile.read())
     
         result = algo.verify(jwt_message, jwt_pub_key, jwt_sig)
@@ -293,7 +293,7 @@ class TestEd25519Algorithms:
     def test_ed25519_prepare_key_should_be_idempotent(self):
         algo = Ed25519Algorithm()
 
-        with open(key_path("testkey_ed25519.pub"), "r") as keyfile:
+        with open(key_path("testkey_ed25519.pub")) as keyfile:
             jwt_pub_key_first = algo.prepare_key(keyfile.read())
             jwt_pub_key_second = algo.prepare_key(jwt_pub_key_first)
     

--- a/tests/keys/__init__.py
+++ b/tests/keys/__init__.py
@@ -13,7 +13,7 @@ def decode_value(val):
 
 
 def load_hmac_key():
-    with open(os.path.join(BASE_PATH, "jwk_hmac.json"), "r") as infile:
+    with open(os.path.join(BASE_PATH, "jwk_hmac.json")) as infile:
         keyobj = json.load(infile)
 
     return base64url_decode(force_bytes(keyobj["k"]))
@@ -31,15 +31,15 @@ except ImportError:
 if has_crypto:
 
     def load_rsa_key():
-        with open(os.path.join(BASE_PATH, "jwk_rsa_key.json"), "r") as infile:
+        with open(os.path.join(BASE_PATH, "jwk_rsa_key.json")) as infile:
             return RSAAlgorithm.from_jwk(infile.read())
 
     def load_rsa_pub_key():
-        with open(os.path.join(BASE_PATH, "jwk_rsa_pub.json"), "r") as infile:
+        with open(os.path.join(BASE_PATH, "jwk_rsa_pub.json")) as infile:
             return RSAAlgorithm.from_jwk(infile.read())
 
     def load_ec_key():
-        with open(os.path.join(BASE_PATH, "jwk_ec_key.json"), "r") as infile:
+        with open(os.path.join(BASE_PATH, "jwk_ec_key.json")) as infile:
             keyobj = json.load(infile)
 
         return ec.EllipticCurvePrivateNumbers(
@@ -48,7 +48,7 @@ if has_crypto:
         )
 
     def load_ec_pub_key():
-        with open(os.path.join(BASE_PATH, "jwk_ec_pub.json"), "r") as infile:
+        with open(os.path.join(BASE_PATH, "jwk_ec_pub.json")) as infile:
             keyobj = json.load(infile)
 
         return ec.EllipticCurvePublicNumbers(

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -74,41 +74,41 @@ class TestAlgorithms:
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
 
         with pytest.raises(InvalidKeyError):
-            with open(key_path("testkey2_rsa.pub.pem"), "r") as keyfile:
+            with open(key_path("testkey2_rsa.pub.pem")) as keyfile:
                 algo.prepare_key(keyfile.read())
 
     def test_hmac_should_throw_exception_if_key_is_x509_certificate(self):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
 
         with pytest.raises(InvalidKeyError):
-            with open(key_path("testkey_rsa.cer"), "r") as keyfile:
+            with open(key_path("testkey_rsa.cer")) as keyfile:
                 algo.prepare_key(keyfile.read())
 
     def test_hmac_should_throw_exception_if_key_is_ssh_public_key(self):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
 
         with pytest.raises(InvalidKeyError):
-            with open(key_path("testkey_rsa.pub"), "r") as keyfile:
+            with open(key_path("testkey_rsa.pub")) as keyfile:
                 algo.prepare_key(keyfile.read())
 
     def test_hmac_should_throw_exception_if_key_is_x509_cert(self):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
 
         with pytest.raises(InvalidKeyError):
-            with open(key_path("testkey2_rsa.pub.pem"), "r") as keyfile:
+            with open(key_path("testkey2_rsa.pub.pem")) as keyfile:
                 algo.prepare_key(keyfile.read())
 
     def test_hmac_should_throw_exception_if_key_is_pkcs1_pem_public(self):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
 
         with pytest.raises(InvalidKeyError):
-            with open(key_path("testkey_pkcs1.pub.pem"), "r") as keyfile:
+            with open(key_path("testkey_pkcs1.pub.pem")) as keyfile:
                 algo.prepare_key(keyfile.read())
 
     def test_hmac_jwk_should_parse_and_verify(self):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
 
-        with open(key_path("jwk_hmac.json"), "r") as keyfile:
+        with open(key_path("jwk_hmac.json")) as keyfile:
             key = algo.from_jwk(keyfile.read())
 
         signature = algo.sign(b"Hello World!", key)
@@ -123,7 +123,7 @@ class TestAlgorithms:
     def test_hmac_from_jwk_should_raise_exception_if_not_hmac_key(self):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
 
-        with open(key_path("jwk_rsa_pub.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_pub.json")) as keyfile:
             with pytest.raises(InvalidKeyError):
                 algo.from_jwk(keyfile.read())
 
@@ -133,7 +133,7 @@ class TestAlgorithms:
     def test_rsa_should_parse_pem_public_key(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("testkey2_rsa.pub.pem"), "r") as pem_key:
+        with open(key_path("testkey2_rsa.pub.pem")) as pem_key:
             algo.prepare_key(pem_key.read())
 
     @pytest.mark.skipif(
@@ -151,7 +151,7 @@ class TestAlgorithms:
     def test_rsa_should_accept_unicode_key(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("testkey_rsa"), "r") as rsa_key:
+        with open(key_path("testkey_rsa")) as rsa_key:
             algo.prepare_key(force_unicode(rsa_key.read()))
 
     @pytest.mark.skipif(
@@ -184,7 +184,7 @@ class TestAlgorithms:
 
         sig += force_bytes("123")  # Signature is now invalid
 
-        with open(key_path("testkey_rsa.pub"), "r") as keyfile:
+        with open(key_path("testkey_rsa.pub")) as keyfile:
             pub_key = algo.prepare_key(keyfile.read())
 
         result = algo.verify(message, pub_key, sig)
@@ -196,10 +196,10 @@ class TestAlgorithms:
     def test_rsa_jwk_public_and_private_keys_should_parse_and_verify(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("jwk_rsa_pub.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_pub.json")) as keyfile:
             pub_key = algo.from_jwk(keyfile.read())
 
-        with open(key_path("jwk_rsa_key.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_key.json")) as keyfile:
             priv_key = algo.from_jwk(keyfile.read())
 
         signature = algo.sign(force_bytes("Hello World!"), priv_key)
@@ -211,7 +211,7 @@ class TestAlgorithms:
     def test_rsa_private_key_to_jwk_works_with_from_jwk(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("testkey_rsa"), "r") as rsa_key:
+        with open(key_path("testkey_rsa")) as rsa_key:
             orig_key = algo.prepare_key(force_unicode(rsa_key.read()))
 
         parsed_key = algo.from_jwk(algo.to_jwk(orig_key))
@@ -227,7 +227,7 @@ class TestAlgorithms:
     def test_rsa_public_key_to_jwk_works_with_from_jwk(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("testkey_rsa.pub"), "r") as rsa_key:
+        with open(key_path("testkey_rsa.pub")) as rsa_key:
             orig_key = algo.prepare_key(force_unicode(rsa_key.read()))
 
         parsed_key = algo.from_jwk(algo.to_jwk(orig_key))
@@ -239,7 +239,7 @@ class TestAlgorithms:
     def test_rsa_jwk_private_key_with_other_primes_is_invalid(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("jwk_rsa_key.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_key.json")) as keyfile:
             with pytest.raises(InvalidKeyError):
                 keydata = json.loads(keyfile.read())
                 keydata["oth"] = []
@@ -252,7 +252,7 @@ class TestAlgorithms:
     def test_rsa_jwk_private_key_with_missing_values_is_invalid(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("jwk_rsa_key.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_key.json")) as keyfile:
             with pytest.raises(InvalidKeyError):
                 keydata = json.loads(keyfile.read())
                 del keydata["p"]
@@ -265,7 +265,7 @@ class TestAlgorithms:
     def test_rsa_jwk_private_key_can_recover_prime_factors(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("jwk_rsa_key.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_key.json")) as keyfile:
             keybytes = keyfile.read()
             control_key = algo.from_jwk(keybytes).private_numbers()
 
@@ -289,7 +289,7 @@ class TestAlgorithms:
     def test_rsa_jwk_private_key_with_missing_required_values_is_invalid(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("jwk_rsa_key.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_key.json")) as keyfile:
             with pytest.raises(InvalidKeyError):
                 keydata = json.loads(keyfile.read())
                 del keydata["p"]
@@ -316,7 +316,7 @@ class TestAlgorithms:
     def test_rsa_to_jwk_returns_correct_values_for_public_key(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("testkey_rsa.pub"), "r") as keyfile:
+        with open(key_path("testkey_rsa.pub")) as keyfile:
             pub_key = algo.prepare_key(keyfile.read())
 
         key = algo.to_jwk(pub_key)
@@ -342,13 +342,13 @@ class TestAlgorithms:
     def test_rsa_to_jwk_returns_correct_values_for_private_key(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("testkey_rsa"), "r") as keyfile:
+        with open(key_path("testkey_rsa")) as keyfile:
             priv_key = algo.prepare_key(keyfile.read())
 
         key = algo.to_jwk(priv_key)
 
         expected = {
-            "key_ops": [u"sign"],
+            "key_ops": ["sign"],
             "kty": "RSA",
             "e": "AQAB",
             "n": (
@@ -410,7 +410,7 @@ class TestAlgorithms:
     def test_rsa_from_jwk_raises_exception_on_invalid_key(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("jwk_hmac.json"), "r") as keyfile:
+        with open(key_path("jwk_hmac.json")) as keyfile:
             with pytest.raises(InvalidKeyError):
                 algo.from_jwk(keyfile.read())
 
@@ -429,7 +429,7 @@ class TestAlgorithms:
     def test_ec_should_accept_unicode_key(self):
         algo = ECAlgorithm(ECAlgorithm.SHA256)
 
-        with open(key_path("testkey_ec"), "r") as ec_key:
+        with open(key_path("testkey_ec")) as ec_key:
             algo.prepare_key(force_unicode(ec_key.read()))
 
     @pytest.mark.skipif(
@@ -447,7 +447,7 @@ class TestAlgorithms:
     def test_ec_should_accept_ssh_public_key_bytes(self):
         algo = ECAlgorithm(ECAlgorithm.SHA256)
 
-        with open(key_path("testkey_ec_ssh.pub"), "r") as ec_key:
+        with open(key_path("testkey_ec_ssh.pub")) as ec_key:
             algo.prepare_key(ec_key.read())
 
     @pytest.mark.skipif(
@@ -469,7 +469,7 @@ class TestAlgorithms:
             )
         )
 
-        with open(key_path("testkey_ec.pub"), "r") as keyfile:
+        with open(key_path("testkey_ec.pub")) as keyfile:
             pub_key = algo.prepare_key(keyfile.read())
 
         result = algo.verify(message, pub_key, sig)
@@ -485,7 +485,7 @@ class TestAlgorithms:
 
         sig = base64.b64decode(force_bytes("AC+m4Jf/xI3guAC6w0w3"))
 
-        with open(key_path("testkey_ec.pub"), "r") as keyfile:
+        with open(key_path("testkey_ec.pub")) as keyfile:
             pub_key = algo.prepare_key(keyfile.read())
 
         result = algo.verify(message, pub_key, sig)
@@ -499,11 +499,11 @@ class TestAlgorithms:
 
         message = force_bytes("Hello World!")
 
-        with open(key_path("testkey_rsa"), "r") as keyfile:
+        with open(key_path("testkey_rsa")) as keyfile:
             priv_key = algo.prepare_key(keyfile.read())
             sig = algo.sign(message, priv_key)
 
-        with open(key_path("testkey_rsa.pub"), "r") as keyfile:
+        with open(key_path("testkey_rsa.pub")) as keyfile:
             pub_key = algo.prepare_key(keyfile.read())
 
         result = algo.verify(message, pub_key, sig)
@@ -530,7 +530,7 @@ class TestAlgorithms:
 
         jwt_sig += force_bytes("123")  # Signature is now invalid
 
-        with open(key_path("testkey_rsa.pub"), "r") as keyfile:
+        with open(key_path("testkey_rsa.pub")) as keyfile:
             jwt_pub_key = algo.prepare_key(keyfile.read())
 
         result = algo.verify(jwt_message, jwt_pub_key, jwt_sig)

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -221,7 +221,7 @@ class TestJWS:
     )
     def test_decodes_valid_es384_jws(self, jws):
         example_payload = {"hello": "world"}
-        with open("tests/keys/testkey_ec.pub", "r") as fp:
+        with open("tests/keys/testkey_ec.pub") as fp:
             example_pubkey = fp.read()
         example_jws = (
             b"eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9"
@@ -245,7 +245,7 @@ class TestJWS:
     )
     def test_decodes_valid_rs384_jws(self, jws):
         example_payload = {"hello": "world"}
-        with open("tests/keys/testkey_rsa.pub", "r") as fp:
+        with open("tests/keys/testkey_rsa.pub") as fp:
             example_pubkey = fp.read()
         example_jws = (
             b"eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9"
@@ -489,7 +489,7 @@ class TestJWS:
     )
     def test_encode_decode_with_rsa_sha256(self, jws, payload):
         # PEM-formatted RSA key
-        with open("tests/keys/testkey_rsa", "r") as rsa_priv_file:
+        with open("tests/keys/testkey_rsa") as rsa_priv_file:
             priv_rsakey = load_pem_private_key(
                 force_bytes(rsa_priv_file.read()),
                 password=None,
@@ -497,7 +497,7 @@ class TestJWS:
             )
             jws_message = jws.encode(payload, priv_rsakey, algorithm="RS256")
 
-        with open("tests/keys/testkey_rsa.pub", "r") as rsa_pub_file:
+        with open("tests/keys/testkey_rsa.pub") as rsa_pub_file:
             pub_rsakey = load_ssh_public_key(
                 force_bytes(rsa_pub_file.read()), backend=default_backend()
             )
@@ -505,11 +505,11 @@ class TestJWS:
             jws.decode(jws_message, pub_rsakey)
 
         # string-formatted key
-        with open("tests/keys/testkey_rsa", "r") as rsa_priv_file:
+        with open("tests/keys/testkey_rsa") as rsa_priv_file:
             priv_rsakey = rsa_priv_file.read()
             jws_message = jws.encode(payload, priv_rsakey, algorithm="RS256")
 
-        with open("tests/keys/testkey_rsa.pub", "r") as rsa_pub_file:
+        with open("tests/keys/testkey_rsa.pub") as rsa_pub_file:
             pub_rsakey = rsa_pub_file.read()
             jws.decode(jws_message, pub_rsakey)
 
@@ -518,7 +518,7 @@ class TestJWS:
     )
     def test_encode_decode_with_rsa_sha384(self, jws, payload):
         # PEM-formatted RSA key
-        with open("tests/keys/testkey_rsa", "r") as rsa_priv_file:
+        with open("tests/keys/testkey_rsa") as rsa_priv_file:
             priv_rsakey = load_pem_private_key(
                 force_bytes(rsa_priv_file.read()),
                 password=None,
@@ -526,18 +526,18 @@ class TestJWS:
             )
             jws_message = jws.encode(payload, priv_rsakey, algorithm="RS384")
 
-        with open("tests/keys/testkey_rsa.pub", "r") as rsa_pub_file:
+        with open("tests/keys/testkey_rsa.pub") as rsa_pub_file:
             pub_rsakey = load_ssh_public_key(
                 force_bytes(rsa_pub_file.read()), backend=default_backend()
             )
             jws.decode(jws_message, pub_rsakey)
 
         # string-formatted key
-        with open("tests/keys/testkey_rsa", "r") as rsa_priv_file:
+        with open("tests/keys/testkey_rsa") as rsa_priv_file:
             priv_rsakey = rsa_priv_file.read()
             jws_message = jws.encode(payload, priv_rsakey, algorithm="RS384")
 
-        with open("tests/keys/testkey_rsa.pub", "r") as rsa_pub_file:
+        with open("tests/keys/testkey_rsa.pub") as rsa_pub_file:
             pub_rsakey = rsa_pub_file.read()
             jws.decode(jws_message, pub_rsakey)
 
@@ -546,7 +546,7 @@ class TestJWS:
     )
     def test_encode_decode_with_rsa_sha512(self, jws, payload):
         # PEM-formatted RSA key
-        with open("tests/keys/testkey_rsa", "r") as rsa_priv_file:
+        with open("tests/keys/testkey_rsa") as rsa_priv_file:
             priv_rsakey = load_pem_private_key(
                 force_bytes(rsa_priv_file.read()),
                 password=None,
@@ -554,18 +554,18 @@ class TestJWS:
             )
             jws_message = jws.encode(payload, priv_rsakey, algorithm="RS512")
 
-        with open("tests/keys/testkey_rsa.pub", "r") as rsa_pub_file:
+        with open("tests/keys/testkey_rsa.pub") as rsa_pub_file:
             pub_rsakey = load_ssh_public_key(
                 force_bytes(rsa_pub_file.read()), backend=default_backend()
             )
             jws.decode(jws_message, pub_rsakey)
 
         # string-formatted key
-        with open("tests/keys/testkey_rsa", "r") as rsa_priv_file:
+        with open("tests/keys/testkey_rsa") as rsa_priv_file:
             priv_rsakey = rsa_priv_file.read()
             jws_message = jws.encode(payload, priv_rsakey, algorithm="RS512")
 
-        with open("tests/keys/testkey_rsa.pub", "r") as rsa_pub_file:
+        with open("tests/keys/testkey_rsa.pub") as rsa_pub_file:
             pub_rsakey = rsa_pub_file.read()
             jws.decode(jws_message, pub_rsakey)
 
@@ -594,7 +594,7 @@ class TestJWS:
     )
     def test_encode_decode_with_ecdsa_sha256(self, jws, payload):
         # PEM-formatted EC key
-        with open("tests/keys/testkey_ec", "r") as ec_priv_file:
+        with open("tests/keys/testkey_ec") as ec_priv_file:
             priv_eckey = load_pem_private_key(
                 force_bytes(ec_priv_file.read()),
                 password=None,
@@ -602,18 +602,18 @@ class TestJWS:
             )
             jws_message = jws.encode(payload, priv_eckey, algorithm="ES256")
 
-        with open("tests/keys/testkey_ec.pub", "r") as ec_pub_file:
+        with open("tests/keys/testkey_ec.pub") as ec_pub_file:
             pub_eckey = load_pem_public_key(
                 force_bytes(ec_pub_file.read()), backend=default_backend()
             )
             jws.decode(jws_message, pub_eckey)
 
         # string-formatted key
-        with open("tests/keys/testkey_ec", "r") as ec_priv_file:
+        with open("tests/keys/testkey_ec") as ec_priv_file:
             priv_eckey = ec_priv_file.read()
             jws_message = jws.encode(payload, priv_eckey, algorithm="ES256")
 
-        with open("tests/keys/testkey_ec.pub", "r") as ec_pub_file:
+        with open("tests/keys/testkey_ec.pub") as ec_pub_file:
             pub_eckey = ec_pub_file.read()
             jws.decode(jws_message, pub_eckey)
 
@@ -623,7 +623,7 @@ class TestJWS:
     def test_encode_decode_with_ecdsa_sha384(self, jws, payload):
 
         # PEM-formatted EC key
-        with open("tests/keys/testkey_ec", "r") as ec_priv_file:
+        with open("tests/keys/testkey_ec") as ec_priv_file:
             priv_eckey = load_pem_private_key(
                 force_bytes(ec_priv_file.read()),
                 password=None,
@@ -631,18 +631,18 @@ class TestJWS:
             )
             jws_message = jws.encode(payload, priv_eckey, algorithm="ES384")
 
-        with open("tests/keys/testkey_ec.pub", "r") as ec_pub_file:
+        with open("tests/keys/testkey_ec.pub") as ec_pub_file:
             pub_eckey = load_pem_public_key(
                 force_bytes(ec_pub_file.read()), backend=default_backend()
             )
             jws.decode(jws_message, pub_eckey)
 
         # string-formatted key
-        with open("tests/keys/testkey_ec", "r") as ec_priv_file:
+        with open("tests/keys/testkey_ec") as ec_priv_file:
             priv_eckey = ec_priv_file.read()
             jws_message = jws.encode(payload, priv_eckey, algorithm="ES384")
 
-        with open("tests/keys/testkey_ec.pub", "r") as ec_pub_file:
+        with open("tests/keys/testkey_ec.pub") as ec_pub_file:
             pub_eckey = ec_pub_file.read()
             jws.decode(jws_message, pub_eckey)
 
@@ -651,7 +651,7 @@ class TestJWS:
     )
     def test_encode_decode_with_ecdsa_sha512(self, jws, payload):
         # PEM-formatted EC key
-        with open("tests/keys/testkey_ec", "r") as ec_priv_file:
+        with open("tests/keys/testkey_ec") as ec_priv_file:
             priv_eckey = load_pem_private_key(
                 force_bytes(ec_priv_file.read()),
                 password=None,
@@ -659,18 +659,18 @@ class TestJWS:
             )
             jws_message = jws.encode(payload, priv_eckey, algorithm="ES521")
 
-        with open("tests/keys/testkey_ec.pub", "r") as ec_pub_file:
+        with open("tests/keys/testkey_ec.pub") as ec_pub_file:
             pub_eckey = load_pem_public_key(
                 force_bytes(ec_pub_file.read()), backend=default_backend()
             )
             jws.decode(jws_message, pub_eckey)
 
         # string-formatted key
-        with open("tests/keys/testkey_ec", "r") as ec_priv_file:
+        with open("tests/keys/testkey_ec") as ec_priv_file:
             priv_eckey = ec_priv_file.read()
             jws_message = jws.encode(payload, priv_eckey, algorithm="ES521")
 
-        with open("tests/keys/testkey_ec.pub", "r") as ec_pub_file:
+        with open("tests/keys/testkey_ec.pub") as ec_pub_file:
             pub_eckey = ec_pub_file.read()
             jws.decode(jws_message, pub_eckey)
 
@@ -709,7 +709,7 @@ class TestJWS:
             def default(self, o):
                 if isinstance(o, Decimal):
                     return "it worked"
-                return super(CustomJSONEncoder, self).default(o)
+                return super().default(o)
 
         data = {"some_decimal": Decimal("2.2")}
 

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -201,7 +201,7 @@ class TestJWT:
     )
     def test_decodes_valid_es384_jwt(self, jwt):
         example_payload = {"hello": "world"}
-        with open("tests/keys/testkey_ec.pub", "r") as fp:
+        with open("tests/keys/testkey_ec.pub") as fp:
             example_pubkey = fp.read()
         example_jwt = (
             b"eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9"
@@ -224,7 +224,7 @@ class TestJWT:
     )
     def test_decodes_valid_rs384_jwt(self, jwt):
         example_payload = {"hello": "world"}
-        with open("tests/keys/testkey_rsa.pub", "r") as fp:
+        with open("tests/keys/testkey_rsa.pub") as fp:
             example_pubkey = fp.read()
         example_jwt = (
             b"eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9"
@@ -481,7 +481,7 @@ class TestJWT:
             def default(self, o):
                 if isinstance(o, Decimal):
                     return "it worked"
-                return super(CustomJSONEncoder, self).default(o)
+                return super().default(o)
 
         data = {"some_decimal": Decimal("2.2")}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,16 +115,16 @@ class TestCli:
     )
     def test_encode_decode(self, key, header, name, job, exp, verify):
         encode_args = [
-            "--key={0}".format(key),
-            "--header={0}".format(header),
+            "--key={}".format(key),
+            "--header={}".format(header),
             "encode",
-            "name={0}".format(name),
-            "job={0}".format(job),
+            "name={}".format(name),
+            "job={}".format(job),
         ]
         if exp:
-            encode_args.append("exp={0}".format(exp))
+            encode_args.append("exp={}".format(exp))
         if verify:
-            encode_args.append("verify={0}".format(verify))
+            encode_args.append("verify={}".format(verify))
 
         parser = build_argparser()
         parsed_encode_args = parser.parse_args(encode_args)
@@ -132,7 +132,7 @@ class TestCli:
         assert token is not None
         assert token != ""
 
-        decode_args = ["--key={0}".format(key), "decode", token]
+        decode_args = ["--key={}".format(key), "decode", token]
         parser = build_argparser()
         parsed_decode_args = parser.parse_args(decode_args)
 
@@ -152,15 +152,15 @@ class TestCli:
     def test_main(self, monkeypatch, key, name, job, exp, verify):
         args = [
             "test_cli.py",
-            "--key={0}".format(key),
+            "--key={}".format(key),
             "encode",
-            "name={0}".format(name),
-            "job={0}".format(job),
+            "name={}".format(name),
+            "job={}".format(job),
         ]
         if exp:
-            args.append("exp={0}".format(exp))
+            args.append("exp={}".format(exp))
         if verify:
-            args.append("verify={0}".format(verify))
+            args.append("verify={}".format(verify))
         monkeypatch.setattr(sys, "argv", args)
         main()
 


### PR DESCRIPTION
pyupgrade is a tool to automatically upgrade Python syntax for newer
versions of the language. Running pyupgrade removes several
Python-2-isms that are no longer necessary now that the project is
Python 3 only.

https://github.com/asottile/pyupgrade