### PR TITLE
Replace merge_dict() with builtin dict unpacking generalizations

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -11,7 +11,7 @@ from .exceptions import (
     InvalidSignatureError,
     InvalidTokenError,
 )
-from .utils import base64url_decode, base64url_encode, merge_dict
+from .utils import base64url_decode, base64url_encode
 
 
 class PyJWS:
@@ -30,10 +30,9 @@ class PyJWS:
             if key not in self._valid_algs:
                 del self._algorithms[key]
 
-        if not options:
+        if options is None:
             options = {}
-
-        self.options = merge_dict(self._get_default_options(), options)
+        self.options = {**self._get_default_options(), **options}
 
     @staticmethod
     def _get_default_options():
@@ -133,8 +132,9 @@ class PyJWS:
         complete: bool = False,
         **kwargs,
     ):
-
-        merged_options = merge_dict(self.options, options)
+        if options is None:
+            options = {}
+        merged_options = {**self.options, **options}
         verify_signature = merged_options["verify_signature"]
 
         if verify_signature and not algorithms:

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -15,7 +15,6 @@ from .exceptions import (
     InvalidIssuerError,
     MissingRequiredClaimError,
 )
-from .utils import merge_dict
 
 
 class PyJWT(PyJWS):
@@ -104,7 +103,7 @@ class PyJWT(PyJWS):
             raise DecodeError("Invalid payload string: must be a json object")
 
         if options["verify_signature"]:
-            merged_options = merge_dict(self.options, options)
+            merged_options = {**self.options, **options}
             self._validate_claims(payload, merged_options, **kwargs)
 
         if complete:

--- a/jwt/utils.py
+++ b/jwt/utils.py
@@ -58,19 +58,6 @@ def from_base64url_uint(val):
     return int("".join(["%02x" % byte for byte in buf]), 16)
 
 
-def merge_dict(original, updates):
-    if not updates:
-        return original
-
-    try:
-        merged_options = original.copy()
-        merged_options.update(updates)
-    except (AttributeError, ValueError) as e:
-        raise TypeError("original and updates must be a dictionary: %s" % e)
-
-    return merged_options
-
-
 def number_to_bytes(num, num_bytes):
     padded_hex = "%0*x" % (2 * num_bytes, num)
     big_endian = binascii.a2b_hex(padded_hex.encode("ascii"))


### PR DESCRIPTION
Merging two dict is support since Python 3.5 using the ** syntax.

See:

- https://docs.python.org/3.9/whatsnew/3.5.html#whatsnew-pep-448
- https://www.python.org/dev/peps/pep-0448/