### PR TITLE
Add classifier for Python 3.11

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Changed
 Fixed
 ~~~~~
 
+- Add classifier for Python 3.11 by @eseifert in `#818 <https://github.com/jpadilla/pyjwt/pull/818>`_
+
 Added
 ~~~~~
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Utilities
 
 [options]


### PR DESCRIPTION
Some tools or services like https://pyreadiness.org/ use classifiers to check for compatibility with a particular Python version. It would be nice to have classifiers for all tested Python versions in `setup.cfg`.