### PR TITLE
Add decode timezone support

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -51,6 +51,7 @@ API Reference
             .. deprecated:: 1.2.0
                 Use ``verify_exp`` instead
 
+        * ``timezone`` change the timezone used for decoding and validation, expects tzinfo object
 
     :param iterable audience: optional, the value for ``verify_aud`` check
     :param str issuer: optional, the value for ``verify_iss`` check

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -36,7 +36,7 @@ class PyJWT(PyJWS):
             "verify_iat": True,
             "verify_aud": True,
             "verify_iss": True,
-            "timezone": timezone.utc,
+            "timezone": timezone.utc,   # type: tzinfo
             "require": [],
         }
 

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -1,7 +1,7 @@
 import json
 from calendar import timegm
 from collections.abc import Iterable, Mapping
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from .algorithms import Algorithm, get_default_algorithms  # NOQA
 from .api_jws import PyJWS
@@ -36,6 +36,7 @@ class PyJWT(PyJWS):
             "verify_iat": True,
             "verify_aud": True,
             "verify_iss": True,
+            "timezone": timezone.utc,
             "require": [],
         }
 
@@ -132,7 +133,7 @@ class PyJWT(PyJWS):
 
         self._validate_required_claims(payload, options)
 
-        now = timegm(datetime.utcnow().utctimetuple())
+        now = timegm(datetime.now(tz=options.get("timezone")).utctimetuple())
 
         if "iat" in payload and options.get("verify_iat"):
             self._validate_iat(payload, now, leeway)

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ tests =
     pytest>=6.0.0,<7.0.0
     coverage[toml]==5.0.4
     requests-mock>=1.7.0,<2.0.0
+    pytz >= 2020.1
 dev =
     sphinx
     sphinx-rtd-theme


### PR DESCRIPTION
Added `timezone` support to `options` dictionary.
The change is needed since the expiry of the tokens are validated against the machines local timezone, this new option enables explicitly choosing and setting the timezone used for decoding and validations.
I made to sure to document the new option + wrote a test for it.
This solves issue #487 .