### PR TITLE
Fix `from_jwk()` for all algorithms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Changed
 ~~~~~~~
 
 - Rename CHANGELOG.md to CHANGELOG.rst and include in docs `#597 <https://github.com/jpadilla/pyjwt/pull/597>`__
+- Fix `from_jwk()` for all algorithms `#598 <https://github.com/jpadilla/pyjwt/pull/598>`__
 
 Fixed
 ~~~~~

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -199,7 +199,15 @@ class HMACAlgorithm(Algorithm):
 
     @staticmethod
     def from_jwk(jwk):
-        obj = json.loads(jwk)
+        try:
+            if isinstance(jwk, str):
+                obj = json.loads(jwk)
+            elif isinstance(jwk, dict):
+                obj = jwk
+            else:
+                raise ValueError
+        except ValueError:
+            raise InvalidKeyError("Key is not valid JSON")
 
         if obj.get("kty") != "oct":
             raise InvalidKeyError("Not an HMAC key")
@@ -424,9 +432,13 @@ if has_crypto:
 
         @staticmethod
         def from_jwk(jwk):
-
             try:
-                obj = json.loads(jwk)
+                if isinstance(jwk, str):
+                    obj = json.loads(jwk)
+                elif isinstance(jwk, dict):
+                    obj = jwk
+                else:
+                    raise ValueError
             except ValueError:
                 raise InvalidKeyError("Key is not valid JSON")
 


### PR DESCRIPTION
This was previously fixed for `RSAAlgorithm`. Closes #593 