### PR TITLE
Explicit check the key for ECAlgorithm

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -417,6 +417,10 @@ if has_crypto:
             except ValueError:
                 key = load_pem_private_key(key, password=None)
 
+            # Explicit check the key to prevent confusing errors from cryptography
+            if not isinstance(key, (EllipticCurvePrivateKey, EllipticCurvePublicKey)):
+                raise InvalidKeyError("Expecting a EllipticCurvePrivateKey/EllipticCurvePublicKey. Wrong key provided for ECDSA algorithms")
+
             return key
 
         def sign(self, msg, key):

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -419,7 +419,9 @@ if has_crypto:
 
             # Explicit check the key to prevent confusing errors from cryptography
             if not isinstance(key, (EllipticCurvePrivateKey, EllipticCurvePublicKey)):
-                raise InvalidKeyError("Expecting a EllipticCurvePrivateKey/EllipticCurvePublicKey. Wrong key provided for ECDSA algorithms")
+                raise InvalidKeyError(
+                    "Expecting a EllipticCurvePrivateKey/EllipticCurvePublicKey. Wrong key provided for ECDSA algorithms"
+                )
 
             return key
 

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -495,6 +495,18 @@ class TestAlgorithms:
         assert not result
 
     @crypto_required
+    def test_ec_should_throw_exception_on_wrong_key(self):
+        algo = ECAlgorithm(ECAlgorithm.SHA256)
+
+        with pytest.raises(InvalidKeyError):
+            with open(key_path("testkey_rsa.priv")) as keyfile:
+                algo.prepare_key(keyfile.read())
+
+        with pytest.raises(InvalidKeyError):
+            with open(key_path("testkey2_rsa.pub.pem")) as pem_key:
+                algo.prepare_key(pem_key.read())
+
+    @crypto_required
     def test_rsa_pss_sign_then_verify_should_return_true(self):
         algo = RSAPSSAlgorithm(RSAPSSAlgorithm.SHA256)
 


### PR DESCRIPTION
Hi!

I was try to encode and sign jwt with ES256 algorithm and key was generated not by me.
And I don't know what kind of key was.

And I fall to same situation as #706  - `TypeError: sign() missing 1 required positional argument: 'algorithm'`
When I dig in  (one hour later)  And it was not incompatible pjwt with cryptography.
The key was RSA (without curve) 

This PR - throws the explicit exception to check your key.

P.S. Sorry for my poor English and feel free to close this PR without merging it