### PR TITLE
support decoding and encoding DEFLATE-encoded JWT bodies

### DIFF
--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -3,6 +3,7 @@ from calendar import timegm
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Type, Union
+import zlib
 
 from . import api_jws
 from .exceptions import (
@@ -96,7 +97,11 @@ class PyJWT:
         )
 
         try:
-            payload = json.loads(decoded["payload"])
+            if decoded.get("header", {}).get("zip", None) == "DEF":
+                raw_payload = zlib.decompress(decoded["payload"], wbits=-8)
+            else:
+                raw_payload = decoded["payload"]
+            payload = json.loads(raw_payload)
         except ValueError as e:
             raise DecodeError("Invalid payload string: %s" % e)
         if not isinstance(payload, dict):


### PR DESCRIPTION
These are used in the [Smart Health Card](https://spec.smarthealth.cards/) framework that several regions (including California and Quebec) are using for COVID-19 proofs of vaccination, and are supported by some other JWT libraries, such as [jwt-go](https://github.com/dgrijalva/jwt-go/pull/102).

If y'all like this approach, I'm glad to write tests. I could also see putting this logic in `api_jws.py`.