### PR TITLE
Remove unnecessary Unicode decoding before json.loads()

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -190,7 +190,7 @@ class PyJWS:
             raise DecodeError("Invalid header padding") from err
 
         try:
-            header = json.loads(header_data.decode("utf-8"))
+            header = json.loads(header_data)
         except ValueError as e:
             raise DecodeError("Invalid header string: %s" % e) from e
 

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -95,9 +95,9 @@ class PyJWT(PyJWS):
 
         try:
             if complete:
-                payload = json.loads(decoded["payload"].decode("utf-8"))
+                payload = json.loads(decoded["payload"])
             else:
-                payload = json.loads(decoded.decode("utf-8"))
+                payload = json.loads(decoded)
         except ValueError as e:
             raise DecodeError("Invalid payload string: %s" % e)
         if not isinstance(payload, dict):

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -232,7 +232,7 @@ class TestJWS:
         decoded_payload = jws.decode(
             example_jws, example_pubkey, algorithms=["ES256"]
         )
-        json_payload = json.loads(force_unicode(decoded_payload))
+        json_payload = json.loads(decoded_payload)
 
         assert json_payload == example_payload
 
@@ -262,7 +262,7 @@ class TestJWS:
         decoded_payload = jws.decode(
             example_jws, example_pubkey, algorithms=["RS384"]
         )
-        json_payload = json.loads(force_unicode(decoded_payload))
+        json_payload = json.loads(decoded_payload)
 
         assert json_payload == example_payload
 
@@ -699,7 +699,7 @@ class TestJWS:
         )
 
         header = force_bytes(force_unicode(token).split(".")[0])
-        header = json.loads(force_unicode(base64url_decode(header)))
+        header = json.loads(base64url_decode(header))
 
         assert "some_decimal" in header
         assert header["some_decimal"] == "it worked"


### PR DESCRIPTION
Since Python 3.6, json.loads() accepts both Unicode and byte strings.

https://docs.python.org/3/library/json.html#json.loads

> Changed in version 3.6: s can now be of type bytes or bytearray. The
> input encoding should be UTF-8, UTF-16 or UTF-32.