### PR TITLE
Remove "Command line" sections from docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,22 +47,6 @@ Usage
     >>> jwt.decode(encoded, 'secret', algorithms=['HS256'])
     {'some': 'payload'}
 
-
-Command line
-------------
-
-Usage::
-
-    pyjwt [options] INPUT
-
-Decoding examples::
-
-    pyjwt --key=secret decode TOKEN
-    pyjwt decode --no-verify TOKEN
-
-See more options executing ``pyjwt --help``.
-
-
 Documentation
 -------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,20 +40,6 @@ Example Usage
 
 See :doc:`Usage Examples <usage>` for more examples.
 
-Command line
-------------
-
-Usage::
-
-    pyjwt [options] INPUT
-
-Decoding examples::
-
-    pyjwt --key=secret decode TOKEN
-    pyjwt decode --no-verify TOKEN
-
-See more options executing ``pyjwt --help``.
-
 Index
 -----
 


### PR DESCRIPTION
The CLI entry point was removed in commit
8a14f087c285bbe2f6e85ba4818e6c620b708d5d.