### PR TITLE
Drop lint environment from GitHub actions in favor of pre-commit.ci

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ filterwarnings =
 python =
     3.6: py36
     3.7: py37, docs
-    3.8: py38, lint, typing
+    3.8: py38, typing
     3.9: py39
 
 


### PR DESCRIPTION
The lint stage of CI is already handled by pre-commit.ci. With it, the
extra run in GitHub action is redundant and only consumes time and
resources unnecessarily.

pre-commit.ci is also faster to respond with results.