### PR TITLE
Run pyupgrade to simplify code and use Python 3.6 syntax

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -468,7 +468,7 @@ if has_crypto:  # noqa: C901
                         "Coords should be 66 bytes for curve P-521"
                     )
             else:
-                raise InvalidKeyError("Invalid curve: {}".format(curve))
+                raise InvalidKeyError(f"Invalid curve: {curve}")
 
             public_numbers = ec.EllipticCurvePublicNumbers(
                 x=int_from_bytes(x, "big"),

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -174,9 +174,7 @@ class PyJWS:
             jwt = jwt.encode("utf-8")
 
         if not isinstance(jwt, bytes):
-            raise DecodeError(
-                "Invalid token type. Token must be a {}".format(bytes)
-            )
+            raise DecodeError(f"Invalid token type. Token must be a {bytes}")
 
         try:
             signing_input, crypto_segment = jwt.rsplit(b".", 1)

--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -53,7 +53,7 @@ class PyJWKClient:
 
         if not signing_key:
             raise PyJWKClientError(
-                'Unable to find a signing key that matches: "{}"'.format(kid)
+                f'Unable to find a signing key that matches: "{kid}"'
             )
 
         return signing_key

--- a/tests/keys/__init__.py
+++ b/tests/keys/__init__.py
@@ -13,7 +13,7 @@ def decode_value(val):
 
 
 def load_hmac_key():
-    with open(os.path.join(BASE_PATH, "jwk_hmac.json"), "r") as infile:
+    with open(os.path.join(BASE_PATH, "jwk_hmac.json")) as infile:
         keyobj = json.load(infile)
 
     return base64url_decode(force_bytes(keyobj["k"]))
@@ -31,15 +31,15 @@ except ImportError:
 if has_crypto:
 
     def load_rsa_key():
-        with open(os.path.join(BASE_PATH, "jwk_rsa_key.json"), "r") as infile:
+        with open(os.path.join(BASE_PATH, "jwk_rsa_key.json")) as infile:
             return RSAAlgorithm.from_jwk(infile.read())
 
     def load_rsa_pub_key():
-        with open(os.path.join(BASE_PATH, "jwk_rsa_pub.json"), "r") as infile:
+        with open(os.path.join(BASE_PATH, "jwk_rsa_pub.json")) as infile:
             return RSAAlgorithm.from_jwk(infile.read())
 
     def load_ec_key():
-        with open(os.path.join(BASE_PATH, "jwk_ec_key.json"), "r") as infile:
+        with open(os.path.join(BASE_PATH, "jwk_ec_key.json")) as infile:
             keyobj = json.load(infile)
 
         return ec.EllipticCurvePrivateNumbers(
@@ -48,9 +48,7 @@ if has_crypto:
         )
 
     def load_ec_pub_key_p_521():
-        with open(
-            os.path.join(BASE_PATH, "jwk_ec_pub_P-521.json"), "r"
-        ) as infile:
+        with open(os.path.join(BASE_PATH, "jwk_ec_pub_P-521.json")) as infile:
             keyobj = json.load(infile)
 
         return ec.EllipticCurvePublicNumbers(

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -80,41 +80,41 @@ class TestAlgorithms:
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
 
         with pytest.raises(InvalidKeyError):
-            with open(key_path("testkey2_rsa.pub.pem"), "r") as keyfile:
+            with open(key_path("testkey2_rsa.pub.pem")) as keyfile:
                 algo.prepare_key(keyfile.read())
 
     def test_hmac_should_throw_exception_if_key_is_x509_certificate(self):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
 
         with pytest.raises(InvalidKeyError):
-            with open(key_path("testkey_rsa.cer"), "r") as keyfile:
+            with open(key_path("testkey_rsa.cer")) as keyfile:
                 algo.prepare_key(keyfile.read())
 
     def test_hmac_should_throw_exception_if_key_is_ssh_public_key(self):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
 
         with pytest.raises(InvalidKeyError):
-            with open(key_path("testkey_rsa.pub"), "r") as keyfile:
+            with open(key_path("testkey_rsa.pub")) as keyfile:
                 algo.prepare_key(keyfile.read())
 
     def test_hmac_should_throw_exception_if_key_is_x509_cert(self):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
 
         with pytest.raises(InvalidKeyError):
-            with open(key_path("testkey2_rsa.pub.pem"), "r") as keyfile:
+            with open(key_path("testkey2_rsa.pub.pem")) as keyfile:
                 algo.prepare_key(keyfile.read())
 
     def test_hmac_should_throw_exception_if_key_is_pkcs1_pem_public(self):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
 
         with pytest.raises(InvalidKeyError):
-            with open(key_path("testkey_pkcs1.pub.pem"), "r") as keyfile:
+            with open(key_path("testkey_pkcs1.pub.pem")) as keyfile:
                 algo.prepare_key(keyfile.read())
 
     def test_hmac_jwk_should_parse_and_verify(self):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
 
-        with open(key_path("jwk_hmac.json"), "r") as keyfile:
+        with open(key_path("jwk_hmac.json")) as keyfile:
             key = algo.from_jwk(keyfile.read())
 
         signature = algo.sign(b"Hello World!", key)
@@ -129,7 +129,7 @@ class TestAlgorithms:
     def test_hmac_from_jwk_should_raise_exception_if_not_hmac_key(self):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
 
-        with open(key_path("jwk_rsa_pub.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_pub.json")) as keyfile:
             with pytest.raises(InvalidKeyError):
                 algo.from_jwk(keyfile.read())
 
@@ -139,7 +139,7 @@ class TestAlgorithms:
     def test_rsa_should_parse_pem_public_key(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("testkey2_rsa.pub.pem"), "r") as pem_key:
+        with open(key_path("testkey2_rsa.pub.pem")) as pem_key:
             algo.prepare_key(pem_key.read())
 
     @pytest.mark.skipif(
@@ -157,7 +157,7 @@ class TestAlgorithms:
     def test_rsa_should_accept_unicode_key(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("testkey_rsa.priv"), "r") as rsa_key:
+        with open(key_path("testkey_rsa.priv")) as rsa_key:
             algo.prepare_key(force_unicode(rsa_key.read()))
 
     @pytest.mark.skipif(
@@ -190,7 +190,7 @@ class TestAlgorithms:
 
         sig += force_bytes("123")  # Signature is now invalid
 
-        with open(key_path("testkey_rsa.pub"), "r") as keyfile:
+        with open(key_path("testkey_rsa.pub")) as keyfile:
             pub_key = algo.prepare_key(keyfile.read())
 
         result = algo.verify(message, pub_key, sig)
@@ -208,14 +208,10 @@ class TestAlgorithms:
         for (curve, hash) in tests.items():
             algo = ECAlgorithm(hash)
 
-            with open(
-                key_path("jwk_ec_pub_{}.json".format(curve)), "r"
-            ) as keyfile:
+            with open(key_path(f"jwk_ec_pub_{curve}.json")) as keyfile:
                 pub_key = algo.from_jwk(keyfile.read())
 
-            with open(
-                key_path("jwk_ec_key_{}.json".format(curve)), "r"
-            ) as keyfile:
+            with open(key_path(f"jwk_ec_key_{curve}.json")) as keyfile:
                 priv_key = algo.from_jwk(keyfile.read())
 
             signature = algo.sign(force_bytes("Hello World!"), priv_key)
@@ -290,10 +286,10 @@ class TestAlgorithms:
     def test_rsa_jwk_public_and_private_keys_should_parse_and_verify(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("jwk_rsa_pub.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_pub.json")) as keyfile:
             pub_key = algo.from_jwk(keyfile.read())
 
-        with open(key_path("jwk_rsa_key.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_key.json")) as keyfile:
             priv_key = algo.from_jwk(keyfile.read())
 
         signature = algo.sign(force_bytes("Hello World!"), priv_key)
@@ -305,7 +301,7 @@ class TestAlgorithms:
     def test_rsa_private_key_to_jwk_works_with_from_jwk(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("testkey_rsa.priv"), "r") as rsa_key:
+        with open(key_path("testkey_rsa.priv")) as rsa_key:
             orig_key = algo.prepare_key(force_unicode(rsa_key.read()))
 
         parsed_key = algo.from_jwk(algo.to_jwk(orig_key))
@@ -321,7 +317,7 @@ class TestAlgorithms:
     def test_rsa_public_key_to_jwk_works_with_from_jwk(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("testkey_rsa.pub"), "r") as rsa_key:
+        with open(key_path("testkey_rsa.pub")) as rsa_key:
             orig_key = algo.prepare_key(force_unicode(rsa_key.read()))
 
         parsed_key = algo.from_jwk(algo.to_jwk(orig_key))
@@ -333,7 +329,7 @@ class TestAlgorithms:
     def test_rsa_jwk_private_key_with_other_primes_is_invalid(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("jwk_rsa_key.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_key.json")) as keyfile:
             with pytest.raises(InvalidKeyError):
                 keydata = json.loads(keyfile.read())
                 keydata["oth"] = []
@@ -346,7 +342,7 @@ class TestAlgorithms:
     def test_rsa_jwk_private_key_with_missing_values_is_invalid(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("jwk_rsa_key.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_key.json")) as keyfile:
             with pytest.raises(InvalidKeyError):
                 keydata = json.loads(keyfile.read())
                 del keydata["p"]
@@ -359,7 +355,7 @@ class TestAlgorithms:
     def test_rsa_jwk_private_key_can_recover_prime_factors(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("jwk_rsa_key.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_key.json")) as keyfile:
             keybytes = keyfile.read()
             control_key = algo.from_jwk(keybytes).private_numbers()
 
@@ -383,7 +379,7 @@ class TestAlgorithms:
     def test_rsa_jwk_private_key_with_missing_required_values_is_invalid(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("jwk_rsa_key.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_key.json")) as keyfile:
             with pytest.raises(InvalidKeyError):
                 keydata = json.loads(keyfile.read())
                 del keydata["p"]
@@ -410,7 +406,7 @@ class TestAlgorithms:
     def test_rsa_to_jwk_returns_correct_values_for_public_key(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("testkey_rsa.pub"), "r") as keyfile:
+        with open(key_path("testkey_rsa.pub")) as keyfile:
             pub_key = algo.prepare_key(keyfile.read())
 
         key = algo.to_jwk(pub_key)
@@ -436,7 +432,7 @@ class TestAlgorithms:
     def test_rsa_to_jwk_returns_correct_values_for_private_key(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("testkey_rsa.priv"), "r") as keyfile:
+        with open(key_path("testkey_rsa.priv")) as keyfile:
             priv_key = algo.prepare_key(keyfile.read())
 
         key = algo.to_jwk(priv_key)
@@ -504,7 +500,7 @@ class TestAlgorithms:
     def test_rsa_from_jwk_raises_exception_on_invalid_key(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("jwk_hmac.json"), "r") as keyfile:
+        with open(key_path("jwk_hmac.json")) as keyfile:
             with pytest.raises(InvalidKeyError):
                 algo.from_jwk(keyfile.read())
 
@@ -532,7 +528,7 @@ class TestAlgorithms:
     def test_ec_should_accept_ssh_public_key_bytes(self):
         algo = ECAlgorithm(ECAlgorithm.SHA256)
 
-        with open(key_path("testkey_ec_ssh.pub"), "r") as ec_key:
+        with open(key_path("testkey_ec_ssh.pub")) as ec_key:
             algo.prepare_key(ec_key.read())
 
     @pytest.mark.skipif(
@@ -554,7 +550,7 @@ class TestAlgorithms:
             )
         )
 
-        with open(key_path("testkey_ec.pub"), "r") as keyfile:
+        with open(key_path("testkey_ec.pub")) as keyfile:
             pub_key = algo.prepare_key(keyfile.read())
 
         result = algo.verify(message, pub_key, sig)
@@ -570,7 +566,7 @@ class TestAlgorithms:
 
         sig = base64.b64decode(force_bytes("AC+m4Jf/xI3guAC6w0w3"))
 
-        with open(key_path("testkey_ec.pub"), "r") as keyfile:
+        with open(key_path("testkey_ec.pub")) as keyfile:
             pub_key = algo.prepare_key(keyfile.read())
 
         result = algo.verify(message, pub_key, sig)
@@ -584,11 +580,11 @@ class TestAlgorithms:
 
         message = force_bytes("Hello World!")
 
-        with open(key_path("testkey_rsa.priv"), "r") as keyfile:
+        with open(key_path("testkey_rsa.priv")) as keyfile:
             priv_key = algo.prepare_key(keyfile.read())
             sig = algo.sign(message, priv_key)
 
-        with open(key_path("testkey_rsa.pub"), "r") as keyfile:
+        with open(key_path("testkey_rsa.pub")) as keyfile:
             pub_key = algo.prepare_key(keyfile.read())
 
         result = algo.verify(message, pub_key, sig)
@@ -615,7 +611,7 @@ class TestAlgorithms:
 
         jwt_sig += force_bytes("123")  # Signature is now invalid
 
-        with open(key_path("testkey_rsa.pub"), "r") as keyfile:
+        with open(key_path("testkey_rsa.pub")) as keyfile:
             jwt_pub_key = algo.prepare_key(keyfile.read())
 
         result = algo.verify(jwt_message, jwt_pub_key, jwt_sig)

--- a/tests/test_api_jwk.py
+++ b/tests/test_api_jwk.py
@@ -22,7 +22,7 @@ class TestPyJWK:
     def test_should_load_key_from_jwk_data_dict(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("jwk_rsa_pub.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_pub.json")) as keyfile:
             pub_key = algo.from_jwk(keyfile.read())
 
         key_data_str = algo.to_jwk(pub_key)
@@ -46,7 +46,7 @@ class TestPyJWK:
     def test_should_load_key_from_jwk_data_json_string(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("jwk_rsa_pub.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_pub.json")) as keyfile:
             pub_key = algo.from_jwk(keyfile.read())
 
         key_data_str = algo.to_jwk(pub_key)
@@ -72,7 +72,7 @@ class TestPyJWKSet:
     def test_should_load_keys_from_jwk_data_dict(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("jwk_rsa_pub.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_pub.json")) as keyfile:
             pub_key = algo.from_jwk(keyfile.read())
 
         key_data_str = algo.to_jwk(pub_key)
@@ -97,7 +97,7 @@ class TestPyJWKSet:
     def test_should_load_keys_from_jwk_data_json_string(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
-        with open(key_path("jwk_rsa_pub.json"), "r") as keyfile:
+        with open(key_path("jwk_rsa_pub.json")) as keyfile:
             pub_key = algo.from_jwk(keyfile.read())
 
         key_data_str = algo.to_jwk(pub_key)

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -222,7 +222,7 @@ class TestJWS:
     )
     def test_decodes_valid_es384_jws(self, jws):
         example_payload = {"hello": "world"}
-        with open("tests/keys/testkey_ec.pub", "r") as fp:
+        with open("tests/keys/testkey_ec.pub") as fp:
             example_pubkey = fp.read()
         example_jws = (
             b"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."
@@ -245,7 +245,7 @@ class TestJWS:
     )
     def test_decodes_valid_rs384_jws(self, jws):
         example_payload = {"hello": "world"}
-        with open("tests/keys/testkey_rsa.pub", "r") as fp:
+        with open("tests/keys/testkey_rsa.pub") as fp:
             example_pubkey = fp.read()
         example_jws = (
             b"eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9"
@@ -491,23 +491,23 @@ class TestJWS:
     )
     def test_encode_decode_with_rsa_sha256(self, jws, payload):
         # PEM-formatted RSA key
-        with open("tests/keys/testkey_rsa.priv", "r") as rsa_priv_file:
+        with open("tests/keys/testkey_rsa.priv") as rsa_priv_file:
             priv_rsakey = load_pem_private_key(
                 force_bytes(rsa_priv_file.read()), password=None
             )
             jws_message = jws.encode(payload, priv_rsakey, algorithm="RS256")
 
-        with open("tests/keys/testkey_rsa.pub", "r") as rsa_pub_file:
+        with open("tests/keys/testkey_rsa.pub") as rsa_pub_file:
             pub_rsakey = load_ssh_public_key(force_bytes(rsa_pub_file.read()))
 
             jws.decode(jws_message, pub_rsakey, algorithms=["RS256"])
 
         # string-formatted key
-        with open("tests/keys/testkey_rsa.priv", "r") as rsa_priv_file:
+        with open("tests/keys/testkey_rsa.priv") as rsa_priv_file:
             priv_rsakey = rsa_priv_file.read()
             jws_message = jws.encode(payload, priv_rsakey, algorithm="RS256")
 
-        with open("tests/keys/testkey_rsa.pub", "r") as rsa_pub_file:
+        with open("tests/keys/testkey_rsa.pub") as rsa_pub_file:
             pub_rsakey = rsa_pub_file.read()
             jws.decode(jws_message, pub_rsakey, algorithms=["RS256"])
 
@@ -516,22 +516,22 @@ class TestJWS:
     )
     def test_encode_decode_with_rsa_sha384(self, jws, payload):
         # PEM-formatted RSA key
-        with open("tests/keys/testkey_rsa.priv", "r") as rsa_priv_file:
+        with open("tests/keys/testkey_rsa.priv") as rsa_priv_file:
             priv_rsakey = load_pem_private_key(
                 force_bytes(rsa_priv_file.read()), password=None
             )
             jws_message = jws.encode(payload, priv_rsakey, algorithm="RS384")
 
-        with open("tests/keys/testkey_rsa.pub", "r") as rsa_pub_file:
+        with open("tests/keys/testkey_rsa.pub") as rsa_pub_file:
             pub_rsakey = load_ssh_public_key(force_bytes(rsa_pub_file.read()))
             jws.decode(jws_message, pub_rsakey, algorithms=["RS384"])
 
         # string-formatted key
-        with open("tests/keys/testkey_rsa.priv", "r") as rsa_priv_file:
+        with open("tests/keys/testkey_rsa.priv") as rsa_priv_file:
             priv_rsakey = rsa_priv_file.read()
             jws_message = jws.encode(payload, priv_rsakey, algorithm="RS384")
 
-        with open("tests/keys/testkey_rsa.pub", "r") as rsa_pub_file:
+        with open("tests/keys/testkey_rsa.pub") as rsa_pub_file:
             pub_rsakey = rsa_pub_file.read()
             jws.decode(jws_message, pub_rsakey, algorithms=["RS384"])
 
@@ -540,22 +540,22 @@ class TestJWS:
     )
     def test_encode_decode_with_rsa_sha512(self, jws, payload):
         # PEM-formatted RSA key
-        with open("tests/keys/testkey_rsa.priv", "r") as rsa_priv_file:
+        with open("tests/keys/testkey_rsa.priv") as rsa_priv_file:
             priv_rsakey = load_pem_private_key(
                 force_bytes(rsa_priv_file.read()), password=None
             )
             jws_message = jws.encode(payload, priv_rsakey, algorithm="RS512")
 
-        with open("tests/keys/testkey_rsa.pub", "r") as rsa_pub_file:
+        with open("tests/keys/testkey_rsa.pub") as rsa_pub_file:
             pub_rsakey = load_ssh_public_key(force_bytes(rsa_pub_file.read()))
             jws.decode(jws_message, pub_rsakey, algorithms=["RS512"])
 
         # string-formatted key
-        with open("tests/keys/testkey_rsa.priv", "r") as rsa_priv_file:
+        with open("tests/keys/testkey_rsa.priv") as rsa_priv_file:
             priv_rsakey = rsa_priv_file.read()
             jws_message = jws.encode(payload, priv_rsakey, algorithm="RS512")
 
-        with open("tests/keys/testkey_rsa.pub", "r") as rsa_pub_file:
+        with open("tests/keys/testkey_rsa.pub") as rsa_pub_file:
             pub_rsakey = rsa_pub_file.read()
             jws.decode(jws_message, pub_rsakey, algorithms=["RS512"])
 
@@ -584,22 +584,22 @@ class TestJWS:
     )
     def test_encode_decode_with_ecdsa_sha256(self, jws, payload):
         # PEM-formatted EC key
-        with open("tests/keys/testkey_ec.priv", "r") as ec_priv_file:
+        with open("tests/keys/testkey_ec.priv") as ec_priv_file:
             priv_eckey = load_pem_private_key(
                 force_bytes(ec_priv_file.read()), password=None
             )
             jws_message = jws.encode(payload, priv_eckey, algorithm="ES256")
 
-        with open("tests/keys/testkey_ec.pub", "r") as ec_pub_file:
+        with open("tests/keys/testkey_ec.pub") as ec_pub_file:
             pub_eckey = load_pem_public_key(force_bytes(ec_pub_file.read()))
             jws.decode(jws_message, pub_eckey, algorithms=["ES256"])
 
         # string-formatted key
-        with open("tests/keys/testkey_ec.priv", "r") as ec_priv_file:
+        with open("tests/keys/testkey_ec.priv") as ec_priv_file:
             priv_eckey = ec_priv_file.read()
             jws_message = jws.encode(payload, priv_eckey, algorithm="ES256")
 
-        with open("tests/keys/testkey_ec.pub", "r") as ec_pub_file:
+        with open("tests/keys/testkey_ec.pub") as ec_pub_file:
             pub_eckey = ec_pub_file.read()
             jws.decode(jws_message, pub_eckey, algorithms=["ES256"])
 
@@ -609,22 +609,22 @@ class TestJWS:
     def test_encode_decode_with_ecdsa_sha384(self, jws, payload):
 
         # PEM-formatted EC key
-        with open("tests/keys/testkey_ec.priv", "r") as ec_priv_file:
+        with open("tests/keys/testkey_ec.priv") as ec_priv_file:
             priv_eckey = load_pem_private_key(
                 force_bytes(ec_priv_file.read()), password=None
             )
             jws_message = jws.encode(payload, priv_eckey, algorithm="ES384")
 
-        with open("tests/keys/testkey_ec.pub", "r") as ec_pub_file:
+        with open("tests/keys/testkey_ec.pub") as ec_pub_file:
             pub_eckey = load_pem_public_key(force_bytes(ec_pub_file.read()))
             jws.decode(jws_message, pub_eckey, algorithms=["ES384"])
 
         # string-formatted key
-        with open("tests/keys/testkey_ec.priv", "r") as ec_priv_file:
+        with open("tests/keys/testkey_ec.priv") as ec_priv_file:
             priv_eckey = ec_priv_file.read()
             jws_message = jws.encode(payload, priv_eckey, algorithm="ES384")
 
-        with open("tests/keys/testkey_ec.pub", "r") as ec_pub_file:
+        with open("tests/keys/testkey_ec.pub") as ec_pub_file:
             pub_eckey = ec_pub_file.read()
             jws.decode(jws_message, pub_eckey, algorithms=["ES384"])
 
@@ -633,22 +633,22 @@ class TestJWS:
     )
     def test_encode_decode_with_ecdsa_sha512(self, jws, payload):
         # PEM-formatted EC key
-        with open("tests/keys/testkey_ec.priv", "r") as ec_priv_file:
+        with open("tests/keys/testkey_ec.priv") as ec_priv_file:
             priv_eckey = load_pem_private_key(
                 force_bytes(ec_priv_file.read()), password=None
             )
             jws_message = jws.encode(payload, priv_eckey, algorithm="ES512")
 
-        with open("tests/keys/testkey_ec.pub", "r") as ec_pub_file:
+        with open("tests/keys/testkey_ec.pub") as ec_pub_file:
             pub_eckey = load_pem_public_key(force_bytes(ec_pub_file.read()))
             jws.decode(jws_message, pub_eckey, algorithms=["ES512"])
 
         # string-formatted key
-        with open("tests/keys/testkey_ec.priv", "r") as ec_priv_file:
+        with open("tests/keys/testkey_ec.priv") as ec_priv_file:
             priv_eckey = ec_priv_file.read()
             jws_message = jws.encode(payload, priv_eckey, algorithm="ES512")
 
-        with open("tests/keys/testkey_ec.pub", "r") as ec_pub_file:
+        with open("tests/keys/testkey_ec.pub") as ec_pub_file:
             pub_eckey = ec_pub_file.read()
             jws.decode(jws_message, pub_eckey, algorithms=["ES512"])
 
@@ -687,7 +687,7 @@ class TestJWS:
             def default(self, o):
                 if isinstance(o, Decimal):
                     return "it worked"
-                return super(CustomJSONEncoder, self).default(o)
+                return super().default(o)
 
         data = {"some_decimal": Decimal("2.2")}
 

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -220,7 +220,7 @@ class TestJWT:
     )
     def test_decodes_valid_es256_jwt(self, jwt):
         example_payload = {"hello": "world"}
-        with open("tests/keys/testkey_ec.pub", "r") as fp:
+        with open("tests/keys/testkey_ec.pub") as fp:
             example_pubkey = fp.read()
         example_jwt = (
             b"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."
@@ -242,7 +242,7 @@ class TestJWT:
     )
     def test_decodes_valid_rs384_jwt(self, jwt):
         example_payload = {"hello": "world"}
-        with open("tests/keys/testkey_rsa.pub", "r") as fp:
+        with open("tests/keys/testkey_rsa.pub") as fp:
             example_pubkey = fp.read()
         example_jwt = (
             b"eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9"
@@ -556,7 +556,7 @@ class TestJWT:
             def default(self, o):
                 if isinstance(o, Decimal):
                     return "it worked"
-                return super(CustomJSONEncoder, self).default(o)
+                return super().default(o)
 
         data = {"some_decimal": Decimal("2.2")}
 


### PR DESCRIPTION
pyugrade is a command line tool to automatically update Python syntax to
modern usage and patterns. For additional details, see:

https://github.com/asottile/pyupgrade

Changes made by the tool:

- Use short Python3 super() syntax.
- Use f-strings when they are simple and more readable.
- Drop Python 2 u prefix from strings.
- Drop "r" argument from open(). It is the default and so specifying it is
  unnecessary.