### PR TITLE
feat: allow PyJWKClient to receive HTTPS context

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Fixed
 Added
 ~~~~~
 
+- Allow PyJWKClient to receive HTTPS context
+
 `v2.1.0 <https://github.com/jpadilla/pyjwt/compare/2.0.1...2.1.0>`__
 --------------------------------------------------------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -291,3 +291,19 @@ Retrieve RSA signing keys from a JWKS endpoint
     ... )
     >>> print(data)
     {'iss': 'https://dev-87evx9ru.auth0.com/', 'sub': 'aW4Cca79xReLWUz0aE2H6kD0O3cXBVtC@clients', 'aud': 'https://expenses-api', 'iat': 1572006954, 'exp': 1572006964, 'azp': 'aW4Cca79xReLWUz0aE2H6kD0O3cXBVtC', 'gty': 'client-credentials'}
+
+You can pass a SSL context as an argument to PyJWKClient. This is useful to set
+manually a certificate or by pass certificate validation, for example.
+
+.. code-block:: pycon
+
+    >>> from ssl import SSLContext
+    >>> context = SSLContext()
+    >>> context.check_hostname = False
+    >>> import jwt
+    >>> from jwt import PyJWKClient
+    >>> url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
+    >>> jwks_client = PyJWKClient(url, ssl_context=context)
+    >>> keys = jwks_client.get_jwk_set()
+    >>> print(keys)
+    <jwt.api_jwk.PyJWKSet object at 0x7f9063af0d00>


### PR DESCRIPTION
Sometimes you have a SSO with a customized certificate, or you just need
to ignore certificate validation for testing or development pourposes.
This change allow us to call PyJWKClient with a customized SSLContext,
that allow us to customize JWKS URL request.