### PR TITLE
Use direct indexing in PyJWKClient.get_signing_key_from_jwt()

### DIFF
--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -53,5 +53,5 @@ class PyJWKClient:
         unverified = decode_token(
             token, complete=True, options={"verify_signature": False}
         )
-        header = unverified.get("header")
+        header = unverified["header"]
         return self.get_signing_key(header.get("kid"))


### PR DESCRIPTION
When complete=True is passed to api_jwt.decode() (aliased as
decode_token()), the "header" key always exists.