### PR TITLE
Replace int_from_bytes() with builtin int.from_bytes()

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -42,7 +42,6 @@ try:
         load_pem_public_key,
         load_ssh_public_key,
     )
-    from cryptography.utils import int_from_bytes
 
     has_crypto = True
 except ImportError:
@@ -471,8 +470,8 @@ if has_crypto:  # noqa: C901
                 raise InvalidKeyError(f"Invalid curve: {curve}")
 
             public_numbers = ec.EllipticCurvePublicNumbers(
-                x=int_from_bytes(x, "big"),
-                y=int_from_bytes(y, "big"),
+                x=int.from_bytes(x, byteorder="big"),
+                y=int.from_bytes(y, byteorder="big"),
                 curve=curve_obj,
             )
 
@@ -486,7 +485,7 @@ if has_crypto:  # noqa: C901
                 )
 
             return ec.EllipticCurvePrivateNumbers(
-                int_from_bytes(d, "big"), public_numbers
+                int.from_bytes(d, byteorder="big"), public_numbers
             ).private_key()
 
     class RSAPSSAlgorithm(RSAAlgorithm):

--- a/tests/keys/__init__.py
+++ b/tests/keys/__init__.py
@@ -2,14 +2,13 @@ import json
 import os
 
 from jwt.utils import base64url_decode
-from tests.utils import int_from_bytes
 
 BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 
 
 def decode_value(val):
     decoded = base64url_decode(val)
-    return int_from_bytes(decoded, "big")
+    return int.from_bytes(decoded, byteorder="big")
 
 
 def load_hmac_key():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,4 @@
 import os
-import struct
 from calendar import timegm
 from datetime import datetime
 
@@ -12,25 +11,3 @@ def key_path(key_name):
     return os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "keys", key_name
     )
-
-
-# Borrowed from `cryptography`
-if hasattr(int, "from_bytes"):
-    int_from_bytes = int.from_bytes
-else:
-
-    def int_from_bytes(data, byteorder, signed=False):
-        assert byteorder == "big"
-        assert not signed
-
-        if len(data) % 4 != 0:
-            data = (b"\x00" * (4 - (len(data) % 4))) + data
-
-        result = 0
-
-        while len(data) > 0:
-            (digit,) = struct.unpack(">I", data[:4])
-            result = (result << 32) + digit
-            data = data[4:]
-
-        return result


### PR DESCRIPTION
Follows upstream cryptography commit:
https://github.com/pyca/cryptography/commit/5528a3182fdd6ed1c44c126d451a87bcf39e79de

Since Python 3.2, this bytes to an int is a native feature.