### PR TITLE
Remove upper bound on cryptography version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ docs =
     sphinx-rtd-theme
     zope.interface
 crypto =
-    cryptography>=3.3.1,<4.0.0
+    cryptography>=3.3.1
 tests =
     pytest>=6.0.0,<7.0.0
     coverage[toml]==5.0.4
@@ -52,7 +52,7 @@ dev =
     sphinx
     sphinx-rtd-theme
     zope.interface
-    cryptography>=3.3.1,<4.0.0
+    cryptography>=3.3.1
     pytest>=6.0.0,<7.0.0
     coverage[toml]==5.0.4
     mypy


### PR DESCRIPTION
Cryptography has adopted a firefox-style versioning system where new
feature releases always have new major versions even if they don't have
backwards incompatible changes. This means that an upper bound on the
dependency does not make sense.

Resolves #692 