### PR TITLE
Use generator expressions

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -180,7 +180,7 @@ class HMACAlgorithm(Algorithm):
             b"ssh-rsa",
         ]
 
-        if any([string_value in key for string_value in invalid_strings]):
+        if any(string_value in key for string_value in invalid_strings):
             raise InvalidKeyError(
                 "The specified key is an asymmetric key or x509 certificate and"
                 " should not be used as an HMAC secret."


### PR DESCRIPTION
Avoids building a list in memory unnecessarily. Generator expressions
are evaluated lazily.