### PR TITLE
Remove unused argument "verify" from PyJWS.decode()

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -133,7 +133,6 @@ class PyJWS:
         self,
         jwt,  # type: str
         key="",  # type: str
-        verify=True,  # type: bool
         algorithms=None,  # type: List[str]
         options=None,  # type: Dict
         complete=False,  # type: bool


### PR DESCRIPTION
The method signature of PyJWT.decode() now matches the parent
PyJWS.decode().