### PR TITLE
Assume JWK is valid for signing if "use" is omitted

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Changed
 
 Fixed
 ~~~~~
+- Assume JWK without the "use" claim is valid for signing as per RFC7517 `#668 <https://github.com/jpadilla/pyjwt/pull/668>`__
 
 Added
 ~~~~~

--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -29,7 +29,7 @@ class PyJWKClient:
         signing_keys = []
 
         for jwk_set_key in jwk_set.keys:
-            if jwk_set_key.public_key_use == "sig" and jwk_set_key.key_id:
+            if jwk_set_key.public_key_use in ["sig", None] and jwk_set_key.key_id:
                 signing_keys.append(jwk_set_key)
 
         if len(signing_keys) == 0:

--- a/tests/test_jwks_client.py
+++ b/tests/test_jwks_client.py
@@ -61,6 +61,20 @@ class TestPyJWKClient:
         assert len(signing_keys) == 1
         assert isinstance(signing_keys[0], PyJWK)
 
+    def test_get_signing_keys_if_no_use_provided(self):
+        url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
+
+        mocked_key = RESPONSE_DATA["keys"][0].copy()
+        del mocked_key["use"]
+        response = {"keys": [mocked_key]}
+
+        with mocked_response(response):
+            jwks_client = PyJWKClient(url)
+            signing_keys = jwks_client.get_signing_keys()
+
+        assert len(signing_keys) == 1
+        assert isinstance(signing_keys[0], PyJWK)
+
     def test_get_signing_keys_raises_if_none_found(self):
         url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
 


### PR DESCRIPTION
There's an issue https://github.com/jpadilla/pyjwt/issues/626 about this problem. I ran into it today too.

Currently, when getting signing keys, PyJWKClient assumes that a key is intended for signing, only if its "use" claim is set to "sig". This is not entirely correct, as this claim is optional. If it's omitted, then the key can be used both for signing and encryption. 

I guess the correct way to process fetched keys is to check that their "use" claim is either "sig" or missing. In this case, we can safely append it to the list of signing keys.