### PR TITLE
Cache signing keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Fixed
 Added
 ~~~~~
 
+- Add caching `#611 <https://github.com/jpadilla/pyjwt/pull/611>`__
+
 `v2.0.1 <https://github.com/jpadilla/pyjwt/compare/2.0.0...2.0.1>`__
 --------------------------------------------------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Fixed
 Added
 ~~~~~
 
-- Add caching `#611 <https://github.com/jpadilla/pyjwt/pull/611>`__
+- Add caching by default to PyJWKClient `#611 <https://github.com/jpadilla/pyjwt/pull/611>`__
 
 `v2.0.1 <https://github.com/jpadilla/pyjwt/compare/2.0.0...2.0.1>`__
 --------------------------------------------------------------------

--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -1,6 +1,6 @@
 import json
 import urllib.request
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 from .api_jwk import PyJWK, PyJWKSet
 from .api_jwt import decode_complete as decode_token
@@ -10,8 +10,8 @@ from .exceptions import PyJWKClientError
 class PyJWKClient:
     def __init__(self, uri: str):
         self.uri = uri
-        # Map (uri, kid) to signing keys
-        self._known_signing_keys: Dict[Tuple[str, str], PyJWK] = {}
+        # Map kid to signing key
+        self._known_signing_keys: Dict[str, PyJWK] = {}
 
     def fetch_data(self) -> Any:
         with urllib.request.urlopen(self.uri) as response:
@@ -35,13 +35,13 @@ class PyJWKClient:
         return signing_keys
 
     def get_signing_key(self, kid: str) -> PyJWK:
-        if (self.uri, kid) in self._known_signing_keys:
-            return self._known_signing_keys[(self.uri, kid)]
+        if kid in self._known_signing_keys:
+            return self._known_signing_keys[kid]
         signing_keys = self.get_signing_keys()
         signing_key = None
 
         for key in signing_keys:
-            self._known_signing_keys[(self.uri, key.key_id)] = key
+            self._known_signing_keys[key.key_id] = key
             if key.key_id == kid:
                 signing_key = key
                 break

--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -1,6 +1,6 @@
 import json
 import urllib.request
-from typing import Any, List
+from typing import Any, Dict, List
 
 from .api_jwk import PyJWK, PyJWKSet
 from .api_jwt import decode_complete as decode_token
@@ -10,6 +10,7 @@ from .exceptions import PyJWKClientError
 class PyJWKClient:
     def __init__(self, uri: str):
         self.uri = uri
+        self._known_signing_keys: Dict[str, PyJWK] = {}
 
     def fetch_data(self) -> Any:
         with urllib.request.urlopen(self.uri) as response:
@@ -33,10 +34,13 @@ class PyJWKClient:
         return signing_keys
 
     def get_signing_key(self, kid: str) -> PyJWK:
+        if kid in self._known_signing_keys:
+            return self._known_signing_keys[kid]
         signing_keys = self.get_signing_keys()
         signing_key = None
 
         for key in signing_keys:
+            self._known_signing_keys[key.key_id] = key
             if key.key_id == kid:
                 signing_key = key
                 break

--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -9,11 +9,12 @@ from .exceptions import PyJWKClientError
 
 
 class PyJWKClient:
-    def __init__(self, uri: str):
+    def __init__(self, uri: str, cache_keys: bool = True):
         self.uri = uri
-        # Cache signing keys
-        # Ignore mypy (https://github.com/python/mypy/issues/2427)
-        self.get_signing_key = lru_cache(maxsize=16)(self.get_signing_key)  # type: ignore
+        if cache_keys:
+            # Cache signing keys
+            # Ignore mypy (https://github.com/python/mypy/issues/2427)
+            self.get_signing_key = lru_cache(maxsize=16)(self.get_signing_key)  # type: ignore
 
     def fetch_data(self) -> Any:
         with urllib.request.urlopen(self.uri) as response:

--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -9,12 +9,12 @@ from .exceptions import PyJWKClientError
 
 
 class PyJWKClient:
-    def __init__(self, uri: str, cache_keys: bool = True):
+    def __init__(self, uri: str, cache_keys: bool = True, max_cached_keys: int = 16):
         self.uri = uri
         if cache_keys:
             # Cache signing keys
             # Ignore mypy (https://github.com/python/mypy/issues/2427)
-            self.get_signing_key = lru_cache(maxsize=16)(self.get_signing_key)  # type: ignore
+            self.get_signing_key = lru_cache(maxsize=max_cached_keys)(self.get_signing_key)  # type: ignore
 
     def fetch_data(self) -> Any:
         with urllib.request.urlopen(self.uri) as response:

--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -1,6 +1,6 @@
 import json
 import urllib.request
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 from .api_jwk import PyJWK, PyJWKSet
 from .api_jwt import decode_complete as decode_token
@@ -10,7 +10,8 @@ from .exceptions import PyJWKClientError
 class PyJWKClient:
     def __init__(self, uri: str):
         self.uri = uri
-        self._known_signing_keys: Dict[str, PyJWK] = {}
+        # Map (uri, kid) to signing keys
+        self._known_signing_keys: Dict[Tuple[str, str], PyJWK] = {}
 
     def fetch_data(self) -> Any:
         with urllib.request.urlopen(self.uri) as response:
@@ -34,13 +35,13 @@ class PyJWKClient:
         return signing_keys
 
     def get_signing_key(self, kid: str) -> PyJWK:
-        if kid in self._known_signing_keys:
-            return self._known_signing_keys[kid]
+        if (self.uri, kid) in self._known_signing_keys:
+            return self._known_signing_keys[(self.uri, kid)]
         signing_keys = self.get_signing_keys()
         signing_key = None
 
         for key in signing_keys:
-            self._known_signing_keys[key.key_id] = key
+            self._known_signing_keys[(self.uri, key.key_id)] = key
             if key.key_id == kid:
                 signing_key = key
                 break

--- a/tests/test_jwks_client.py
+++ b/tests/test_jwks_client.py
@@ -99,24 +99,6 @@ class TestPyJWKClient:
 
         assert network_response.call_count == 1
 
-    def test_get_signing_key_cache_distinguishes_uris(self):
-        url_1 = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
-        url_2 = "https://dev-88evx9ru.auth0.com/.well-known/jwks.json"
-        kid = "NEE1QURBOTM4MzI5RkFDNTYxOTU1MDg2ODgwQ0UzMTk1QjYyRkRFQw"
-
-        with mocked_response(RESPONSE_DATA):
-            jwks_client = PyJWKClient(url_1)
-            jwks_client.get_signing_key(kid)
-
-        # mocked_response does not allow urllib.request.urlopen to be called twice
-        # so a second mock is needed
-        with mocked_response(RESPONSE_DATA):
-            jwks_client.uri = url_2
-            jwks_client.get_signing_key(kid)
-
-        for uri_kid_pair in ((url_1, kid), (url_2, kid)):
-            assert uri_kid_pair in jwks_client._known_signing_keys
-
     def test_get_signing_key_from_jwt(self):
         token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik5FRTFRVVJCT1RNNE16STVSa0ZETlRZeE9UVTFNRGcyT0Rnd1EwVXpNVGsxUWpZeVJrUkZRdyJ9.eyJpc3MiOiJodHRwczovL2Rldi04N2V2eDlydS5hdXRoMC5jb20vIiwic3ViIjoiYVc0Q2NhNzl4UmVMV1V6MGFFMkg2a0QwTzNjWEJWdENAY2xpZW50cyIsImF1ZCI6Imh0dHBzOi8vZXhwZW5zZXMtYXBpIiwiaWF0IjoxNTcyMDA2OTU0LCJleHAiOjE1NzIwMDY5NjQsImF6cCI6ImFXNENjYTc5eFJlTFdVejBhRTJINmtEME8zY1hCVnRDIiwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIn0.PUxE7xn52aTCohGiWoSdMBZGiYAHwE5FYie0Y1qUT68IHSTXwXVd6hn02HTah6epvHHVKA2FqcFZ4GGv5VTHEvYpeggiiZMgbxFrmTEY0csL6VNkX1eaJGcuehwQCRBKRLL3zKmA5IKGy5GeUnIbpPHLHDxr-GXvgFzsdsyWlVQvPX2xjeaQ217r2PtxDeqjlf66UYl6oY6AqNS8DH3iryCvIfCcybRZkc_hdy-6ZMoKT6Piijvk_aXdm7-QQqKJFHLuEqrVSOuBqqiNfVrG27QzAPuPOxvfXTVLXL2jek5meH6n-VWgrBdoMFH93QEszEDowDAEhQPHVs0xj7SIzA"
         url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"

--- a/tests/test_jwks_client.py
+++ b/tests/test_jwks_client.py
@@ -37,7 +37,7 @@ def mocked_response(data):
         response.__exit__ = mock.Mock()
         response.read.side_effect = [json.dumps(data)]
         urlopen_mock.return_value = response
-        yield
+        yield urlopen_mock
 
 
 @crypto_required
@@ -87,6 +87,17 @@ class TestPyJWKClient:
         assert signing_key.key_type == "RSA"
         assert signing_key.key_id == kid
         assert signing_key.public_key_use == "sig"
+
+    def test_get_signing_key_caches_result(self):
+        url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
+        kid = "NEE1QURBOTM4MzI5RkFDNTYxOTU1MDg2ODgwQ0UzMTk1QjYyRkRFQw"
+
+        with mocked_response(RESPONSE_DATA) as network_response:
+            jwks_client = PyJWKClient(url)
+            jwks_client.get_signing_key(kid)
+            jwks_client.get_signing_key(kid)
+
+        assert network_response.call_count == 1
 
     def test_get_signing_key_from_jwt(self):
         token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik5FRTFRVVJCT1RNNE16STVSa0ZETlRZeE9UVTFNRGcyT0Rnd1EwVXpNVGsxUWpZeVJrUkZRdyJ9.eyJpc3MiOiJodHRwczovL2Rldi04N2V2eDlydS5hdXRoMC5jb20vIiwic3ViIjoiYVc0Q2NhNzl4UmVMV1V6MGFFMkg2a0QwTzNjWEJWdENAY2xpZW50cyIsImF1ZCI6Imh0dHBzOi8vZXhwZW5zZXMtYXBpIiwiaWF0IjoxNTcyMDA2OTU0LCJleHAiOjE1NzIwMDY5NjQsImF6cCI6ImFXNENjYTc5eFJlTFdVejBhRTJINmtEME8zY1hCVnRDIiwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIn0.PUxE7xn52aTCohGiWoSdMBZGiYAHwE5FYie0Y1qUT68IHSTXwXVd6hn02HTah6epvHHVKA2FqcFZ4GGv5VTHEvYpeggiiZMgbxFrmTEY0csL6VNkX1eaJGcuehwQCRBKRLL3zKmA5IKGy5GeUnIbpPHLHDxr-GXvgFzsdsyWlVQvPX2xjeaQ217r2PtxDeqjlf66UYl6oY6AqNS8DH3iryCvIfCcybRZkc_hdy-6ZMoKT6Piijvk_aXdm7-QQqKJFHLuEqrVSOuBqqiNfVrG27QzAPuPOxvfXTVLXL2jek5meH6n-VWgrBdoMFH93QEszEDowDAEhQPHVs0xj7SIzA"

--- a/tests/test_jwks_client.py
+++ b/tests/test_jwks_client.py
@@ -99,6 +99,24 @@ class TestPyJWKClient:
 
         assert network_response.call_count == 1
 
+    def test_get_signing_key_cache_distinguishes_uris(self):
+        url_1 = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
+        url_2 = "https://dev-88evx9ru.auth0.com/.well-known/jwks.json"
+        kid = "NEE1QURBOTM4MzI5RkFDNTYxOTU1MDg2ODgwQ0UzMTk1QjYyRkRFQw"
+
+        with mocked_response(RESPONSE_DATA):
+            jwks_client = PyJWKClient(url_1)
+            jwks_client.get_signing_key(kid)
+
+        # mocked_response does not allow urllib.request.urlopen to be called twice
+        # so a second mock is needed
+        with mocked_response(RESPONSE_DATA):
+            jwks_client.uri = url_2
+            jwks_client.get_signing_key(kid)
+
+        for uri_kid_pair in ((url_1, kid), (url_2, kid)):
+            assert uri_kid_pair in jwks_client._known_signing_keys
+
     def test_get_signing_key_from_jwt(self):
         token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik5FRTFRVVJCT1RNNE16STVSa0ZETlRZeE9UVTFNRGcyT0Rnd1EwVXpNVGsxUWpZeVJrUkZRdyJ9.eyJpc3MiOiJodHRwczovL2Rldi04N2V2eDlydS5hdXRoMC5jb20vIiwic3ViIjoiYVc0Q2NhNzl4UmVMV1V6MGFFMkg2a0QwTzNjWEJWdENAY2xpZW50cyIsImF1ZCI6Imh0dHBzOi8vZXhwZW5zZXMtYXBpIiwiaWF0IjoxNTcyMDA2OTU0LCJleHAiOjE1NzIwMDY5NjQsImF6cCI6ImFXNENjYTc5eFJlTFdVejBhRTJINmtEME8zY1hCVnRDIiwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIn0.PUxE7xn52aTCohGiWoSdMBZGiYAHwE5FYie0Y1qUT68IHSTXwXVd6hn02HTah6epvHHVKA2FqcFZ4GGv5VTHEvYpeggiiZMgbxFrmTEY0csL6VNkX1eaJGcuehwQCRBKRLL3zKmA5IKGy5GeUnIbpPHLHDxr-GXvgFzsdsyWlVQvPX2xjeaQ217r2PtxDeqjlf66UYl6oY6AqNS8DH3iryCvIfCcybRZkc_hdy-6ZMoKT6Piijvk_aXdm7-QQqKJFHLuEqrVSOuBqqiNfVrG27QzAPuPOxvfXTVLXL2jek5meH6n-VWgrBdoMFH93QEszEDowDAEhQPHVs0xj7SIzA"
         url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"

--- a/tests/test_jwks_client.py
+++ b/tests/test_jwks_client.py
@@ -92,12 +92,33 @@ class TestPyJWKClient:
         url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
         kid = "NEE1QURBOTM4MzI5RkFDNTYxOTU1MDg2ODgwQ0UzMTk1QjYyRkRFQw"
 
-        with mocked_response(RESPONSE_DATA) as network_response:
-            jwks_client = PyJWKClient(url)
-            jwks_client.get_signing_key(kid)
+        jwks_client = PyJWKClient(url)
+
+        with mocked_response(RESPONSE_DATA):
             jwks_client.get_signing_key(kid)
 
-        assert network_response.call_count == 1
+        # mocked_response does not allow urllib.request.urlopen to be called twice
+        # so a second mock is needed
+        with mocked_response(RESPONSE_DATA) as repeated_call:
+            jwks_client.get_signing_key(kid)
+
+        assert repeated_call.call_count == 0
+
+    def test_get_signing_key_does_not_cache_opt_out(self):
+        url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
+        kid = "NEE1QURBOTM4MzI5RkFDNTYxOTU1MDg2ODgwQ0UzMTk1QjYyRkRFQw"
+
+        jwks_client = PyJWKClient(url, cache_keys=False)
+
+        with mocked_response(RESPONSE_DATA):
+            jwks_client.get_signing_key(kid)
+
+        # mocked_response does not allow urllib.request.urlopen to be called twice
+        # so a second mock is needed
+        with mocked_response(RESPONSE_DATA) as repeated_call:
+            jwks_client.get_signing_key(kid)
+
+        assert repeated_call.call_count == 1
 
     def test_get_signing_key_from_jwt(self):
         token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik5FRTFRVVJCT1RNNE16STVSa0ZETlRZeE9UVTFNRGcyT0Rnd1EwVXpNVGsxUWpZeVJrUkZRdyJ9.eyJpc3MiOiJodHRwczovL2Rldi04N2V2eDlydS5hdXRoMC5jb20vIiwic3ViIjoiYVc0Q2NhNzl4UmVMV1V6MGFFMkg2a0QwTzNjWEJWdENAY2xpZW50cyIsImF1ZCI6Imh0dHBzOi8vZXhwZW5zZXMtYXBpIiwiaWF0IjoxNTcyMDA2OTU0LCJleHAiOjE1NzIwMDY5NjQsImF6cCI6ImFXNENjYTc5eFJlTFdVejBhRTJINmtEME8zY1hCVnRDIiwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIn0.PUxE7xn52aTCohGiWoSdMBZGiYAHwE5FYie0Y1qUT68IHSTXwXVd6hn02HTah6epvHHVKA2FqcFZ4GGv5VTHEvYpeggiiZMgbxFrmTEY0csL6VNkX1eaJGcuehwQCRBKRLL3zKmA5IKGy5GeUnIbpPHLHDxr-GXvgFzsdsyWlVQvPX2xjeaQ217r2PtxDeqjlf66UYl6oY6AqNS8DH3iryCvIfCcybRZkc_hdy-6ZMoKT6Piijvk_aXdm7-QQqKJFHLuEqrVSOuBqqiNfVrG27QzAPuPOxvfXTVLXL2jek5meH6n-VWgrBdoMFH93QEszEDowDAEhQPHVs0xj7SIzA"


### PR DESCRIPTION
The function `get_signing_key` indirectly makes a network call to get the public key. For a project that authenticates requests extremely often, this introduces a *lot* of delay. 

Cache the result of `get_signing_key` so that it gets reused if called with ~~the same client and~~ the same `kid`. 

This should *not* break any projects that are following JWT standards, as while the RFC is [not entirely explicit](https://tools.ietf.org/html/rfc7515#section-4.1.4), common practice dictates that [the `kid` must be unique](https://auth0.com/blog/navigating-rs256-and-jwks/):
> kid: is the unique identifier for the key

Therefore, unless there is somehow a new key added and an old key removed which both somehow have the same `kid` (which I think is a fair assumption), this is not a breaking change. 

~~I initially wanted to use `functools.lru_cache`, but there are [known issues](https://stackoverflow.com/questions/33672412) with using `functools.lru_cache` with instance methods.~~

~~The `_known_signing_key` key values include the URI, so as not to break any existing workflows that change an instance of PyJWKClient's uri value (for whatever reason). I'm honestly fine with getting rid of the URI part so that it's just kid -> key, but I figure you guys should have the say on that decision :shrug:~~

~~I've also added a test to check that the caching is working, and a test to make sure that we're not overwriting keys from different URIs. During testing, I noticed that `mocked_response` only allows `urllib.request.urlopen` to be called once, so technically `test_get_signing_key_caches_result` will fail with an exception instead of `network_response.call_count == 1`, but it still fails if the caching isn't working.~~