### PR TITLE
type hint fix

### DIFF
--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -42,7 +42,7 @@ class PyJWT:
         algorithm: Optional[str] = "HS256",
         headers: Optional[Dict[str, Any]] = None,
         json_encoder: Optional[Type[json.JSONEncoder]] = None,
-    ) -> str:
+    ) -> bytes:
         # Check that we get a mapping
         if not isinstance(payload, Mapping):
             raise TypeError(


### PR DESCRIPTION
encode is returning a bytes object but the annotation suggests that it returns a str. Trying to send the token over the network ends up ruining the token. The fix is easy - applying `token.decode('utf-8')`, but it can only be used if the developer knows that encode returns `bytes`.