### PR TITLE
Fix incorrect documentation for jwt

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -35,7 +35,7 @@ API Reference
     :param dict options: extended decoding and validation options
 
         * ``require=[]`` list of claims that must be present. E.g. ``require=["exp", "iat", "nbf"]``.
-            Only verifies that the claims exists. Does NOT verify that the claims are valid. 
+            Only verifies that the claims exists. Does NOT verify that the claims are valid.
         * ``verify_aud=True`` but will be ignored if ``verify_signature`` is ``False``.
             Check that ``aud`` (audience) claim matches ``audience``
         * ``verify_iat=True`` but will be ignored if ``verify_signature`` is ``False``.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -45,6 +45,8 @@ API Reference
             Check that ``exp`` (expiration) claim value is OK
         * ``verify_iss=True`` but will be ignored if ``verify_signature`` is ``False``.
             Check that ``iss`` (issuer) claim matches ``issuer``
+        * ``verify_nbf=True`` but will be ignored if ``verify_signature`` is ``False``.
+            Check that ``nbf`` (not before) is in the past
         * ``verify_signature=True`` verify the JWT cryptographic signature
 
     :param Iterable audience: optional, the value for ``verify_aud`` check

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -37,10 +37,14 @@ API Reference
         * ``require_exp=False`` check that ``exp`` (expiration) claim is present
         * ``require_iat=False`` check that ``iat`` (issued at) claim is present
         * ``require_nbf=False`` check that ``nbf`` (not before) claim is present
-        * ``verify_aud=False`` check that ``aud`` (audience) claim matches ``audience``
-        * ``verify_iat=False`` check that ``iat`` (issued at) claim value is an integer
-        * ``verify_exp=False`` check that ``exp`` (expiration) claim value is OK
-        * ``verify_iss=False`` check that ``iss`` (issuer) claim matches ``issuer``
+        * ``verify_aud=True`` but will be ignored if ``verify_signature`` is ``False``.
+            Check that ``aud`` (audience) claim matches ``audience``
+        * ``verify_iat=True`` but will be ignored if ``verify_signature`` is ``False``.
+            Check that ``iat`` (issued at) claim value is an integer
+        * ``verify_exp=True`` but will be ignored if ``verify_signature`` is ``False``.
+            Check that ``exp`` (expiration) claim value is OK
+        * ``verify_iss=True`` but will be ignored if ``verify_signature`` is ``False``.
+            Check that ``iss`` (issuer) claim matches ``issuer``
         * ``verify_signature=True`` verify the JWT cryptographic signature
 
     :param Iterable audience: optional, the value for ``verify_aud`` check

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,9 +34,8 @@ API Reference
 
     :param dict options: extended decoding and validation options
 
-        * ``require_exp=False`` check that ``exp`` (expiration) claim is present
-        * ``require_iat=False`` check that ``iat`` (issued at) claim is present
-        * ``require_nbf=False`` check that ``nbf`` (not before) claim is present
+        * ``require=[]`` list of claims that must be present. E.g. ``require=["exp", "iat", "nbf"]``.
+            Only verifies that the claims exists. Does NOT verify that the claims are valid. 
         * ``verify_aud=True`` but will be ignored if ``verify_signature`` is ``False``.
             Check that ``aud`` (audience) claim matches ``audience``
         * ``verify_iat=True`` but will be ignored if ``verify_signature`` is ``False``.


### PR DESCRIPTION
## Description

- Fix incorrect default values in the documentation. (https://github.com/jpadilla/pyjwt/commit/0b537a402c4f0683cab532754a2cdd7fe6d612b0): `verify_aud`, `verify_iat`, `verify_exp`, and `verify_iss` is `True` by default
  https://github.com/jpadilla/pyjwt/blob/3993ce1d3503b58cf74699a89ba9e5c18ef9b556/jwt/api_jwt.py#L26-L35
  https://github.com/jpadilla/pyjwt/blob/3993ce1d3503b58cf74699a89ba9e5c18ef9b556/jwt/api_jwt.py#L98-L100
- Add missing option `verify_nbf` to documentation (https://github.com/jpadilla/pyjwt/commit/e92ef3df069c0287c957d077d9869b3af4b03be8)
  https://github.com/jpadilla/pyjwt/blob/3993ce1d3503b58cf74699a89ba9e5c18ef9b556/jwt/api_jwt.py#L132-L133
- Set `require` to be  list (https://github.com/jpadilla/pyjwt/commit/692adae4cce44526d5b01ee7bd95b22b7e61f741)
  https://github.com/jpadilla/pyjwt/blob/3993ce1d3503b58cf74699a89ba9e5c18ef9b556/jwt/api_jwt.py#L144-L147