### PR TITLE
Ignore coverage files generated during test runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
+.coverage.*
 .cache
 nosetests.xml
 coverage.xml


### PR DESCRIPTION
During test runs, new coverage files are generated, such as `.coverage.hostname.number.number`. They get deleted at the end of `tox`, but in the interest of not accidentally committing them during a `tox` run, they should be ignored.