### PR TITLE
Remove unnecessary force_bytes() calls priot to base64url_decode()

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -442,8 +442,8 @@ if has_crypto:  # noqa: C901
             if "x" not in obj or "y" not in obj:
                 raise InvalidKeyError("Not an Elliptic curve key")
 
-            x = base64url_decode(force_bytes(obj.get("x")))
-            y = base64url_decode(force_bytes(obj.get("y")))
+            x = base64url_decode(obj.get("x"))
+            y = base64url_decode(obj.get("y"))
 
             curve = obj.get("crv")
             if curve == "P-256":
@@ -479,7 +479,7 @@ if has_crypto:  # noqa: C901
             if "d" not in obj:
                 return public_numbers.public_key()
 
-            d = base64url_decode(force_bytes(obj.get("d")))
+            d = base64url_decode(obj.get("d"))
             if len(d) != len(x):
                 raise InvalidKeyError(
                     "D should be {} bytes for curve {}", len(x), curve

--- a/tests/keys/__init__.py
+++ b/tests/keys/__init__.py
@@ -1,14 +1,14 @@
 import json
 import os
 
-from jwt.utils import base64url_decode, force_bytes
+from jwt.utils import base64url_decode
 from tests.utils import int_from_bytes
 
 BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 
 
 def decode_value(val):
-    decoded = base64url_decode(force_bytes(val))
+    decoded = base64url_decode(val)
     return int_from_bytes(decoded, "big")
 
 
@@ -16,7 +16,7 @@ def load_hmac_key():
     with open(os.path.join(BASE_PATH, "jwk_hmac.json"), "r") as infile:
         keyobj = json.load(infile)
 
-    return base64url_decode(force_bytes(keyobj["k"]))
+    return base64url_decode(keyobj["k"])
 
 
 try:


### PR DESCRIPTION
The first line of base64url_decode() is:

    if isinstance(input, str):
        input = input.encode("ascii")

It therefore accepts either str or bytes. Don't bother coercing to bytes
at the call site.