### PR TITLE
Run tests against Python 3.9 and add trove classifier

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         platform: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
 
     steps:
       - uses: "actions/checkout@v2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ docs =
     sphinx-rtd-theme
     zope.interface
 crypto =
-    cryptography>=2.6,<3.0.0
+    cryptography>=2.6,<4.0.0
 tests =
     pytest>=6.0.0,<7.0.0
     coverage[toml]==5.0.4
@@ -48,7 +48,7 @@ dev =
     sphinx
     sphinx-rtd-theme
     zope.interface
-    cryptography>=2.6,<3.0.0
+    cryptography>=2.6,<4.0.0
     pytest>=6.0.0,<7.0.0
     coverage[toml]==5.0.4
     requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Utilities
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ python =
     3.6: py36
     3.7: py37, docs
     3.8: py38, lint, manifest, typing
+    3.9: py39
 
 
 [gh-actions:env]
@@ -24,8 +25,8 @@ PLATFORM =
 envlist =
     lint
     typing
-    py{36,37,38}-crypto-{linux,windows}
-    py{36,37,38}-nocrypto-{linux,windows}
+    py{36,37,38,39}-crypto-{linux,windows}
+    py{36,37,38,39}-nocrypto-{linux,windows}
     manifest
     docs
     pypi-description
@@ -40,7 +41,7 @@ setenv =
     VIRTUALENV_NO_DOWNLOAD=1
 extras =
     tests
-    py{36,37,38}-crypto-{linux,windows}: crypto
+    py{36,37,38,39}-crypto-{linux,windows}: crypto
 commands = coverage run -m pytest {posargs}
 
 


### PR DESCRIPTION
The Python 3.9 jobs on windows currently fails with

> ERROR: Could not build wheels for cryptography which use PEP 517 and cannot be installed directly

cryptography provides abi3 wheels, but they are only available for cryptography>=3 on windows.  Wheels for Python 3 probably won't be available for cryptography < 3.  ~Is removing the upper bound worth investigating?~

**Update:**

I've checked the [changelog](https://github.com/pyca/cryptography/blob/master/CHANGELOG.rst) and gave it a try.  All the tests pass with cryptography 3.x.

