### PR TITLE
Use UTC time for exp/nbf validation.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Fixed
 ~~~~~
 
 - Remove padding from JWK test data. `#628 <https://github.com/jpadilla/pyjwt/pull/628>`__
+- Use UTC time for exp/nbf validation. `#633 <https://github.com/jpadilla/pyjwt/pull/633>`__
 
 Added
 ~~~~~

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -1,5 +1,5 @@
 import json
-from calendar import timegm
+import time
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Type, Union
@@ -54,7 +54,9 @@ class PyJWT:
         for time_claim in ["exp", "iat", "nbf"]:
             # Convert datetime to a intDate value in known time-format claims
             if isinstance(payload.get(time_claim), datetime):
-                payload[time_claim] = timegm(payload[time_claim].utctimetuple())
+                payload[time_claim] = int(
+                    time.mktime(payload[time_claim].utctimetuple())
+                )
 
         json_payload = json.dumps(
             payload, separators=(",", ":"), cls=json_encoder
@@ -130,7 +132,7 @@ class PyJWT:
 
         self._validate_required_claims(payload, options)
 
-        now = timegm(datetime.utcnow().utctimetuple())
+        now = datetime.utcnow().timestamp()
 
         if "iat" in payload and options["verify_iat"]:
             self._validate_iat(payload, now, leeway)

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -132,7 +132,7 @@ class PyJWT:
 
         self._validate_required_claims(payload, options)
 
-        now = datetime.utcnow().timestamp()
+        now = int(datetime.utcnow().timestamp())
 
         if "iat" in payload and options["verify_iat"]:
             self._validate_iat(payload, now, leeway)

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -1,6 +1,5 @@
 import json
 import time
-from calendar import timegm
 from datetime import datetime, timedelta
 from decimal import Decimal
 
@@ -215,9 +214,15 @@ class TestJWT:
             jwt_message, secret, leeway=1, algorithms=["HS256"]
         )
 
-        assert decoded_payload["exp"] == timegm(current_datetime.utctimetuple())
-        assert decoded_payload["iat"] == timegm(current_datetime.utctimetuple())
-        assert decoded_payload["nbf"] == timegm(current_datetime.utctimetuple())
+        assert decoded_payload["exp"] == int(
+            time.mktime(current_datetime.utctimetuple())
+        )
+        assert decoded_payload["iat"] == int(
+            time.mktime(current_datetime.utctimetuple())
+        )
+        assert decoded_payload["nbf"] == int(
+            time.mktime(current_datetime.utctimetuple())
+        )
         # payload is not mutated.
         assert payload == {
             "exp": current_datetime,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,5 @@
 import os
-from calendar import timegm
+import time
 from datetime import datetime
 
 import pytest
@@ -8,7 +8,7 @@ from jwt.algorithms import has_crypto
 
 
 def utc_timestamp():
-    return timegm(datetime.utcnow().utctimetuple())
+    return int(time.mktime(datetime.utcnow().utctimetuple()))
 
 
 def key_path(key_name):


### PR DESCRIPTION
To be compliant with RFC7519, Update exp/nbf validation to use UTC time instead of local time.

Close #487 
Close #631 
