### PR TITLE
docs: correct mistake in the changelog about verify param

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -261,7 +261,7 @@ use
 And the old v1.x syntax
 ``jwt.decode(token, verify=False)``
 is now:
-``jwt.decode(jwt=token, key='secret', algorithms=['HS256'], options={"verify_signature": False, "verify_exp": True})``
+``jwt.decode(jwt=token, key='secret', algorithms=['HS256'], options={"verify_signature": False})``
 
 Added
 ~~~~~


### PR DESCRIPTION
I believe there is a mistake in the changelog regarding the deprecated `verify=False` parameter.

When migrating from `pyjwt` version 1.7.1 to version 2.6.0, I noticed this line in the changelog:

>And the old v1.x syntax
>``jwt.decode(token, verify=False)``
>is now:
>``jwt.decode(jwt=token, key='secret', algorithms=['HS256'], options={"verify_signature": False, "verify_exp": True})``

However, when I examined the implementation, it seems that in version `1.7.1`, setting the `verify=False` parameter disables the timestamp verification. Hence, the equivalent to `verify=False` in version 2.x would just be ` options={"verify_signature": False}`.

This is also supported by a comment in `jwt/api_jwt.py:102`:
>"The verify argument to decode does nothing in PyJWT 2.0 and newer. "
>"The equivalent is setting verify_signature to False in the options dictionary. "