### PR TITLE
Simplify tox configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,8 +35,6 @@ jobs:
 
       - name: "Run tox targets for ${{ matrix.python-version }}"
         run: "python -m tox"
-        env:
-          PLATFORM: ${{ matrix.platform }}
 
       # We always use a modern Python version for combining coverage to prevent
       # parsing errors in older versions for modern code.

--- a/tox.ini
+++ b/tox.ini
@@ -14,18 +14,11 @@ python =
     3.9: py39
 
 
-[gh-actions:env]
-PLATFORM =
-    ubuntu-latest: linux
-    windows-latest: windows
-
-
 [tox]
 envlist =
     lint
     typing
-    py{36,37,38,39}-crypto-{linux,windows}
-    py{36,37,38,39}-nocrypto-{linux,windows}
+    py{36,37,38,39}-{crypto,nocrypto}
     docs
     pypi-description
     coverage-report
@@ -39,7 +32,7 @@ setenv =
     VIRTUALENV_NO_DOWNLOAD=1
 extras =
     tests
-    py{36,37,38,39}-crypto-{linux,windows}: crypto
+    crypto: crypto
 commands = {envpython} -b -m coverage run -m pytest {posargs}
 
 


### PR DESCRIPTION
Remove the extra dimension: {windows,linux}. In local testing, this
suffix has no practical effect on test runs as the OS is always either
Linux or Window. Adding this suffixes forces many extra test runs when
simply using the command "tox". This has been removed to avoid these
extra runs. This allowed removing the environment variable PLATFORM.
Both Windows and Linux still run in CI.

Use only the component "crypto" to install the extra cryptography
package. This simplifies adding Python versions in the future as
modifying this line is no longer required.

Merge suffixes to one line: py{36,37,38,39}-{crypto,nocrypto}. Again,
this simplifies adding Python versions in the future as one needs to
modify only one line.