### PR TITLE
Remove arbitrary kwargs.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`__.
 Changed
 ~~~~~~~
 
+- Remove arbitrary kwalgs. `#657 <https://github.com/jpadilla/pyjwt/pull/657>`__
+
 Fixed
 ~~~~~
 

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -131,7 +131,6 @@ class PyJWS:
         key: str = "",
         algorithms: List[str] = None,
         options: Dict = None,
-        **kwargs,
     ) -> Dict[str, Any]:
         if options is None:
             options = {}
@@ -160,9 +159,8 @@ class PyJWS:
         key: str = "",
         algorithms: List[str] = None,
         options: Dict = None,
-        **kwargs,
     ) -> str:
-        decoded = self.decode_complete(jwt, key, algorithms, options, **kwargs)
+        decoded = self.decode_complete(jwt, key, algorithms, options)
         return decoded["payload"]
 
     def get_unverified_header(self, jwt):

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -105,6 +105,17 @@ class TestJWT:
         exception = context.value
         assert str(exception) == "Invalid payload string: must be a json object"
 
+    def test_decode_with_unknown_parameter_throws_exception(self, jwt):
+        secret = "secret"
+        example_jwt = (
+            b"eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9"
+            b".eyJoZWxsbyI6ICJ3b3JsZCJ9"
+            b".tvagLDLoaiJKxOKqpBXSEGy7SYSifZhjntgm9ctpyj8"
+        )
+
+        with pytest.raises(TypeError):
+            jwt.decode(example_jwt, key=secret, foo="bar", algorithms=["HS256"])
+
     def test_decode_with_invalid_audience_param_throws_exception(self, jwt):
         secret = "secret"
         example_jwt = (


### PR DESCRIPTION
Removed arbitrary keyword parameters (**kwargs) that are not being used in order to comply with the current API specification.
As mentioned in #606, I think it's a bit problematic not to get an error if you specify an unsupported argument.

If you agree with this change, I will update a CHANGELOG.

Close #606.