### PR TITLE
Make missing crypto dependency error more friendly

### DIFF
--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -78,7 +78,9 @@ class PyJWKClient:
         ]
 
         if not signing_keys:
-            raise PyJWKClientError("The JWKS endpoint did not contain any signing keys")
+            raise PyJWKClientError(
+                "The JWKS endpoint did not contain any recognized signing keys. Did you mean to use pyjwt[crypto]?"
+            )
 
         return signing_keys
 


### PR DESCRIPTION
Give users a hint about the most likely reason the JWKS verification isn't working.