### PR TITLE
mbeliaev/setup_fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ docs =
     sphinx-rtd-theme
     zope.interface
 crypto =
-    cryptography>=3.3.1,<4.0.0
+    cryptography>=3.3.1,<50.0.0
 tests =
     pytest>=6.0.0,<7.0.0
     coverage[toml]==5.0.4


### PR DESCRIPTION
need to fix the version due to change in cryptography release. See https://github.com/pyca/cryptography/issues/6344 and https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst