### PR TITLE
Remove support for python3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         platform: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10",
+        python-version: ["3.7", "3.8", "3.9", "3.10",
                          "3.11.0-beta - 3.11", "pypy-3.8", "pypy-3.9"]
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,13 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-        args: ["--target-version=py36"]
+        args: ["--target-version=py37"]
 
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.12.1
     hooks:
       - id: blacken-docs
-        args: ["--target-version=py36"]
+        args: ["--target-version=py37"]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`__.
 Changed
 ~~~~~~~
 - Skip keys with incompatible alg when loading JWKSet by @DaGuich in https://github.com/jpadilla/pyjwt/pull/762
+- Remove support for python3.6
 
 Fixed
 ~~~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -33,7 +32,7 @@ classifiers =
 [options]
 zip_safe = false
 include_package_data = true
-python_requires = >=3.6
+python_requires = >=3.7
 packages = find:
 
 [options.package_data]
@@ -68,7 +67,7 @@ exclude =
 extend-ignore = E203, E501
 
 [mypy]
-python_version = 3.6
+python_version = 3.7
 ignore_missing_imports = true
 warn_unused_ignores = true
 no_implicit_optional = true

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ filterwarnings =
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37, docs
     3.8: py38, typing
     3.9: py39
@@ -22,7 +21,7 @@ python =
 envlist =
     lint
     typing
-    py{36,37,38,39,310,311,py3}-{crypto,nocrypto}
+    py{37,38,39,310,311,py3}-{crypto,nocrypto}
     docs
     pypi-description
     coverage-report


### PR DESCRIPTION
closes #764 

---

The presence of `py36` in `tox.ini` makes it that much slower to run full tests locally with a bare `tox` invocation. It looks like 3.6 isn't supported anymore, and there's an unfinished PR to remove it. Just take the requisite steps to finish the job.