### PR TITLE
Fix type annotation for `decode()`/`encode()`'s parameter key

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Fixed
 - Make `kty` mandatory in JWK to be compliant with RFC7517. `#624 <https://github.com/jpadilla/pyjwt/pull/624>`__
 - Allow JWK without `alg` to be compliant with RFC7517. `#624 <https://github.com/jpadilla/pyjwt/pull/624>`__
 - ``encode()``, ``decode()``, and ``decode_complete()``'s parameter key now
-  accepts and defaults to `bytes` `#605 <https://github.com/jpadilla/pyjwt/pull/605>`__
+  accepts ``typing.Any`` and defaults to `bytes` `#605 <https://github.com/jpadilla/pyjwt/pull/605>`__
 
 Added
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Fixed
 - Remove padding from JWK test data. `#628 <https://github.com/jpadilla/pyjwt/pull/628>`__
 - Make `kty` mandatory in JWK to be compliant with RFC7517. `#624 <https://github.com/jpadilla/pyjwt/pull/624>`__
 - Allow JWK without `alg` to be compliant with RFC7517. `#624 <https://github.com/jpadilla/pyjwt/pull/624>`__
+- ``encode()``, ``decode()``, and ``decode_complete()``'s parameter key now
+  accepts and defaults to `bytes` `#605 <https://github.com/jpadilla/pyjwt/pull/605>`__
 
 Added
 ~~~~~

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -144,7 +144,7 @@ class NoneAlgorithm(Algorithm):
     """
 
     def prepare_key(self, key):
-        if key == "":
+        if key in ("", b""):
             key = None
 
         if key is not None:

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -144,7 +144,7 @@ class NoneAlgorithm(Algorithm):
     """
 
     def prepare_key(self, key):
-        if key in ("", b""):
+        if not key:
             key = None
 
         if key is not None:

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -1,7 +1,7 @@
 import binascii
 import json
 from collections.abc import Mapping
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Type, Union
 
 from .algorithms import (
     Algorithm,
@@ -76,7 +76,7 @@ class PyJWS:
     def encode(
         self,
         payload: bytes,
-        key: str,
+        key: Union[str, bytes],
         algorithm: str = "HS256",
         headers: Optional[Dict] = None,
         json_encoder: Optional[Type[json.JSONEncoder]] = None,
@@ -128,7 +128,7 @@ class PyJWS:
     def decode_complete(
         self,
         jwt: str,
-        key: str = "",
+        key: Union[str, bytes] = b"",
         algorithms: List[str] = None,
         options: Dict = None,
         **kwargs,
@@ -157,7 +157,7 @@ class PyJWS:
     def decode(
         self,
         jwt: str,
-        key: str = "",
+        key: Union[str, bytes] = b"",
         algorithms: List[str] = None,
         options: Dict = None,
         **kwargs,

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -1,7 +1,7 @@
 import binascii
 import json
 from collections.abc import Mapping
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type
 
 from .algorithms import (
     Algorithm,
@@ -76,7 +76,7 @@ class PyJWS:
     def encode(
         self,
         payload: bytes,
-        key: Union[str, bytes],
+        key: Any,
         algorithm: str = "HS256",
         headers: Optional[Dict] = None,
         json_encoder: Optional[Type[json.JSONEncoder]] = None,
@@ -128,7 +128,7 @@ class PyJWS:
     def decode_complete(
         self,
         jwt: str,
-        key: Union[str, bytes] = b"",
+        key: Any = b"",
         algorithms: List[str] = None,
         options: Dict = None,
         **kwargs,
@@ -157,7 +157,7 @@ class PyJWS:
     def decode(
         self,
         jwt: str,
-        key: Union[str, bytes] = b"",
+        key: Any = b"",
         algorithms: List[str] = None,
         options: Dict = None,
         **kwargs,

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -37,7 +37,7 @@ class PyJWT:
     def encode(
         self,
         payload: Dict[str, Any],
-        key: Union[str, bytes],
+        key: Any,
         algorithm: str = "HS256",
         headers: Optional[Dict] = None,
         json_encoder: Optional[Type[json.JSONEncoder]] = None,
@@ -65,7 +65,7 @@ class PyJWT:
     def decode_complete(
         self,
         jwt: str,
-        key: Union[str, bytes] = b"",
+        key: Any = b"",
         algorithms: List[str] = None,
         options: Dict = None,
         **kwargs,
@@ -111,7 +111,7 @@ class PyJWT:
     def decode(
         self,
         jwt: str,
-        key: Union[str, bytes] = b"",
+        key: Any = b"",
         algorithms: List[str] = None,
         options: Dict = None,
         **kwargs,

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -37,7 +37,7 @@ class PyJWT:
     def encode(
         self,
         payload: Dict[str, Any],
-        key: str,
+        key: Union[str, bytes],
         algorithm: str = "HS256",
         headers: Optional[Dict] = None,
         json_encoder: Optional[Type[json.JSONEncoder]] = None,
@@ -65,7 +65,7 @@ class PyJWT:
     def decode_complete(
         self,
         jwt: str,
-        key: str = "",
+        key: Union[str, bytes] = b"",
         algorithms: List[str] = None,
         options: Dict = None,
         **kwargs,
@@ -111,7 +111,7 @@ class PyJWT:
     def decode(
         self,
         jwt: str,
-        key: str = "",
+        key: Union[str, bytes] = b"",
         algorithms: List[str] = None,
         options: Dict = None,
         **kwargs,

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -32,45 +32,97 @@ def payload():
 
 
 class TestJWT:
-    def test_decodes_valid_jwt(self, jwt):
+    @pytest.mark.parametrize(
+        "example_secret,example_jwt",
+        [
+            (
+                "secret",
+                (
+                    b"eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9"
+                    b".eyJoZWxsbyI6ICJ3b3JsZCJ9"
+                    b".tvagLDLoaiJKxOKqpBXSEGy7SYSifZhjntgm9ctpyj8"
+                ),
+            ),
+            (
+                b"\xb1\xe7+z",
+                (
+                    "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
+                    "eyJoZWxsbyI6ICJ3b3JsZCJ9."
+                    "ZTywb6RJhCq8tn1qy5j6YJhKOLw8c7EPRYwNA4Gmd_Q"
+                ),
+            ),
+        ],
+    )
+    def test_decodes_valid_jwt(self, jwt, example_secret, example_jwt):
         example_payload = {"hello": "world"}
-        example_secret = "secret"
-        example_jwt = (
-            b"eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9"
-            b".eyJoZWxsbyI6ICJ3b3JsZCJ9"
-            b".tvagLDLoaiJKxOKqpBXSEGy7SYSifZhjntgm9ctpyj8"
-        )
         decoded_payload = jwt.decode(example_jwt, example_secret, algorithms=["HS256"])
 
         assert decoded_payload == example_payload
 
-    def test_decodes_complete_valid_jwt(self, jwt):
+    @pytest.mark.parametrize(
+        "example_secret,example_jwt,signature",
+        [
+            (
+                "secret",
+                (
+                    b"eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9"
+                    b".eyJoZWxsbyI6ICJ3b3JsZCJ9"
+                    b".tvagLDLoaiJKxOKqpBXSEGy7SYSifZhjntgm9ctpyj8"
+                ),
+                (
+                    b'\xb6\xf6\xa0,2\xe8j"J\xc4\xe2\xaa\xa4\x15\xd2'
+                    b"\x10l\xbbI\x84\xa2}\x98c\x9e\xd8&\xf5\xcbi\xca?"
+                ),
+            ),
+            (
+                b"\xb1\xe7+z",
+                (
+                    "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
+                    "eyJoZWxsbyI6ICJ3b3JsZCJ9."
+                    "ZTywb6RJhCq8tn1qy5j6YJhKOLw8c7EPRYwNA4Gmd_Q"
+                ),
+                (
+                    b"e<\xb0o\xa4I\x84*\xbc\xb6}j\xcb\x98\xfa`\x98J8"
+                    b"\xbc<s\xb1\x0fE\x8c\r\x03\x81\xa6w\xf4"
+                ),
+            ),
+        ],
+    )
+    def test_decodes_complete_valid_jwt(
+        self, jwt, example_secret, example_jwt, signature
+    ):
         example_payload = {"hello": "world"}
-        example_secret = "secret"
-        example_jwt = (
-            b"eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9"
-            b".eyJoZWxsbyI6ICJ3b3JsZCJ9"
-            b".tvagLDLoaiJKxOKqpBXSEGy7SYSifZhjntgm9ctpyj8"
-        )
         decoded = jwt.decode_complete(example_jwt, example_secret, algorithms=["HS256"])
 
         assert decoded == {
             "header": {"alg": "HS256", "typ": "JWT"},
             "payload": example_payload,
-            "signature": (
-                b'\xb6\xf6\xa0,2\xe8j"J\xc4\xe2\xaa\xa4\x15\xd2'
-                b"\x10l\xbbI\x84\xa2}\x98c\x9e\xd8&\xf5\xcbi\xca?"
-            ),
+            "signature": signature,
         }
 
-    def test_load_verify_valid_jwt(self, jwt):
+    @pytest.mark.parametrize(
+        "example_secret,example_jwt",
+        [
+            (
+                "secret",
+                (
+                    b"eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9"
+                    b".eyJoZWxsbyI6ICJ3b3JsZCJ9"
+                    b".tvagLDLoaiJKxOKqpBXSEGy7SYSifZhjntgm9ctpyj8"
+                ),
+            ),
+            (
+                b"\xb1\xe7+z",
+                (
+                    "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
+                    "eyJoZWxsbyI6ICJ3b3JsZCJ9."
+                    "ZTywb6RJhCq8tn1qy5j6YJhKOLw8c7EPRYwNA4Gmd_Q"
+                ),
+            ),
+        ],
+    )
+    def test_load_verify_valid_jwt(self, jwt, example_secret, example_jwt):
         example_payload = {"hello": "world"}
-        example_secret = "secret"
-        example_jwt = (
-            b"eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9"
-            b".eyJoZWxsbyI6ICJ3b3JsZCJ9"
-            b".tvagLDLoaiJKxOKqpBXSEGy7SYSifZhjntgm9ctpyj8"
-        )
 
         decoded_payload = jwt.decode(
             example_jwt, key=example_secret, algorithms=["HS256"]

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1,9 +1,12 @@
+import pytest
+
 import jwt
 
 from .utils import utc_timestamp
 
 
-def test_encode_decode():
+@pytest.mark.parametrize("secret", ["secret", b"\xb1\xe7+z"])
+def test_encode_decode(secret):
     """
     This test exists primarily to ensure that calls to jwt.encode and
     jwt.decode don't explode. Most functionality is tested by the PyJWT class
@@ -12,7 +15,6 @@ def test_encode_decode():
     """
     payload = {"iss": "jeff", "exp": utc_timestamp() + 15, "claim": "insanity"}
 
-    secret = "secret"
     jwt_message = jwt.encode(payload, secret, algorithm="HS256")
     decoded_payload = jwt.decode(jwt_message, secret, algorithms=["HS256"])
 


### PR DESCRIPTION
See #602 for details.

The issue suggests that the parameter `key` should not accept `str`.  I've not included this for backwards compatibility and because I'm not sure if that's really necessary.

Closes jpadilla/pyjwt#602