### PR TITLE
Drop unknown pytest config option: strict

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [pytest]
-strict = true
 addopts = -ra
 testpaths = tests
 filterwarnings =


### PR DESCRIPTION
Fixes the warning when running tests:

    .tox/.../lib/python3.9/site-packages/_pytest/config/__init__.py:1233
      .../pyjwt/.tox/.../lib/python3.9/site-packages/_pytest/config/__init__.py:1233: PytestConfigWarning: Unknown config option: strict

        self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")