### PR TITLE
Upgrade to isort 5 and adjust configurations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,17 +11,10 @@ repos:
       - id: flake8
         language_version: python3.8
 
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.4
-    hooks:
-      - id: seed-isort-config
-
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.6.4
     hooks:
       - id: isort
-        additional_dependencies: [toml]
-        language_version: python3.8
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -15,33 +15,32 @@ from .utils import (
 )
 
 try:
+    import cryptography.exceptions
+    from cryptography.exceptions import InvalidSignature
     from cryptography.hazmat.primitives import hashes
-    from cryptography.hazmat.primitives.serialization import (
-        load_pem_private_key,
-        load_pem_public_key,
-        load_ssh_public_key,
-    )
-    from cryptography.hazmat.primitives.asymmetric.rsa import (
-        RSAPrivateKey,
-        RSAPublicKey,
-        RSAPrivateNumbers,
-        RSAPublicNumbers,
-        rsa_recover_prime_factors,
-        rsa_crt_dmp1,
-        rsa_crt_dmq1,
-        rsa_crt_iqmp,
-    )
+    from cryptography.hazmat.primitives.asymmetric import ec, padding
     from cryptography.hazmat.primitives.asymmetric.ec import (
         EllipticCurvePrivateKey,
         EllipticCurvePublicKey,
     )
-    from cryptography.hazmat.primitives.asymmetric import ec, padding
-    from cryptography.exceptions import InvalidSignature
-
-    import cryptography.exceptions
     from cryptography.hazmat.primitives.asymmetric.ed25519 import (
         Ed25519PrivateKey,
         Ed25519PublicKey,
+    )
+    from cryptography.hazmat.primitives.asymmetric.rsa import (
+        RSAPrivateKey,
+        RSAPrivateNumbers,
+        RSAPublicKey,
+        RSAPublicNumbers,
+        rsa_crt_dmp1,
+        rsa_crt_dmq1,
+        rsa_crt_iqmp,
+        rsa_recover_prime_factors,
+    )
+    from cryptography.hazmat.primitives.serialization import (
+        load_pem_private_key,
+        load_pem_public_key,
+        load_ssh_public_key,
     )
     from cryptography.utils import int_from_bytes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,7 @@ line-length = 79
 
 
 [tool.isort]
-atomic=true
-force_grid_wrap=0
-include_trailing_comma=true
-multi_line_output=3
-use_parentheses=true
-combine_as_imports=true
-
-known_first_party="jwt"
-known_third_party=["pytest", "requests_mock", "setuptools", "sphinx_rtd_theme"]
+profile = "black"
+atomic = true
+combine_as_imports = true
+line_length = 79

--- a/tests/keys/__init__.py
+++ b/tests/keys/__init__.py
@@ -21,6 +21,7 @@ def load_hmac_key():
 
 try:
     from cryptography.hazmat.primitives.asymmetric import ec
+
     from jwt.algorithms import RSAAlgorithm
 
     has_crypto = True

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -12,12 +12,13 @@ from .utils import key_path
 
 try:
     from jwt.algorithms import (
-        RSAAlgorithm,
         ECAlgorithm,
-        RSAPSSAlgorithm,
         Ed25519Algorithm,
+        RSAAlgorithm,
+        RSAPSSAlgorithm,
     )
-    from .keys import load_rsa_pub_key, load_ec_pub_key_p_521
+
+    from .keys import load_ec_pub_key_p_521, load_rsa_pub_key
 
     has_crypto = True
 except ImportError:


### PR DESCRIPTION
With isort 5, asottile/seed-isort-config is deprecated and unnecessary.

The official isort main repo now has a pre-commit hook file.

isort is now better at recognizing first party and third party packages.

isort can now handle imports inside blocks, files have been updated.

isort now supports "profiles" for simpler configuration.