### PR TITLE
Fix tox "manifest" environment to pass

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 79
-extend-ignore = E203, E501

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,9 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: debug-statements
+
+  - repo: https://github.com/mgedmin/check-manifest
+    rev: "0.45"
+    hooks:
+      - id: check-manifest
+        args: [--no-build-isolation]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,14 @@
-include README.rst
+include .pre-commit-config.yaml
+include CODE_OF_CONDUCT.md
+include AUTHORS.rst
 include CHANGELOG.md
 include LICENSE
-include AUTHORS.rst
+include README.rst
 include tox.ini
+include jwt/py.typed
+graft docs
 graft tests
-recursive-exclude * __pycache__
+exclude codecov.yml
+recursive-exclude docs/_build *
 recursive-exclude * *.py[co]
+recursive-exclude * __pycache__

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,10 @@ exclude =
     tests
     tests.*
 
+[flake8]
+max-line-length = 79
+extend-ignore = E203, E501
+
 [mypy]
 python_version = 3.6
 ignore_missing_imports = true

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ filterwarnings =
 python =
     3.6: py36
     3.7: py37, docs
-    3.8: py38, lint, manifest, typing
+    3.8: py38, lint, typing
     3.9: py39
 
 
@@ -26,7 +26,6 @@ envlist =
     typing
     py{36,37,38,39}-crypto-{linux,windows}
     py{36,37,38,39}-nocrypto-{linux,windows}
-    manifest
     docs
     pypi-description
     coverage-report
@@ -64,13 +63,6 @@ basepython = python3.8
 extras = dev
 passenv = HOMEPATH  # needed on Windows
 commands = pre-commit run --all-files
-
-
-[testenv:manifest]
-basepython = python3.8
-deps = check-manifest
-skip_install = true
-commands = check-manifest
 
 
 [testenv:pypi-description]


### PR DESCRIPTION
The command `tox -e manifest` now passes.

Added missing files to the sdist:

- .pre-commit-config.yaml
- CODE_OF_CONDUCT.md
- jwt/py.typed
- docs/

Alphabetized MANIFEST.in

Moved .flake8 to setup.cfg to avoid the need to include yet another file
to MANIFEST.in.

Exclude codecov.yml. This is for CI only.