### PR TITLE
Add Python-3-only trove classifier and remove "universal" from wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
@@ -70,5 +71,4 @@ setup(
     python_requires=">=3.5",
     extras_require=EXTRAS_REQUIRE,
     entry_points={"console_scripts": ["pyjwt = jwt.__main__:main"]},
-    options={"bdist_wheel": {"universal": "1"}},
 )


### PR DESCRIPTION
Documents the project as Python 3 only to potential and current library
users.

As the project no longer supports Python 2, the wheel is not
"universal". From
https://wheel.readthedocs.io/en/stable/user_guide.html?highlight=universal#building-wheels:

> If your project … is expected to work on both Python 2 and 3, you will
> want to tell wheel to produce universal wheels …