### PR TITLE
Remove support for EOL Python 3.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -31,7 +30,7 @@ classifiers =
     Topic :: Utilities
 
 [options]
-python_requires = >=3.5
+python_requires = >=3.6
 packages = find:
 
 [options.extras_require]


### PR DESCRIPTION
Python 3.5 went end-of-life 2020-09-30. See:
https://devguide.python.org/devcycle/#end-of-life-branches