### PR TITLE
Update CHANGELOG.rst

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -164,6 +164,11 @@ For example, instead of
 use
 ``jwt.decode(encoded, key, algorithms=["HS256"], options={"require": ["exp"]})``.
 
+And the old v1.x syntax
+``jwt.decode(token, verify=False)``
+is now:
+``jwt.decode(jwt=token, key='secret', algorithms=['HS256'], options={"verify_signature": False, "verify_exp": True})``
+
 Added
 ~~~~~
 


### PR DESCRIPTION
Add an example of how to convert the old v1.x syntax into v2.x one. That old syntax was popular but it was not clear how to change it after pyjwt upgrade.