### PR TITLE
Remove deprecated arguments from docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,16 +19,12 @@ API Reference
     :rtype: str
     :returns: a JSON Web Token
 
-.. function:: decode(jwt, key="", verify=True, algorithms=None, options=None, audience=None, issuer=None, leeway=0, verify_expiration=True)
+.. function:: decode(jwt, key="", algorithms=None, options=None, audience=None, issuer=None, leeway=0)
 
     Verify the ``jwt`` token signature and return the token claims.
 
     :param str|bytes jwt: the token to be decoded
     :param str key: the key suitable for the allowed algorithm
-    :param bool verify: whether to verify the JWT signature, on by default
-
-        .. deprecated:: 1.5.1
-           to disable signature validation, use ``options=(verify_signature=False)``
 
     :param list algorithms: allowed algorithms, e.g. ``["ES256"]``
 
@@ -46,20 +42,10 @@ API Reference
         * ``verify_exp=False`` check that ``exp`` (expiration) claim value is OK
         * ``verify_iss=False`` check that ``iss`` (issuer) claim matches ``issuer``
         * ``verify_signature=True`` verify the JWT cryptographic signature
-        * ``verify_expiration``
-
-            .. deprecated:: 1.2.0
-                Use ``verify_exp`` instead
-
 
     :param iterable audience: optional, the value for ``verify_aud`` check
     :param str issuer: optional, the value for ``verify_iss`` check
     :param int|float leeway: a time margin in seconds for the expiration check
-    :param bool verify_expiration:
-
-        .. deprecated:: 1.2.0
-            Use ``options=(verify_exp=...)`` instead
-
     :rtype: dict
     :returns: the JWT claims
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -54,8 +54,8 @@ Reading the Claimset without Validation
 ---------------------------------------
 
 If you wish to read the claimset of a JWT without performing validation of the
-signature or any of the registered claim names, you can set the ``verify``
-parameter to ``False``.
+signature or any of the registered claim names, you can set the
+``verify_signature`` option to ``False``.
 
 Note: It is generally ill-advised to use this functionality unless you
 clearly understand what you are doing. Without digital signature information,
@@ -63,7 +63,7 @@ the integrity or authenticity of the claimset cannot be trusted.
 
 .. code-block:: python
 
-    >>jwt.decode(encoded, verify=False)
+    >>jwt.decode(encoded, options={"verify_signature": False})
     {u'some': u'payload'}
 
 Reading Headers without Validation


### PR DESCRIPTION
They were removed from the code in
f690976596bb74221f5a81fc9afffd5609bc4e70.