### PR TITLE
Add `sort_headers` parameter to `api_jwt.encode`

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -134,7 +134,6 @@ class PyJWS:
             # True is the standard value for b64, so no need for it
             del header["b64"]
 
-        # Fix for headers misorder - issue #715
         json_header = json.dumps(
             header, separators=(",", ":"), cls=json_encoder, sort_keys=sort_headers
         ).encode()

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -101,6 +101,7 @@ class PyJWS:
         headers: dict[str, Any] | None = None,
         json_encoder: Type[json.JSONEncoder] | None = None,
         is_payload_detached: bool = False,
+        sort_headers: bool = True,
     ) -> str:
         segments = []
 
@@ -135,7 +136,7 @@ class PyJWS:
 
         # Fix for headers misorder - issue #715
         json_header = json.dumps(
-            header, separators=(",", ":"), cls=json_encoder, sort_keys=True
+            header, separators=(",", ":"), cls=json_encoder, sort_keys=sort_headers
         ).encode()
 
         segments.append(base64url_encode(json_header))

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -45,6 +45,7 @@ class PyJWT:
         algorithm: Optional[str] = "HS256",
         headers: Optional[Dict[str, Any]] = None,
         json_encoder: Optional[Type[json.JSONEncoder]] = None,
+        sort_headers: bool = True,
     ) -> str:
         # Check that we get a mapping
         if not isinstance(payload, Mapping):
@@ -64,7 +65,14 @@ class PyJWT:
             payload, separators=(",", ":"), cls=json_encoder
         ).encode("utf-8")
 
-        return api_jws.encode(json_payload, key, algorithm, headers, json_encoder)
+        return api_jws.encode(
+            json_payload,
+            key,
+            algorithm,
+            headers,
+            json_encoder,
+            sort_headers=sort_headers,
+        )
 
     def decode_complete(
         self,

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -1,5 +1,4 @@
 import json
-from collections import OrderedDict
 from decimal import Decimal
 
 import pytest
@@ -420,7 +419,7 @@ class TestJWS:
         jws_message = jws.encode(
             payload,
             key="\xc2",
-            headers=OrderedDict([("b", "1"), ("a", "2")]),
+            headers=dict([("b", "1"), ("a", "2")]),
             sort_headers=sort_headers,
         )
         header_json = base64url_decode(jws_message.split(".")[0])

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -415,25 +415,16 @@ class TestJWS:
 
         assert decoded_payload == payload
 
-    def test_sorting_of_headers(self, jws, payload):
-        headers = OrderedDict([("b", "1"), ("a", "2")])
-        secret = "\xc2"
-
-        jws_message_unsorted = jws.encode(
-            payload, secret, headers=headers, sort_headers=False
+    @pytest.mark.parametrize("sort_headers", (False, True))
+    def test_sorting_of_headers(self, jws, payload, sort_headers):
+        jws_message = jws.encode(
+            payload,
+            key="\xc2",
+            headers=OrderedDict([("b", "1"), ("a", "2")]),
+            sort_headers=sort_headers,
         )
-        jws_message_sorted = jws.encode(
-            payload, secret, headers=headers, sort_headers=True
-        )
-
-        message_unsorted_splitted, *_ = jws_message_unsorted.split(".")
-        header_unsorted = base64url_decode(message_unsorted_splitted)
-
-        message_sorted_splitted, *_ = jws_message_sorted.split(".")
-        header_sorted = base64url_decode(message_sorted_splitted)
-
-        assert header_unsorted == b'{"typ":"JWT","alg":"HS256","b":"1","a":"2"}'
-        assert header_sorted == b'{"a":"2","alg":"HS256","b":"1","typ":"JWT"}'
+        header_json = base64url_decode(jws_message.split(".")[0])
+        assert sort_headers == (header_json.index(b'"a"') < header_json.index(b'"b"'))
 
     def test_decode_invalid_header_padding(self, jws):
         example_jws = (

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -14,6 +14,7 @@ from jwt.exceptions import (
 )
 from jwt.utils import base64url_decode
 from jwt.warnings import RemovedInPyjwt3Warning
+
 from .utils import crypto_required, key_path, no_crypto_required
 
 try:

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -414,6 +414,22 @@ class TestJWS:
 
         assert decoded_payload == payload
 
+    def test_sorting_headers(self, jws, payload):
+        secret = "\xc2"
+        encoded_without_sorting = jws.encode(payload, secret, sort_headers=False)
+        encoded_with_sorting = jws.encode(payload, secret, sort_headers=True)
+
+        assert encoded_with_sorting != encoded_without_sorting
+
+        decoded_without_sorting = jws.decode(
+            encoded_without_sorting, secret, algorithms=["HS256"]
+        )
+        decoded_with_sorting = jws.decode(
+            encoded_with_sorting, secret, algorithms=["HS256"]
+        )
+
+        assert decoded_without_sorting == decoded_with_sorting
+
     def test_decode_invalid_header_padding(self, jws):
         example_jws = (
             "aeyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9"

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -419,7 +419,7 @@ class TestJWS:
         jws_message = jws.encode(
             payload,
             key="\xc2",
-            headers=dict([("b", "1"), ("a", "2")]),
+            headers={"b": "1", "a": "2"},
             sort_headers=sort_headers,
         )
         header_json = base64url_decode(jws_message.split(".")[0])


### PR DESCRIPTION
This allows you to not sort headers, which prevents a breaking change between v2.4.0 and v2.5.0

fixes https://github.com/jpadilla/pyjwt/issues/811

Should I create a unittest for this?