### PR TITLE
Removes kid presence verification

### DIFF
--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -74,7 +74,7 @@ class PyJWKClient:
         signing_keys = [
             jwk_set_key
             for jwk_set_key in jwk_set.keys
-            if jwk_set_key.public_key_use in ["sig", None] and jwk_set_key.key_id
+            if jwk_set_key.public_key_use in ["sig", None]
         ]
 
         if not signing_keys:


### PR DESCRIPTION
Per the [RFC 7517](https://www.rfc-editor.org/rfc/rfc7517#section-4.5), the `kid` key is optional.

This PR removes the check for a non-None value.