### PR TITLE
Implement AWS KMS algorithm

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import json
+import re
 
 from .exceptions import InvalidKeyError
 from .utils import (
@@ -688,10 +689,35 @@ if has_kms:
 
     class AWSKMSAlgorithm(Algorithm):
 
+        # Basic UUID
+        uuid_pattern = r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        mrk_pattern = r'mrk-[0-9a-f]{32}'
+        # arn:[partition]:kms:[region name]:[account id]:
+        arn_pattern = r'arn:[\w\-]*:kms:[\w\-]+:\d{12}:'
+        single_region_pattern = re.compile(uuid_pattern)
+        multi_region_pattern = re.compile(mrk_pattern)
+        arn_key_single_region_pattern = re.compile(rf'{arn_pattern}key/{uuid_pattern}')
+        arn_key_multi_region_pattern = re.compile(rf'{arn_pattern}key/{mrk_pattern}')
+        arn_alias_pattern = re.compile(rf'{arn_pattern}alias/.+')
+
         def __init__(self, **kwargs):
             pass
 
         def prepare_key(self, key):
+            if self.single_region_pattern.match(key):
+                pass
+            elif self.multi_region_pattern.match(key):
+                pass
+            elif self.arn_key_single_region_pattern.match(key):
+                pass
+            elif self.arn_key_multi_region_pattern.match(key):
+                pass
+            elif self.arn_alias_pattern.match(key):
+                pass
+            elif key.startswith('alias/'):
+                pass
+            else:
+                raise TypeError("Expecting a valid KMS key id.")
             return key
 
         def sign(self, msg, key):

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -689,15 +689,15 @@ if has_kms:
     class AWSKMSAlgorithm(Algorithm):
 
         # Basic UUID
-        uuid_pattern = r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
-        mrk_pattern = r'mrk-[0-9a-f]{32}'
+        uuid_pattern = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        mrk_pattern = r"mrk-[0-9a-f]{32}"
         # arn:[partition]:kms:[region name]:[account id]:
-        arn_pattern = r'arn:[\w\-]*:kms:[\w\-]+:\d{12}:'
+        arn_pattern = r"arn:[\w\-]*:kms:[\w\-]+:\d{12}:"
         single_region_pattern = re.compile(uuid_pattern)
         multi_region_pattern = re.compile(mrk_pattern)
-        arn_key_single_region_pattern = re.compile(rf'{arn_pattern}key/{uuid_pattern}')
-        arn_key_multi_region_pattern = re.compile(rf'{arn_pattern}key/{mrk_pattern}')
-        arn_alias_pattern = re.compile(rf'{arn_pattern}alias/.+')
+        arn_key_single_region_pattern = re.compile(rf"{arn_pattern}key/{uuid_pattern}")
+        arn_key_multi_region_pattern = re.compile(rf"{arn_pattern}key/{mrk_pattern}")
+        arn_alias_pattern = re.compile(rf"{arn_pattern}alias/.+")
 
         def __init__(self, **kwargs):
             pass
@@ -713,7 +713,7 @@ if has_kms:
                 pass
             elif self.arn_alias_pattern.match(key):
                 pass
-            elif key.startswith('alias/'):
+            elif key.startswith("alias/"):
                 pass
             else:
                 raise TypeError("Expecting a valid KMS key id.")


### PR DESCRIPTION
Hello! This adds a new "algorithm" that wraps the AWS KMS `sign` and `verify` methods. If given a valid ARN (and provided that AWS credentials are properly set) this algorithm allows for encoding and decoding JWTs without ever seeing a private or public key.

Example usage:

```
import jwt
arn = 'arn:aws:kms:us-east-1:2***0:key/***'
jtw_str = jwt.encode({'foo': 'bar'}, arn, algorithm='AWS-KMS')
dct = jwt.decode(jwt_str, arn, algorithms=['AWS-KMS'])
```

This is a WIP as there are some issues to work out. 

- How does the user change the signing algorithm? 
- What if the AWS credentials are not set up? 
- How to mock the API for testing purposes?
Any ideas are welcome.

Closes #681 