### PR TITLE
Improve PyJWKSet error accuracy

### DIFF
--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 from .algorithms import get_default_algorithms
@@ -74,14 +76,14 @@ class PyJWK:
 
 
 class PyJWKSet:
-    def __init__(self, keys):
+    def __init__(self, keys: list[dict]) -> None:
         self.keys = []
 
-        if not keys or not isinstance(keys, list):
-            raise PyJWKSetError("Invalid JWK Set value")
-
-        if len(keys) == 0:
+        if not keys:
             raise PyJWKSetError("The JWK Set did not contain any keys")
+
+        if not isinstance(keys, list):
+            raise PyJWKSetError("Invalid JWK Set value")
 
         for key in keys:
             try:

--- a/tests/test_api_jwk.py
+++ b/tests/test_api_jwk.py
@@ -290,3 +290,13 @@ class TestPyJWKSet:
             assert len(jwks.get("keys")) == 1
             with pytest.raises(PyJWKSetError):
                 _ = PyJWKSet.from_json(jwks_text)
+
+    def test_invalid_keys_list(self):
+        with pytest.raises(PyJWKSetError) as err:
+            PyJWKSet(keys="string")
+        assert str(err.value) == "Invalid JWK Set value"
+
+    def test_empty_keys_list(self):
+        with pytest.raises(PyJWKSetError) as err:
+            PyJWKSet(keys=[])
+        assert str(err.value) == "Invalid JWK Set value"

--- a/tests/test_api_jwk.py
+++ b/tests/test_api_jwk.py
@@ -299,4 +299,4 @@ class TestPyJWKSet:
     def test_empty_keys_list(self):
         with pytest.raises(PyJWKSetError) as err:
             PyJWKSet(keys=[])
-        assert str(err.value) == "Invalid JWK Set value"
+        assert str(err.value) == "The JWK Set did not contain any keys"

--- a/tests/test_api_jwk.py
+++ b/tests/test_api_jwk.py
@@ -208,8 +208,8 @@ class TestPyJWK:
             PyJWK.from_dict(v)
 
 
+@crypto_required
 class TestPyJWKSet:
-    @crypto_required
     def test_should_load_keys_from_jwk_data_dict(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
@@ -231,7 +231,6 @@ class TestPyJWKSet:
         assert jwk.key_id == "keyid-abc123"
         assert jwk.public_key_use == "sig"
 
-    @crypto_required
     def test_should_load_keys_from_jwk_data_json_string(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
@@ -253,7 +252,6 @@ class TestPyJWKSet:
         assert jwk.key_id == "keyid-abc123"
         assert jwk.public_key_use == "sig"
 
-    @crypto_required
     def test_keyset_should_index_by_kid(self):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
@@ -276,7 +274,6 @@ class TestPyJWKSet:
         with pytest.raises(KeyError):
             _ = jwk_set["this-kid-does-not-exist"]
 
-    @crypto_required
     def test_keyset_with_unknown_alg(self):
         # first keyset with unusable key and usable key
         with open(key_path("jwk_keyset_with_unknown_alg.json")) as keyfile:


### PR DESCRIPTION
Hello :wave: 

This RP is intended to correct the problem related to issue #754.
I took the opportunity to add some typing and to simplify the testcase a bit.

I feel like we could also bring some key payload validation at the `PyJWK` constructor level (in another PR).