### PR TITLE
Removed redundant `default_backend()`

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -11,10 +11,9 @@ extract the public or private keys from a x509 certificate in PEM format.
 
     # Python 2
     from cryptography.x509 import load_pem_x509_certificate
-    from cryptography.hazmat.backends import default_backend
 
     cert_str = "-----BEGIN CERTIFICATE-----MIIDETCCAfm..."
-    cert_obj = load_pem_x509_certificate(cert_str, default_backend())
+    cert_obj = load_pem_x509_certificate(cert_str)
     public_key = cert_obj.public_key()
     private_key = cert_obj.private_key()
 
@@ -22,9 +21,8 @@ extract the public or private keys from a x509 certificate in PEM format.
 
     # Python 3
     from cryptography.x509 import load_pem_x509_certificate
-    from cryptography.hazmat.backends import default_backend
 
     cert_str = "-----BEGIN CERTIFICATE-----MIIDETCCAfm...".encode()
-    cert_obj = load_pem_x509_certificate(cert_str, default_backend())
+    cert_obj = load_pem_x509_certificate(cert_str)
     public_key = cert_obj.public_key()
     private_key = cert_obj.private_key()

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -36,7 +36,6 @@ try:
         EllipticCurvePublicKey,
     )
     from cryptography.hazmat.primitives.asymmetric import ec, padding
-    from cryptography.hazmat.backends import default_backend
     from cryptography.exceptions import InvalidSignature
 
     import cryptography.exceptions
@@ -241,15 +240,11 @@ if has_crypto:  # noqa: C901
 
                 try:
                     if key.startswith(b"ssh-rsa"):
-                        key = load_ssh_public_key(
-                            key, backend=default_backend()
-                        )
+                        key = load_ssh_public_key(key)
                     else:
-                        key = load_pem_private_key(
-                            key, password=None, backend=default_backend()
-                        )
+                        key = load_pem_private_key(key, password=None)
                 except ValueError:
-                    key = load_pem_public_key(key, backend=default_backend())
+                    key = load_pem_public_key(key)
             else:
                 raise TypeError("Expecting a PEM-formatted key.")
 
@@ -357,7 +352,7 @@ if has_crypto:  # noqa: C901
                         public_numbers=public_numbers,
                     )
 
-                return numbers.private_key(default_backend())
+                return numbers.private_key()
             elif "n" in obj and "e" in obj:
                 # Public key
                 numbers = RSAPublicNumbers(
@@ -365,7 +360,7 @@ if has_crypto:  # noqa: C901
                     from_base64url_uint(obj["n"]),
                 )
 
-                return numbers.public_key(default_backend())
+                return numbers.public_key()
             else:
                 raise InvalidKeyError("Not a public or private key")
 
@@ -406,17 +401,11 @@ if has_crypto:  # noqa: C901
                 # the Verifying Key first.
                 try:
                     if key.startswith(b"ecdsa-sha2-"):
-                        key = load_ssh_public_key(
-                            key, backend=default_backend()
-                        )
+                        key = load_ssh_public_key(key)
                     else:
-                        key = load_pem_public_key(
-                            key, backend=default_backend()
-                        )
+                        key = load_pem_public_key(key)
                 except ValueError:
-                    key = load_pem_private_key(
-                        key, password=None, backend=default_backend()
-                    )
+                    key = load_pem_private_key(key, password=None)
 
             else:
                 raise TypeError("Expecting a PEM-formatted key.")
@@ -489,7 +478,7 @@ if has_crypto:  # noqa: C901
             )
 
             if "d" not in obj:
-                return public_numbers.public_key(default_backend())
+                return public_numbers.public_key()
 
             d = base64url_decode(force_bytes(obj.get("d")))
             if len(d) != len(x):
@@ -499,7 +488,7 @@ if has_crypto:  # noqa: C901
 
             return ec.EllipticCurvePrivateNumbers(
                 int_from_bytes(d, "big"), public_numbers
-            ).private_key(default_backend())
+            ).private_key()
 
     class RSAPSSAlgorithm(RSAAlgorithm):
         """
@@ -552,13 +541,11 @@ if has_crypto:  # noqa: C901
                 str_key = key.decode("utf-8")
 
                 if "-----BEGIN PUBLIC" in str_key:
-                    return load_pem_public_key(key, backend=default_backend())
+                    return load_pem_public_key(key)
                 if "-----BEGIN PRIVATE" in str_key:
-                    return load_pem_private_key(
-                        key, password=None, backend=default_backend()
-                    )
+                    return load_pem_private_key(key, password=None)
                 if str_key[0:4] == "ssh-":
-                    return load_ssh_public_key(key, backend=default_backend())
+                    return load_ssh_public_key(key)
 
             raise TypeError("Expecting a PEM-formatted or OpenSSH key.")
 

--- a/tests/keys/__init__.py
+++ b/tests/keys/__init__.py
@@ -21,7 +21,6 @@ def load_hmac_key():
 
 try:
     from cryptography.hazmat.primitives.asymmetric import ec
-    from cryptography.hazmat.backends import default_backend
     from jwt.algorithms import RSAAlgorithm
 
     has_crypto = True
@@ -57,4 +56,4 @@ if has_crypto:
             x=decode_value(keyobj["x"]),
             y=decode_value(keyobj["y"]),
             curve=ec.SECP521R1(),
-        ).public_key(default_backend())
+        ).public_key()

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -14,7 +14,6 @@ from jwt.exceptions import (
 from jwt.utils import base64url_decode, force_bytes, force_unicode
 
 try:
-    from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives.serialization import (
         load_pem_private_key,
         load_pem_public_key,
@@ -494,16 +493,12 @@ class TestJWS:
         # PEM-formatted RSA key
         with open("tests/keys/testkey_rsa.priv", "r") as rsa_priv_file:
             priv_rsakey = load_pem_private_key(
-                force_bytes(rsa_priv_file.read()),
-                password=None,
-                backend=default_backend(),
+                force_bytes(rsa_priv_file.read()), password=None,
             )
             jws_message = jws.encode(payload, priv_rsakey, algorithm="RS256")
 
         with open("tests/keys/testkey_rsa.pub", "r") as rsa_pub_file:
-            pub_rsakey = load_ssh_public_key(
-                force_bytes(rsa_pub_file.read()), backend=default_backend()
-            )
+            pub_rsakey = load_ssh_public_key(force_bytes(rsa_pub_file.read()))
 
             jws.decode(jws_message, pub_rsakey, algorithms=["RS256"])
 
@@ -523,16 +518,12 @@ class TestJWS:
         # PEM-formatted RSA key
         with open("tests/keys/testkey_rsa.priv", "r") as rsa_priv_file:
             priv_rsakey = load_pem_private_key(
-                force_bytes(rsa_priv_file.read()),
-                password=None,
-                backend=default_backend(),
+                force_bytes(rsa_priv_file.read()), password=None,
             )
             jws_message = jws.encode(payload, priv_rsakey, algorithm="RS384")
 
         with open("tests/keys/testkey_rsa.pub", "r") as rsa_pub_file:
-            pub_rsakey = load_ssh_public_key(
-                force_bytes(rsa_pub_file.read()), backend=default_backend()
-            )
+            pub_rsakey = load_ssh_public_key(force_bytes(rsa_pub_file.read()))
             jws.decode(jws_message, pub_rsakey, algorithms=["RS384"])
 
         # string-formatted key
@@ -551,16 +542,12 @@ class TestJWS:
         # PEM-formatted RSA key
         with open("tests/keys/testkey_rsa.priv", "r") as rsa_priv_file:
             priv_rsakey = load_pem_private_key(
-                force_bytes(rsa_priv_file.read()),
-                password=None,
-                backend=default_backend(),
+                force_bytes(rsa_priv_file.read()), password=None,
             )
             jws_message = jws.encode(payload, priv_rsakey, algorithm="RS512")
 
         with open("tests/keys/testkey_rsa.pub", "r") as rsa_pub_file:
-            pub_rsakey = load_ssh_public_key(
-                force_bytes(rsa_pub_file.read()), backend=default_backend()
-            )
+            pub_rsakey = load_ssh_public_key(force_bytes(rsa_pub_file.read()))
             jws.decode(jws_message, pub_rsakey, algorithms=["RS512"])
 
         # string-formatted key
@@ -599,16 +586,12 @@ class TestJWS:
         # PEM-formatted EC key
         with open("tests/keys/testkey_ec.priv", "r") as ec_priv_file:
             priv_eckey = load_pem_private_key(
-                force_bytes(ec_priv_file.read()),
-                password=None,
-                backend=default_backend(),
+                force_bytes(ec_priv_file.read()), password=None,
             )
             jws_message = jws.encode(payload, priv_eckey, algorithm="ES256")
 
         with open("tests/keys/testkey_ec.pub", "r") as ec_pub_file:
-            pub_eckey = load_pem_public_key(
-                force_bytes(ec_pub_file.read()), backend=default_backend()
-            )
+            pub_eckey = load_pem_public_key(force_bytes(ec_pub_file.read()))
             jws.decode(jws_message, pub_eckey, algorithms=["ES256"])
 
         # string-formatted key
@@ -628,16 +611,12 @@ class TestJWS:
         # PEM-formatted EC key
         with open("tests/keys/testkey_ec.priv", "r") as ec_priv_file:
             priv_eckey = load_pem_private_key(
-                force_bytes(ec_priv_file.read()),
-                password=None,
-                backend=default_backend(),
+                force_bytes(ec_priv_file.read()), password=None,
             )
             jws_message = jws.encode(payload, priv_eckey, algorithm="ES384")
 
         with open("tests/keys/testkey_ec.pub", "r") as ec_pub_file:
-            pub_eckey = load_pem_public_key(
-                force_bytes(ec_pub_file.read()), backend=default_backend()
-            )
+            pub_eckey = load_pem_public_key(force_bytes(ec_pub_file.read()))
             jws.decode(jws_message, pub_eckey, algorithms=["ES384"])
 
         # string-formatted key
@@ -656,16 +635,12 @@ class TestJWS:
         # PEM-formatted EC key
         with open("tests/keys/testkey_ec.priv", "r") as ec_priv_file:
             priv_eckey = load_pem_private_key(
-                force_bytes(ec_priv_file.read()),
-                password=None,
-                backend=default_backend(),
+                force_bytes(ec_priv_file.read()), password=None,
             )
             jws_message = jws.encode(payload, priv_eckey, algorithm="ES512")
 
         with open("tests/keys/testkey_ec.pub", "r") as ec_pub_file:
-            pub_eckey = load_pem_public_key(
-                force_bytes(ec_pub_file.read()), backend=default_backend()
-            )
+            pub_eckey = load_pem_public_key(force_bytes(ec_pub_file.read()))
             jws.decode(jws_message, pub_eckey, algorithms=["ES512"])
 
         # string-formatted key


### PR DESCRIPTION
- Cryptography now has default_backend by default

Since Cryptography v3.1, backend arguments to functions are no longer required and the default backend will automatically be selected if no backend is provided.