### PR TITLE
Update return type for jwt.encode

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,7 +16,7 @@ API Reference
     :param str algorithm: algorithm to sign the token with, e.g. ``"ES256"``
     :param dict headers: additional JWT header fields, e.g. ``dict(kid="my-key-id")``
     :param json.JSONEncoder json_encoder: custom JSON encoder for ``payload`` and ``headers``
-    :rtype: str
+    :rtype: bytes
     :returns: a JSON Web Token
 
 .. function:: decode(jwt, key="", verify=True, algorithms=None, options=None, audience=None, issuer=None, leeway=0, verify_expiration=True)


### PR DESCRIPTION
It seems to me that the return type for the encode method is actually 'bytes' type and not 'str'. While this doesn't make a huge difference working with python code, it gave me some issues yesterday when sending JWT tokens between a Python (flask) REST API and Javascript (Vue) frontend.