### PR TITLE
Refactor jwt/jwks_client.py without requests dependency

### DIFF
--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -1,27 +1,18 @@
+import json
+import urllib.request
+
 from .api_jwk import PyJWKSet
 from .api_jwt import decode as decode_token
 from .exceptions import PyJWKClientError
 
-try:
-    import requests
-
-    has_requests = True
-except ImportError:
-    has_requests = False
-
 
 class PyJWKClient:
     def __init__(self, uri):
-        if not has_requests:
-            raise PyJWKClientError(
-                "Missing dependencies for `PyJWKClient`. Run `pip install pyjwt[jwks-client]` to install dependencies."
-            )
-
         self.uri = uri
 
     def fetch_data(self):
-        r = requests.get(self.uri)
-        return r.json()
+        with urllib.request.urlopen(self.uri) as response:
+            return json.load(response)
 
     def get_jwk_set(self):
         data = self.fetch_data()

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,6 @@ crypto =
 tests =
     pytest>=6.0.0,<7.0.0
     coverage[toml]==5.0.4
-    requests-mock>=1.7.0,<2.0.0
 dev =
     sphinx
     sphinx-rtd-theme
@@ -56,11 +55,8 @@ dev =
     cryptography>=2.6,<4.0.0
     pytest>=6.0.0,<7.0.0
     coverage[toml]==5.0.4
-    requests
     mypy
     pre-commit
-jwks-client =
-    requests
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Allows dropping a dependency that isn't very necessary.

The requests library was used for a single line of code. This same code
is just as easily expressible using the stdlib, thus alllows removing a
dependency.

Tests were adjusted to mock this new approach.