### PR TITLE
Fixed typo in usage.rst

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -8,7 +8,7 @@ Encoding & Decoding Tokens with HS256
 
     >>> import jwt
     >>> key = "secret"
-    >>> encoded = jwt.encode({"some": "payload"}, key, algorithms="HS256")
+    >>> encoded = jwt.encode({"some": "payload"}, key, algorithm="HS256")
     >>> print(encoded)
     eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzb21lIjoicGF5bG9hZCJ9.4twFt5NiznN84AWoo1d7KO1T_yoc0Z6XOpOVswacPZg
     >>> jwt.decode(encoded, key, algorithms="HS256")


### PR DESCRIPTION
In the example [above](https://github.com/jpadilla/pyjwt/edit/master/docs/usage.rst#encoding--decoding-tokens-with-hs256), when tried, it throws a TypeError that says: `encode() got an unexpected keyword argument 'algorithms'`, so I changed the `algorithms` to `algorithm`