### PR TITLE
Add missing exceptions.InvalidKeyError to jwt module __init__ imports.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Added
 ~~~~~
 
 - Add caching by default to PyJWKClient `#611 <https://github.com/jpadilla/pyjwt/pull/611>`__
+- Add missing exceptions.InvalidKeyError to jwt module __init__ imports `#620 <https://github.com/jpadilla/pyjwt/pull/620>`__
 
 `v2.0.1 <https://github.com/jpadilla/pyjwt/compare/2.0.0...2.0.1>`__
 --------------------------------------------------------------------

--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     "InvalidAudienceError",
     "InvalidIssuedAtError",
     "InvalidIssuerError",
+    "InvalidKeyError",
     "InvalidSignatureError",
     "InvalidTokenError",
     "MissingRequiredClaimError",

--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -13,6 +13,7 @@ from .exceptions import (
     InvalidAudienceError,
     InvalidIssuedAtError,
     InvalidIssuerError,
+    InvalidKeyError,
     InvalidSignatureError,
     InvalidTokenError,
     MissingRequiredClaimError,


### PR DESCRIPTION
All other error classes are already here, so I'm assuming this was an oversight.