### PR TITLE
refactor: Support TypedDict

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 José Padilla
+Copyright (c) 2015-2022 José Padilla
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "PyJWT"
-copyright = "2015, José Padilla"
+copyright = "2015-2022, José Padilla"
 author = "José Padilla"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -37,7 +37,7 @@ __author__ = "José Padilla"
 __email__ = "hello@jpadilla.com"
 
 __license__ = "MIT"
-__copyright__ = "Copyright 2015-2020 José Padilla"
+__copyright__ = "Copyright 2015-2022 José Padilla"
 
 
 __all__ = [

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -50,7 +50,7 @@ class PyJWS:
 
         if options is None:
             options = PyJWSOptions()
-        self.options = PyJWSOptions(**self._get_default_options(), **options)
+        self.options = PyJWSOptions({**self._get_default_options(), **options})
 
     @staticmethod
     def _get_default_options() -> PyJWSOptions:
@@ -154,7 +154,7 @@ class PyJWS:
     ) -> DecodedPyJWS:
         if options is None:
             options = PyJWSOptions()
-        merged_options = PyJWSOptions(**self.options, **options)
+        merged_options = PyJWSOptions({**self.options, **options})
         verify_signature = merged_options["verify_signature"]
 
         if verify_signature and not algorithms:

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -2,7 +2,7 @@ import binascii
 import json
 from collections.abc import Mapping
 from sys import version_info
-from typing import Any, Dict, List, Optional, Type
+from typing import Dict, List, Optional, Type
 
 from .algorithms import (
     Algorithm,

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -3,7 +3,7 @@ from calendar import timegm
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timedelta, timezone
 from sys import version_info
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type
 
 from . import api_jws
 from .exceptions import (

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -117,7 +117,7 @@ class PyJWT:
         if not isinstance(payload, dict):
             raise DecodeError("Invalid payload string: must be a json object")
 
-        merged_options = {**self.options, **options}
+        merged_options = PyJWTOptions({**self.options, **options})
         self._validate_claims(payload, merged_options, **kwargs)
 
         decoded["payload"] = payload

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,9 @@ include_package_data = true
 python_requires = >=3.6
 packages = find:
 
+install_requires =
+    typing-extensions>=4;python_version<"3.8"
+
 [options.package_data]
 * = py.typed
 


### PR DESCRIPTION
This merge request adds support for `TypedDict` for Options and certain returns to improve type hints. This relies on the typing-extensions module if below Python 3.8 or uses the standard library's implementation if it's available.

Accidentally based off of #729