### PR TITLE
ignoring RSA-OAEP if included in algorithm so it falls back to 'kty'

### DIFF
--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -16,7 +16,7 @@ class PyJWK:
         if not algorithm and isinstance(self._jwk_data, dict):
             algorithm = self._jwk_data.get("alg", None)
 
-        if not algorithm:
+        if not algorithm or "OAEP" in algorithm:
             # Determine alg with kty (and crv).
             crv = self._jwk_data.get("crv", None)
             if kty == "EC":


### PR DESCRIPTION
So this seems like a bit of a stretch to just ignore the algorithm if `RSA-OAEP`, but I have a working proof of concept to back it up:

https://github.com/gchamon/pyjwt-oaep-poc

Read the readme for more details on how to run the PoC. You can switch back and forth between my branch and the official pyjwt package by commenting/uncommenting the lines in `Pipfile` related to the package.

Resolves: https://github.com/jpadilla/pyjwt/issues/722