### PR TITLE
Update jwks_client.py due to public key use "encryption"

### DIFF
--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -29,7 +29,7 @@ class PyJWKClient:
         signing_keys = [
             jwk_set_key
             for jwk_set_key in jwk_set.keys
-            if jwk_set_key.public_key_use in ["sig", None] and jwk_set_key.key_id
+            if jwk_set_key.public_key_use in ["sig", "enc", None] and jwk_set_key.key_id
         ]
 
         if not signing_keys:


### PR DESCRIPTION
If the public key use of the JWK is encryption, this code does not work. Is there a reason for that?
https://datatracker.ietf.org/doc/html/rfc7517#section-4.2