### PR TITLE
Update typing syntax and usage for Python 3.6+

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -1,6 +1,7 @@
 import binascii
 import json
 from collections.abc import Mapping
+from typing import Dict, List, Optional, Type, Union
 
 from .algorithms import requires_cryptography  # NOQA
 from .algorithms import Algorithm, get_default_algorithms, has_crypto
@@ -11,12 +12,6 @@ from .exceptions import (
     InvalidTokenError,
 )
 from .utils import base64url_decode, base64url_encode, force_bytes, merge_dict
-
-try:
-    # import required by mypy to perform type checking, not used for normal execution
-    from typing import Callable, Dict, List, Optional, Type, Union  # NOQA
-except ImportError:
-    pass
 
 
 class PyJWS:
@@ -79,11 +74,11 @@ class PyJWS:
 
     def encode(
         self,
-        payload,  # type: Union[Dict, bytes]
-        key,  # type: str
-        algorithm="HS256",  # type: str
-        headers=None,  # type: Optional[Dict]
-        json_encoder=None,  # type: Optional[Type[json.JSONEncoder]]
+        payload: Union[Dict, bytes],
+        key: str,
+        algorithm: str = "HS256",
+        headers: Optional[Dict] = None,
+        json_encoder: Optional[Type[json.JSONEncoder]] = None,
     ):
         segments = []
 
@@ -131,11 +126,11 @@ class PyJWS:
 
     def decode(
         self,
-        jwt,  # type: str
-        key="",  # type: str
-        algorithms=None,  # type: List[str]
-        options=None,  # type: Dict
-        complete=False,  # type: bool
+        jwt: str,
+        key: str = "",
+        algorithms: List[str] = None,
+        options: Dict = None,
+        complete: bool = False,
         **kwargs
     ):
 

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -2,6 +2,7 @@ import json
 from calendar import timegm
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Type, Union
 
 from .algorithms import Algorithm, get_default_algorithms  # NOQA
 from .api_jws import PyJWS
@@ -16,19 +17,12 @@ from .exceptions import (
 )
 from .utils import merge_dict
 
-try:
-    # import required by mypy to perform type checking, not used for normal execution
-    from typing import Any, Callable, Dict, List, Optional, Type, Union  # NOQA
-except ImportError:
-    pass
-
 
 class PyJWT(PyJWS):
     header_type = "JWT"
 
     @staticmethod
-    def _get_default_options():
-        # type: () -> Dict[str, Union[bool, List[str]]]
+    def _get_default_options() -> Dict[str, Union[bool, List[str]]]:
         return {
             "verify_signature": True,
             "verify_exp": True,
@@ -41,11 +35,11 @@ class PyJWT(PyJWS):
 
     def encode(
         self,
-        payload,  # type: Union[Dict, bytes]
-        key,  # type: str
-        algorithm="HS256",  # type: str
-        headers=None,  # type: Optional[Dict]
-        json_encoder=None,  # type: Optional[Type[json.JSONEncoder]]
+        payload: Union[Dict, bytes],
+        key: str,
+        algorithm: str = "HS256",
+        headers: Optional[Dict] = None,
+        json_encoder: Optional[Type[json.JSONEncoder]] = None,
     ):
         # Check that we get a mapping
         if not isinstance(payload, Mapping):
@@ -60,7 +54,7 @@ class PyJWT(PyJWS):
             if isinstance(payload.get(time_claim), datetime):
                 payload[time_claim] = timegm(
                     payload[time_claim].utctimetuple()
-                )  # type: ignore
+                )
 
         json_payload = json.dumps(
             payload, separators=(",", ":"), cls=json_encoder
@@ -72,13 +66,13 @@ class PyJWT(PyJWS):
 
     def decode(
         self,
-        jwt,  # type: str
-        key="",  # type: str
-        algorithms=None,  # type: List[str]
-        options=None,  # type: Dict
-        complete=False,  # type: bool
+        jwt: str,
+        key: str = "",
+        algorithms: List[str] = None,
+        options: Dict = None,
+        complete: bool = False,
         **kwargs
-    ):  # type: (...) -> Dict[str, Any]
+    ) -> Dict[str, Any]:
 
         if options is None:
             options = {"verify_signature": True}

--- a/jwt/help.py
+++ b/jwt/help.py
@@ -5,7 +5,7 @@ import sys
 from . import __version__ as pyjwt_version
 
 try:
-    import cryptography  # type: ignore
+    import cryptography
 except ImportError:
     cryptography = None  # type: ignore
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,8 +30,13 @@ classifiers =
     Topic :: Utilities
 
 [options]
+zip_safe = false
+include_package_data = true
 python_requires = >=3.6
 packages = find:
+
+[options.package_data]
+* = py.typed
 
 [options.extras_require]
 docs =
@@ -61,3 +66,8 @@ jwks-client =
 exclude =
     tests
     tests.*
+
+[mypy]
+python_version = 3.6
+ignore_missing_imports = true
+warn_unused_ignores = true

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ commands =
 [testenv:typing]
 basepython = python3.8
 extras = dev
-commands = mypy --ignore-missing-imports jwt
+commands = mypy jwt
 
 
 [testenv:lint]


### PR DESCRIPTION
Now that Python 2 is not supported, can move away from type comments to
type annotation 🎉.

The typing module is always available, so remove the guards.

Specify the supported Python in the mypy configuration.

Move other mypy configurations to one place. This way, whether tox is
used or not, the same mypy errors appear.

Distribute and install PEP-561 compliant py.typed file. When PyJWT is a
imported as a library, this tells mypy to use the provided type
annotations rather than going through typeshed. This way, the types are
always up to date when running mypy.

Remove outdated ignores since dropping Python 2.