### PR TITLE
Fix aud validation to support {'aud': null} case.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Changed
 Fixed
 ~~~~~
 
+- Fix aud validation to support {'aud': null} case. `#670 <https://github.com/jpadilla/pyjwt/pull/670>`__
+
 Added
 ~~~~~
 

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -177,18 +177,17 @@ class PyJWT:
             raise ExpiredSignatureError("Signature has expired")
 
     def _validate_aud(self, payload, audience):
-        if audience is None and "aud" not in payload:
-            return
-
-        if audience is not None and "aud" not in payload:
-            # Application specified an audience, but it could not be
-            # verified since the token does not contain a claim.
-            raise MissingRequiredClaimError("aud")
-
-        if audience is None and "aud" in payload:
+        if audience is None:
+            if "aud" not in payload or not payload["aud"]:
+                return
             # Application did not specify an audience, but
             # the token has the 'aud' claim
             raise InvalidAudienceError("Invalid audience")
+
+        if "aud" not in payload or not payload["aud"]:
+            # Application specified an audience, but it could not be
+            # verified since the token does not contain a claim.
+            raise MissingRequiredClaimError("aud")
 
         audience_claims = payload["aud"]
 

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -202,6 +202,16 @@ class TestJWT:
         with pytest.raises(DecodeError):
             jwt.decode(example_jwt, "secret", algorithms=["HS256"])
 
+    def test_decode_raises_exception_if_aud_is_none(self, jwt):
+        # >>> jwt.encode({'aud': None}, 'secret')
+        example_jwt = (
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
+            "eyJhdWQiOm51bGx9."
+            "-Peqc-pTugGvrc5C8Bnl0-X1V_5fv-aVb_7y7nGBVvQ"
+        )
+        decoded = jwt.decode(example_jwt, "secret", algorithms=["HS256"])
+        assert decoded["aud"] is None
+
     def test_encode_datetime(self, jwt):
         secret = "secret"
         current_datetime = datetime.utcnow()
@@ -406,6 +416,15 @@ class TestJWT:
 
     def test_raise_exception_token_without_audience(self, jwt):
         payload = {"some": "payload"}
+        token = jwt.encode(payload, "secret")
+
+        with pytest.raises(MissingRequiredClaimError) as exc:
+            jwt.decode(token, "secret", audience="urn:me", algorithms=["HS256"])
+
+        assert exc.value.claim == "aud"
+
+    def test_raise_exception_token_with_aud_none_and_without_audience(self, jwt):
+        payload = {"some": "payload", "aud": None}
         token = jwt.encode(payload, "secret")
 
         with pytest.raises(MissingRequiredClaimError) as exc:


### PR DESCRIPTION
Hi, @jpadilla. 

I found a case where a JWT has {"aud": null} header. In the current implementation, if {”aud”: null｝is specified, the audience parameter must be specified on decode() function.

I think {"aud": null} should be treated as the same as that is not specified.

See #669 for details.

Closes #669