### PR TITLE
Adjust expected exceptions in option merging tests for PyPy3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,8 @@ jobs:
     strategy:
       matrix:
         platform: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10",
+                         "3.11.0-beta - 3.11", "pypy-3.8", "pypy-3.9"]
 
     steps:
       - uses: "actions/checkout@v3"

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -83,7 +83,7 @@ class TestJWS:
 
     def test_options_must_be_dict(self, jws):
         pytest.raises(TypeError, PyJWS, options=object())
-        pytest.raises(TypeError, PyJWS, options=("something"))
+        pytest.raises((TypeError, ValueError), PyJWS, options=("something"))
 
     def test_encode_decode(self, jws, payload):
         secret = "secret"
@@ -607,7 +607,7 @@ class TestJWS:
         with pytest.raises(TypeError):
             jws.decode(token, "secret", options=object())
 
-        with pytest.raises(TypeError):
+        with pytest.raises((TypeError, ValueError)):
             jws.decode(token, "secret", options="something")
 
     def test_custom_json_encoder(self, jws, payload):

--- a/tox.ini
+++ b/tox.ini
@@ -13,13 +13,17 @@ python =
     3.8: py38, typing
     3.9: py39
     3.10: py310
+    3.11: py311
+    pypy-3.7: pypy3
+    pypy-3.8: pypy3
+    pypy-3.9: pypy3
 
 
 [tox]
 envlist =
     lint
     typing
-    py{36,37,38,39}-{crypto,nocrypto}
+    py{36,37,38,39,310,311,py3}-{crypto,nocrypto}
     docs
     pypi-description
     coverage-report

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
-    pypy-3.7: pypy3
     pypy-3.8: pypy3
     pypy-3.9: pypy3
 


### PR DESCRIPTION
PyPy3 raises ValueError rather than TypeError when trying to combine
a dict and a str in dict unpacking.  Update the test expectations
appropriately.

Fixes #580

-----
I've also fixed CI testing for Python 3.10 (no tox targets were run) and added 3.11 and all PyPy3 versions. They seem to all pass on my fork, except for codecov uploads (obviously).