### PR TITLE
Add more types

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -423,7 +423,7 @@ if has_crypto:
         SHA384: ClassVar[Type[hashes.HashAlgorithm]] = hashes.SHA384
         SHA512: ClassVar[Type[hashes.HashAlgorithm]] = hashes.SHA512
 
-        def __init__(self, hash_alg) -> None:
+        def __init__(self, hash_alg: Type[hashes.HashAlgorithm]) -> None:
             self.hash_alg = hash_alg
 
         def prepare_key(self, key):

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -1,10 +1,10 @@
 import hashlib
 import hmac
 import json
-from typing import Any, Dict, Union
+from typing import Any, ClassVar, Dict, Type, Union
 
 from .exceptions import InvalidKeyError
-from .types import JWKDict
+from .types import HashlibHash, JWKDict
 from .utils import (
     base64url_decode,
     base64url_encode,
@@ -212,11 +212,11 @@ class HMACAlgorithm(Algorithm):
     and the specified hash function.
     """
 
-    SHA256 = hashlib.sha256
-    SHA384 = hashlib.sha384
-    SHA512 = hashlib.sha512
+    SHA256: ClassVar[HashlibHash] = hashlib.sha256
+    SHA384: ClassVar[HashlibHash] = hashlib.sha384
+    SHA512: ClassVar[HashlibHash] = hashlib.sha512
 
-    def __init__(self, hash_alg) -> None:
+    def __init__(self, hash_alg: HashlibHash) -> None:
         self.hash_alg = hash_alg
 
     def prepare_key(self, key):
@@ -271,11 +271,11 @@ if has_crypto:
         RSASSA-PKCS-v1_5 and the specified hash function.
         """
 
-        SHA256 = hashes.SHA256
-        SHA384 = hashes.SHA384
-        SHA512 = hashes.SHA512
+        SHA256: ClassVar[Type[hashes.HashAlgorithm]] = hashes.SHA256
+        SHA384: ClassVar[Type[hashes.HashAlgorithm]] = hashes.SHA384
+        SHA512: ClassVar[Type[hashes.HashAlgorithm]] = hashes.SHA512
 
-        def __init__(self, hash_alg) -> None:
+        def __init__(self, hash_alg: Type[hashes.HashAlgorithm]) -> None:
             self.hash_alg = hash_alg
 
         def prepare_key(self, key):
@@ -419,9 +419,9 @@ if has_crypto:
         ECDSA and the specified hash function
         """
 
-        SHA256 = hashes.SHA256
-        SHA384 = hashes.SHA384
-        SHA512 = hashes.SHA512
+        SHA256: ClassVar[Type[hashes.HashAlgorithm]] = hashes.SHA256
+        SHA384: ClassVar[Type[hashes.HashAlgorithm]] = hashes.SHA384
+        SHA512: ClassVar[Type[hashes.HashAlgorithm]] = hashes.SHA512
 
         def __init__(self, hash_alg) -> None:
             self.hash_alg = hash_alg

--- a/jwt/jwk_set_cache.py
+++ b/jwt/jwk_set_cache.py
@@ -5,11 +5,11 @@ from .api_jwk import PyJWKSet, PyJWTSetWithTimestamp
 
 
 class JWKSetCache:
-    def __init__(self, lifespan: int):
+    def __init__(self, lifespan: int) -> None:
         self.jwk_set_with_timestamp: Optional[PyJWTSetWithTimestamp] = None
         self.lifespan = lifespan
 
-    def put(self, jwk_set: PyJWKSet):
+    def put(self, jwk_set: PyJWKSet) -> None:
         if jwk_set is not None:
             self.jwk_set_with_timestamp = PyJWTSetWithTimestamp(jwk_set)
         else:

--- a/jwt/types.py
+++ b/jwt/types.py
@@ -1,3 +1,5 @@
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 JWKDict = Dict[str, Any]
+
+HashlibHash = Callable[..., Any]


### PR DESCRIPTION
A few fixes I had while trying to fix https://github.com/jpadilla/pyjwt/issues/602.

I was also wondering if `Algorithm` could be made an abstract base class? Afaik it is not instanciated as is and this would avoid having to explicitly raise `NotImplementedError`.

Regarding https://github.com/jpadilla/pyjwt/issues/602, I might have a few solutions, but that might be tricky to handle (regarding the fact that `cryptography` is optional, as stated in https://github.com/jpadilla/pyjwt/pull/605). The least that can be done:

- Add types to the following methods for each algorithm: `prepare_key`, `sign` and `verify`.
- For the `Algorithm` methods, use a conditional Union including all available types, depending on the availability of `cryptography` (not sure if this will work as excepted).
- Use this same Union type for the `encode` / `decode` / `decode_complete` public methods.

Additionally, overloads could be defined for the methods listed above:

```python
@overload
def encode(
    self,
    payload: bytes,
    key: Union[str, bytes],
    algorithm: Literal["HS256", "HS384", "HS512"],
    headers: dict[str, Any] | None = None,
    json_encoder: Type[json.JSONEncoder] | None = None,
    is_payload_detached: bool = False,
    sort_headers: bool = True,
) -> str:

@overload
def encode(
    self,
    payload: bytes,
    key: Union[RSAPrivateKey, str, bytes],
    algorithm: Literal["RS256", "RS384", "RS512"],
    headers: dict[str, Any] | None = None,
    json_encoder: Type[json.JSONEncoder] | None = None,
    is_payload_detached: bool = False,
    sort_headers: bool = True,
) -> str:

# And so on
```
That way type checkers could attest that for instance when using `encode(payload, key, "HS256")`, key should be `Union[str, bytes]`. Although this improves type safety, it adds a lot of boilerplate code.