### PR TITLE
Allow to verify with private key on ECAlgorithm, as well as on Ed25519Algorithm.

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -427,6 +427,8 @@ if has_crypto:
                 return False
 
             try:
+                if isinstance(key, EllipticCurvePrivateKey):
+                    key = key.public_key()
                 key.verify(der_sig, msg, ec.ECDSA(self.hash_alg()))
                 return True
             except InvalidSignature:

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -658,6 +658,13 @@ class TestAlgorithmsRFC7520:
         result = algo.verify(signing_input, key, signature)
         assert result
 
+        # private key can also be used.
+        with open(key_path("jwk_ec_key_P-521.json")) as keyfile:
+            private_key = algo.from_jwk(keyfile.read())
+
+        result = algo.verify(signing_input, private_key, signature)
+        assert result
+
 
 @crypto_required
 class TestEd25519Algorithms:


### PR DESCRIPTION
At the current implementation of Ed25519Algorithm, verify() can accept a private key as a verification key (See https://github.com/jpadilla/pyjwt/blob/master/jwt/algorithms.py#L583-L584). However, ECAlgorithm's verify() cannot.

I think the both of two should work in the same way. There are two options:
1. Remove private key support from Ed25519Algorithm's verify().
2. Add private key support to ECAlgorithm's verify().

Considering backward-compat, I selected 2.