### PR TITLE
refactor: add type hints to help and algorithms

### DIFF
--- a/jwt/help.py
+++ b/jwt/help.py
@@ -1,6 +1,7 @@
 import json
 import platform
 import sys
+import typing
 
 from . import __version__ as pyjwt_version
 
@@ -10,7 +11,7 @@ except ModuleNotFoundError:
     cryptography = None  # type: ignore
 
 
-def info():
+def info() -> typing.Dict[str, typing.Union[typing.Dict[str, str], str]]:
     """
     Generate information for a bug report.
     Based on the requests package help utility module.
@@ -29,13 +30,13 @@ def info():
         implementation_version = platform.python_version()
     elif implementation == "PyPy":
         implementation_version = (
-            f"{sys.pypy_version_info.major}."
-            f"{sys.pypy_version_info.minor}."
-            f"{sys.pypy_version_info.micro}"
+            f"{sys.pypy_version_info.major}."  # type: ignore
+            f"{sys.pypy_version_info.minor}."  # type: ignore
+            f"{sys.pypy_version_info.micro}"  # type: ignore
         )
-        if sys.pypy_version_info.releaselevel != "final":
+        if sys.pypy_version_info.releaselevel != "final":  # type: ignore
             implementation_version = "".join(
-                [implementation_version, sys.pypy_version_info.releaselevel]
+                [implementation_version, sys.pypy_version_info.releaselevel]  # type: ignore
             )
     else:
         implementation_version = "Unknown"
@@ -51,7 +52,7 @@ def info():
     }
 
 
-def main():
+def main() -> None:
     """Pretty-print the bug information as JSON."""
     print(json.dumps(info(), sort_keys=True, indent=2))
 


### PR DESCRIPTION
This merge request expands the type hints to the algorithms and help files. Additional work will be done after this is merged to extend type hints to remaining parts of the API and expand type information to better address gaps / inaccuracies as reported in #660