### PR TITLE
Remove `types-cryptography` from `crypto` extra

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,6 @@ docs =
     zope.interface
 crypto =
     cryptography>=3.3.1
-    types-cryptography>=3.3.21
 tests =
     pytest>=6.0.0,<7.0.0
     coverage[toml]==5.0.4


### PR DESCRIPTION
This is not needed for using the project with `cryptography`. Also, the typing information is incorrect or incomplete for the latest version of `cryptography`.

Fixes #804