### PR TITLE
DOC: Clarify RSA encoding and decoding depend on the cryptography package

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,6 +7,9 @@ You can install ``PyJWT`` with ``pip``:
 
     $ pip install pyjwt
 
+
+.. _installation_cryptography
+
 Cryptographic Dependencies (Optional)
 -------------------------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -17,6 +17,8 @@ Encoding & Decoding Tokens with HS256
 Encoding & Decoding Tokens with RS256 (RSA)
 -------------------------------------------
 
+RSA encoding and decoding require the ``cryptography`` module. See :ref:`installation_cryptography`.
+
 .. code-block:: pycon
 
     >>> import jwt


### PR DESCRIPTION
Followup to #208

I faced a similar issue because I read the installation part a little too fast, but I believe this should be clarified over the example many other developers will refer to.

Thanks for this project ❤️ 