### PR TITLE
Expose InvalidKeyError on jwt module

### DIFF
--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -35,6 +35,7 @@ from .exceptions import (
     InvalidIssuedAtError,
     InvalidIssuer,
     InvalidIssuerError,
+    InvalidKeyError,
     InvalidSignatureError,
     InvalidTokenError,
     MissingRequiredClaimError,


### PR DESCRIPTION
This allows one to import that error similar to other errors:
```
from jwt import InvalidKeyError
```