### PR TITLE
Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
The `wheel` dependency is added automatically by setuptools build
backend (since day one) and therefore should not be specified
explicitly.  Listing it in documentation was a historical mistake
and has been corrected since.  See:
https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a