### PR TITLE
Mypy as pre-commit check + api_jws typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,8 @@ repos:
     hooks:
       - id: check-manifest
         args: [--no-build-isolation]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: "v0.971"
+    hooks:
+      - id: mypy

--- a/jwt/help.py
+++ b/jwt/help.py
@@ -8,7 +8,7 @@ from . import __version__ as pyjwt_version
 try:
     import cryptography
 except ModuleNotFoundError:
-    cryptography = None  # type: ignore
+    cryptography = None
 
 
 def info() -> Dict[str, Dict[str, str]]:
@@ -29,14 +29,15 @@ def info() -> Dict[str, Dict[str, str]]:
     if implementation == "CPython":
         implementation_version = platform.python_version()
     elif implementation == "PyPy":
+        pypy_version_info = getattr(sys, "pypy_version_info")
         implementation_version = (
-            f"{sys.pypy_version_info.major}."  # type: ignore[attr-defined]
-            f"{sys.pypy_version_info.minor}."
-            f"{sys.pypy_version_info.micro}"
+            f"{pypy_version_info.major}."
+            f"{pypy_version_info.minor}."
+            f"{pypy_version_info.micro}"
         )
-        if sys.pypy_version_info.releaselevel != "final":  # type: ignore[attr-defined]
+        if pypy_version_info.releaselevel != "final":
             implementation_version = "".join(
-                [implementation_version, sys.pypy_version_info.releaselevel]  # type: ignore[attr-defined]
+                [implementation_version, pypy_version_info.releaselevel]
             )
     else:
         implementation_version = "Unknown"

--- a/jwt/utils.py
+++ b/jwt/utils.py
@@ -1,7 +1,7 @@
 import base64
 import binascii
 import re
-from typing import Any, Union
+from typing import Union
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
@@ -10,7 +10,7 @@ try:
         encode_dss_signature,
     )
 except ModuleNotFoundError:
-    EllipticCurve = Any  # type: ignore
+    EllipticCurve = None
 
 
 def force_bytes(value: Union[str, bytes]) -> bytes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
-
 [tool.coverage.run]
 parallel = true
 branch = true
@@ -14,8 +13,13 @@ source = ["jwt", ".tox/*/site-packages"]
 [tool.coverage.report]
 show_missing = true
 
-
 [tool.isort]
 profile = "black"
 atomic = true
 combine_as_imports = true
+
+[tool.mypy]
+python_version = 3.7
+ignore_missing_imports = true
+warn_unused_ignores = true
+no_implicit_optional = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,6 @@ dev =
     types-cryptography>=3.3.21
     pytest>=6.0.0,<7.0.0
     coverage[toml]==5.0.4
-    mypy
     pre-commit
 
 [options.packages.find]
@@ -67,9 +66,3 @@ exclude =
 
 [flake8]
 extend-ignore = E203, E501
-
-[mypy]
-python_version = 3.7
-ignore_missing_imports = true
-warn_unused_ignores = true
-no_implicit_optional = true

--- a/tox.ini
+++ b/tox.ini
@@ -48,12 +48,6 @@ commands =
     python -m doctest README.rst
 
 
-[testenv:typing]
-basepython = python3.8
-extras = dev
-commands = mypy jwt
-
-
 [testenv:lint]
 basepython = python3.8
 extras = dev


### PR DESCRIPTION
Hello :wave: 

This RP is intended to solve the issue https://github.com/jpadilla/pyjwt/issues/745.

Moving the mypy check responsibility from tox env to pre-commit to reduce the feedback loop.
Moving config from `setup.cfg` to `pyproject.toml` to fit the new standard.

Thanks for the review :man_dancing: 