### PR TITLE
Differentiate between two errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`__.
 Changed
 ~~~~~~~
 
+- Changed the error message when the token audience doesn't match the expected audience by @irdkwmnsb `#809 <https://github.com/jpadilla/pyjwt/pull/809>`__
+
 Fixed
 ~~~~~
 

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -259,7 +259,7 @@ class PyJWT:
             audience = [audience]
 
         if all(aud not in audience_claims for aud in audience):
-            raise InvalidAudienceError("Invalid audience")
+            raise InvalidAudienceError("Audience doesn't match")
 
     def _validate_iss(self, payload, issuer):
         if issuer is None:


### PR DESCRIPTION
It's impossible to distinguish the two errors when 'audience' doesn't match.
The first error is programmer's fault – supplying an incorrect audience value.
The second is an expected error – when the audience doesn't match the required value.
The error messages shouldn't be the same.