### PR TITLE
Avoid loading token twice in pyjwt.decode

### DIFF
--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -92,8 +92,6 @@ class PyJWT(PyJWS):
                 stacklevel=2,
             )
 
-        payload, _, _, _ = self._load(jwt)
-
         if options is None:
             options = {"verify_signature": verify}
         else:


### PR DESCRIPTION
Removes a duplicate call to `_load` in `pyjwt.decode` method that is unused.