### PR TITLE
changed 'paramenter' to 'parameter'

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -262,7 +262,7 @@ Issued At Claim (iat)
 Requiring Presence of Claims
 ----------------------------
 
-If you wish to require one or more claims to be present in the claimset, you can set the ``require`` paramenter to include these claims.
+If you wish to require one or more claims to be present in the claimset, you can set the ``require`` parameter to include these claims.
 
 .. code-block:: pycon
 


### PR DESCRIPTION
these changes clarify the usage of claims within the usage documentation 