### PR TITLE
Prefer ModuleNotFoundError over ImportError

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -43,7 +43,7 @@ try:
     )
 
     has_crypto = True
-except ImportError:
+except ModuleNotFoundError:
     has_crypto = False
 
 requires_cryptography = {

--- a/jwt/help.py
+++ b/jwt/help.py
@@ -6,7 +6,7 @@ from . import __version__ as pyjwt_version
 
 try:
     import cryptography
-except ImportError:
+except ModuleNotFoundError:
     cryptography = None  # type: ignore
 
 

--- a/jwt/utils.py
+++ b/jwt/utils.py
@@ -9,7 +9,7 @@ try:
         decode_dss_signature,
         encode_dss_signature,
     )
-except ImportError:
+except ModuleNotFoundError:
     EllipticCurve = Any  # type: ignore
 
 

--- a/tests/keys/__init__.py
+++ b/tests/keys/__init__.py
@@ -4,6 +4,14 @@ import os
 from jwt.algorithms import has_crypto
 from jwt.utils import base64url_decode
 
+try:
+    from cryptography.hazmat.primitives.asymmetric import ec
+except ModuleNotFoundError:
+    pass
+
+if has_crypto:
+    from jwt.algorithms import RSAAlgorithm
+
 BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -19,38 +27,32 @@ def load_hmac_key():
     return base64url_decode(keyobj["k"])
 
 
-try:
-    from cryptography.hazmat.primitives.asymmetric import ec
+def load_rsa_key():
+    with open(os.path.join(BASE_PATH, "jwk_rsa_key.json")) as infile:
+        return RSAAlgorithm.from_jwk(infile.read())
 
-    from jwt.algorithms import RSAAlgorithm
-except ImportError:
-    pass
 
-if has_crypto:
+def load_rsa_pub_key():
+    with open(os.path.join(BASE_PATH, "jwk_rsa_pub.json")) as infile:
+        return RSAAlgorithm.from_jwk(infile.read())
 
-    def load_rsa_key():
-        with open(os.path.join(BASE_PATH, "jwk_rsa_key.json")) as infile:
-            return RSAAlgorithm.from_jwk(infile.read())
 
-    def load_rsa_pub_key():
-        with open(os.path.join(BASE_PATH, "jwk_rsa_pub.json")) as infile:
-            return RSAAlgorithm.from_jwk(infile.read())
+def load_ec_key():
+    with open(os.path.join(BASE_PATH, "jwk_ec_key.json")) as infile:
+        keyobj = json.load(infile)
 
-    def load_ec_key():
-        with open(os.path.join(BASE_PATH, "jwk_ec_key.json")) as infile:
-            keyobj = json.load(infile)
+    return ec.EllipticCurvePrivateNumbers(
+        private_value=decode_value(keyobj["d"]),
+        public_numbers=load_ec_pub_key_p_521().public_numbers(),
+    )
 
-        return ec.EllipticCurvePrivateNumbers(
-            private_value=decode_value(keyobj["d"]),
-            public_numbers=load_ec_pub_key_p_521().public_numbers(),
-        )
 
-    def load_ec_pub_key_p_521():
-        with open(os.path.join(BASE_PATH, "jwk_ec_pub_P-521.json")) as infile:
-            keyobj = json.load(infile)
+def load_ec_pub_key_p_521():
+    with open(os.path.join(BASE_PATH, "jwk_ec_pub_P-521.json")) as infile:
+        keyobj = json.load(infile)
 
-        return ec.EllipticCurvePublicNumbers(
-            x=decode_value(keyobj["x"]),
-            y=decode_value(keyobj["y"]),
-            curve=ec.SECP521R1(),
-        ).public_key()
+    return ec.EllipticCurvePublicNumbers(
+        x=decode_value(keyobj["x"]),
+        y=decode_value(keyobj["y"]),
+        curve=ec.SECP521R1(),
+    ).public_key()

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -3,24 +3,20 @@ import json
 
 import pytest
 
-from jwt.algorithms import Algorithm, HMACAlgorithm, NoneAlgorithm
+from jwt.algorithms import Algorithm, HMACAlgorithm, NoneAlgorithm, has_crypto
 from jwt.exceptions import InvalidKeyError
 from jwt.utils import base64url_decode
 
-from .keys import load_hmac_key
+from .keys import load_ec_pub_key_p_521, load_hmac_key, load_rsa_pub_key
 from .utils import crypto_required, key_path
 
-try:
+if has_crypto:
     from jwt.algorithms import (
         ECAlgorithm,
         Ed25519Algorithm,
         RSAAlgorithm,
         RSAPSSAlgorithm,
     )
-
-    from .keys import load_ec_pub_key_p_521, load_rsa_pub_key
-except ImportError:
-    pass
 
 
 class TestAlgorithms:

--- a/tests/test_api_jwk.py
+++ b/tests/test_api_jwk.py
@@ -1,13 +1,12 @@
 import json
 
+from jwt.algorithms import has_crypto
 from jwt.api_jwk import PyJWK, PyJWKSet
 
 from .utils import crypto_required, key_path
 
-try:
+if has_crypto:
     from jwt.algorithms import RSAAlgorithm
-except ImportError:
-    pass
 
 
 class TestPyJWK:

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -21,7 +21,7 @@ try:
         load_pem_public_key,
         load_ssh_public_key,
     )
-except ImportError:
+except ModuleNotFoundError:
     pass
 
 


### PR DESCRIPTION
ModuleNotFoundError was introduced in Python 3. It is raised when the
module does not exist. On the other hand, ImportError is raised during
any import failure. For example, a syntax error or other runtime error.

Using ModuleNotFoundError means that errors unrelated to a missing
package will be propagated to the user. PyJWT doesn't know how to handle
these.

This also allows more functions to always be available for import