### PR TITLE
Improve error messages when cryptography isn't installed

### DIFF
--- a/tests/test_api_jwk.py
+++ b/tests/test_api_jwk.py
@@ -6,7 +6,7 @@ from jwt.algorithms import has_crypto
 from jwt.api_jwk import PyJWK, PyJWKSet
 from jwt.exceptions import InvalidKeyError, PyJWKError, PyJWKSetError
 
-from .utils import crypto_required, key_path
+from .utils import crypto_required, key_path, no_crypto_required
 
 if has_crypto:
     from jwt.algorithms import ECAlgorithm, HMACAlgorithm, OKPAlgorithm, RSAAlgorithm
@@ -207,6 +207,11 @@ class TestPyJWK:
         with pytest.raises(InvalidKeyError):
             PyJWK.from_dict(v)
 
+    @no_crypto_required
+    def test_missing_crypto_library_good_error_message(self):
+        with pytest.raises(PyJWKError) as exc:
+            PyJWK({"kty": "dummy"}, algorithm="RS256")
+            assert "cryptography" in str(exc.value)
 
 @crypto_required
 class TestPyJWKSet:

--- a/tests/test_api_jwk.py
+++ b/tests/test_api_jwk.py
@@ -213,6 +213,7 @@ class TestPyJWK:
             PyJWK({"kty": "dummy"}, algorithm="RS256")
             assert "cryptography" in str(exc.value)
 
+
 @crypto_required
 class TestPyJWKSet:
     def test_should_load_keys_from_jwk_data_dict(self):


### PR DESCRIPTION
Fixes #820.

Maybe a warning could be added when iterating over the keys when we catch a `PyJWKSetError`?