### PR TITLE
Don't raise error when algorithm is not support

### DIFF
--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -48,6 +48,7 @@ class PyJWK:
 
         if not self.Algorithm:
             import logging
+
             self.key = None
             logger = logging.getLogger(__name__)
             logger.warning("Do not support algorithm %s", algorithm)

--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -47,9 +47,11 @@ class PyJWK:
         self.Algorithm = self._algorithms.get(algorithm)
 
         if not self.Algorithm:
-            raise PyJWKError("Unable to find a algorithm for key: %s" % self._jwk_data)
-
-        self.key = self.Algorithm.from_jwk(self._jwk_data)
+            self.key = None
+            logger = logging.getLogger(__name__)
+            logger.warning("Do not support algorithm %s", algorithm)
+        else:
+            self.key = self.Algorithm.from_jwk(self._jwk_data)
 
     @staticmethod
     def from_dict(obj, algorithm=None):

--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -47,6 +47,7 @@ class PyJWK:
         self.Algorithm = self._algorithms.get(algorithm)
 
         if not self.Algorithm:
+            import logging
             self.key = None
             logger = logging.getLogger(__name__)
             logger.warning("Do not support algorithm %s", algorithm)


### PR DESCRIPTION
Instead of raising an error for not supported algorithm we log the warning, and continue with other algorithms/keys