### PR TITLE
Add `as_dict` option to `Algorithm.to_jwk`

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -195,13 +195,13 @@ class Algorithm(ABC):
     @staticmethod
     @abstractmethod
     def to_jwk(key_obj, as_dict: Literal[True]) -> JWKDict:
-        ...
+        ...  # pragma: no cover
 
     @overload
     @staticmethod
     @abstractmethod
     def to_jwk(key_obj, as_dict: Literal[False] = False) -> str:
-        ...
+        ...  # pragma: no cover
 
     @staticmethod
     @abstractmethod
@@ -275,12 +275,12 @@ class HMACAlgorithm(Algorithm):
     @overload
     @staticmethod
     def to_jwk(key_obj: str | bytes, as_dict: Literal[True]) -> JWKDict:
-        ...
+        ...  # pragma: no cover
 
     @overload
     @staticmethod
     def to_jwk(key_obj: str | bytes, as_dict: Literal[False] = False) -> str:
-        ...
+        ...  # pragma: no cover
 
     @staticmethod
     def to_jwk(key_obj: str | bytes, as_dict: bool = False) -> Union[JWKDict, str]:
@@ -355,12 +355,12 @@ if has_crypto:
         @overload
         @staticmethod
         def to_jwk(key_obj: AllowedRSAKeys, as_dict: Literal[True]) -> JWKDict:
-            ...
+            ...  # pragma: no cover
 
         @overload
         @staticmethod
         def to_jwk(key_obj: AllowedRSAKeys, as_dict: Literal[False] = False) -> str:
-            ...
+            ...  # pragma: no cover
 
         @staticmethod
         def to_jwk(
@@ -553,12 +553,12 @@ if has_crypto:
         @overload
         @staticmethod
         def to_jwk(key_obj: AllowedECKeys, as_dict: Literal[True]) -> JWKDict:
-            ...
+            ...  # pragma: no cover
 
         @overload
         @staticmethod
         def to_jwk(key_obj: AllowedECKeys, as_dict: Literal[False] = False) -> str:
-            ...
+            ...  # pragma: no cover
 
         @staticmethod
         def to_jwk(
@@ -772,12 +772,12 @@ if has_crypto:
         @overload
         @staticmethod
         def to_jwk(key: AllowedOKPKeys, as_dict: Literal[True]) -> JWKDict:
-            ...
+            ...  # pragma: no cover
 
         @overload
         @staticmethod
         def to_jwk(key: AllowedOKPKeys, as_dict: Literal[False] = False) -> str:
-            ...
+            ...  # pragma: no cover
 
         @staticmethod
         def to_jwk(key: AllowedOKPKeys, as_dict: bool = False) -> Union[JWKDict, str]:

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -4,9 +4,16 @@ import hashlib
 import hmac
 import json
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, ClassVar, NoReturn, Union, cast, overload
-
-from typing_extensions import Literal
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Literal,
+    NoReturn,
+    Union,
+    cast,
+    overload,
+)
 
 from .exceptions import InvalidKeyError
 from .types import HashlibHash, JWKDict

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -798,7 +798,6 @@ if has_crypto:
                 else:
                     return json.dumps(obj)
 
-
             raise InvalidKeyError("Not a public or private key")
 
         @staticmethod

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -184,7 +184,7 @@ class Algorithm(ABC):
 
     @staticmethod
     @abstractmethod
-    def to_jwk(key_obj, as_dict: bool = False) -> JWKDict | str:
+    def to_jwk(key_obj, as_dict: bool = False) -> Union[JWKDict, str]:
         """
         Serializes a given RSA key into a JWK
         """
@@ -229,7 +229,7 @@ class NoneAlgorithm(Algorithm):
         ...
 
     @staticmethod
-    def to_jwk(key_obj, as_dict: bool = False) -> JWKDict | str:
+    def to_jwk(key_obj, as_dict: bool = False) -> Union[JWKDict, str]:
         raise NotImplementedError()
 
     @staticmethod
@@ -272,7 +272,7 @@ class HMACAlgorithm(Algorithm):
         ...
 
     @staticmethod
-    def to_jwk(key_obj, as_dict: bool = False) -> JWKDict | str:
+    def to_jwk(key_obj, as_dict: bool = False) -> Union[JWKDict, str]:
         jwk = {
             "k": base64url_encode(force_bytes(key_obj)).decode(),
             "kty": "oct",
@@ -350,7 +350,7 @@ if has_crypto:
             ...
 
         @staticmethod
-        def to_jwk(key_obj, as_dict: bool = False) -> JWKDict | str:
+        def to_jwk(key_obj, as_dict: bool = False) -> Union[JWKDict, str]:
             obj = None
 
             if hasattr(key_obj, "private_numbers"):
@@ -541,7 +541,7 @@ if has_crypto:
             ...
 
         @staticmethod
-        def to_jwk(key_obj, as_dict: bool = False) -> JWKDict | str:
+        def to_jwk(key_obj, as_dict: bool = False) -> Union[JWKDict, str]:
             if isinstance(key_obj, EllipticCurvePrivateKey):
                 public_numbers = key_obj.public_key().public_numbers()
             elif isinstance(key_obj, EllipticCurvePublicKey):
@@ -754,7 +754,7 @@ if has_crypto:
             ...
 
         @staticmethod
-        def to_jwk(key, as_dict: bool = False) -> JWKDict | str:
+        def to_jwk(key, as_dict: bool = False) -> Union[JWKDict, str]:
             if isinstance(key, (Ed25519PublicKey, Ed448PublicKey)):
                 x = key.public_bytes(
                     encoding=Encoding.Raw,

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -3,17 +3,9 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import sys
 from abc import ABC, abstractmethod
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Literal,
-    NoReturn,
-    Union,
-    cast,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, ClassVar, NoReturn, Union, cast, overload
 
 from .exceptions import InvalidKeyError
 from .types import HashlibHash, JWKDict
@@ -28,6 +20,12 @@ from .utils import (
     raw_to_der_signature,
     to_base64url_uint,
 )
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
 
 try:
     from cryptography.exceptions import InvalidSignature

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -2,7 +2,9 @@ import hashlib
 import hmac
 import json
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Dict, Literal, Type, Union, overload
+from typing import Any, ClassVar, Dict, Type, Union, overload
+
+from typing_extensions import Literal
 
 from .exceptions import InvalidKeyError
 from .types import HashlibHash, JWKDict

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -235,7 +235,7 @@ class NoneAlgorithm(Algorithm):
         return False
 
     @staticmethod
-    def to_jwk(key_obj: Any) -> NoReturn:
+    def to_jwk(key_obj: Any, as_dict: bool = False) -> NoReturn:
         raise NotImplementedError()
 
     @staticmethod

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -4,7 +4,8 @@ import hashlib
 import hmac
 import json
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, ClassVar, NoReturn, cast, Union, overload
+from typing import TYPE_CHECKING, Any, ClassVar, NoReturn, Union, cast, overload
+
 from typing_extensions import Literal
 
 from .exceptions import InvalidKeyError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ source = ["jwt", ".tox/*/site-packages"]
 
 [tool.coverage.report]
 show_missing = true
-exclude_lines = ["if TYPE_CHECKING:"]
+exclude_lines = ["if TYPE_CHECKING:", "pragma: no cover"]
 
 [tool.isort]
 profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,8 @@ zip_safe = false
 include_package_data = true
 python_requires = >=3.7
 packages = find:
+install_requires =
+    typing_extensions; python_version<="3.7"
 
 [options.package_data]
 * = py.typed

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -314,7 +314,7 @@ class TestAlgorithms:
         algo = ECAlgorithm(ECAlgorithm.SHA256)
 
         with pytest.raises(InvalidKeyError):
-            algo.to_jwk({"not": "a valid key"})  # type: ignore[arg-type]
+            algo.to_jwk({"not": "a valid key"})  # type: ignore[call-overload]
 
     @crypto_required
     @pytest.mark.parametrize("as_dict", (False, True))
@@ -556,7 +556,7 @@ class TestAlgorithms:
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
         with pytest.raises(InvalidKeyError):
-            algo.to_jwk({"not": "a valid key"})  # type: ignore[arg-type]
+            algo.to_jwk({"not": "a valid key"})  # type: ignore[call-overload]
 
     @crypto_required
     def test_rsa_from_jwk_raises_exception_on_invalid_key(self):
@@ -977,7 +977,7 @@ class TestOKPAlgorithms:
         algo = OKPAlgorithm()
 
         with pytest.raises(InvalidKeyError):
-            algo.to_jwk({"not": "a valid key"})  # type: ignore[arg-type]
+            algo.to_jwk({"not": "a valid key"})  # type: ignore[call-overload]
 
     def test_okp_ed448_jwk_private_key_should_parse_and_verify(self):
         algo = OKPAlgorithm()

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -1,5 +1,6 @@
 import base64
 import json
+from typing import Any
 
 import pytest
 
@@ -76,7 +77,7 @@ class TestAlgorithms:
     @pytest.mark.parametrize("as_dict", (False, True))
     def test_hmac_to_jwk_returns_correct_values(self, as_dict):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
-        key = algo.to_jwk("secret", as_dict=as_dict)
+        key: Any = algo.to_jwk("secret", as_dict=as_dict)
 
         if not as_dict:
             key = json.loads(key)
@@ -254,7 +255,7 @@ class TestAlgorithms:
         with open(key_path("testkey_ec.pub")) as keyfile:
             pub_key = algo.prepare_key(keyfile.read())
 
-        key = algo.to_jwk(pub_key, as_dict=as_dict)
+        key: Any = algo.to_jwk(pub_key, as_dict=as_dict)
 
         if not as_dict:
             key = json.loads(key)
@@ -276,7 +277,7 @@ class TestAlgorithms:
         with open(key_path("testkey_ec.priv")) as keyfile:
             priv_key = algo.prepare_key(keyfile.read())
 
-        key = algo.to_jwk(priv_key, as_dict=as_dict)
+        key: Any = algo.to_jwk(priv_key, as_dict=as_dict)
 
         if not as_dict:
             key = json.loads(key)
@@ -312,7 +313,7 @@ class TestAlgorithms:
 
             with open(key_path(f"jwk_ec_pub_{curve}.json")) as keyfile:
                 pub_key = algo.from_jwk(keyfile.read())
-                jwk = algo.to_jwk(pub_key, as_dict=as_dict)
+                jwk: Any = algo.to_jwk(pub_key, as_dict=as_dict)
 
                 if not as_dict:
                     jwk = json.loads(jwk)
@@ -450,7 +451,7 @@ class TestAlgorithms:
         with open(key_path("testkey_rsa.pub")) as keyfile:
             pub_key = algo.prepare_key(keyfile.read())
 
-        key = algo.to_jwk(pub_key, as_dict=as_dict)
+        key: Any = algo.to_jwk(pub_key, as_dict=as_dict)
 
         if not as_dict:
             key = json.loads(key)
@@ -478,7 +479,7 @@ class TestAlgorithms:
         with open(key_path("testkey_rsa.priv")) as keyfile:
             priv_key = algo.prepare_key(keyfile.read())
 
-        key = algo.to_jwk(priv_key, as_dict=as_dict)
+        key: Any = algo.to_jwk(priv_key, as_dict=as_dict)
 
         if not as_dict:
             key = json.loads(key)

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -73,11 +73,15 @@ class TestAlgorithms:
         signature = algo.sign(b"Hello World!", key)
         assert algo.verify(b"Hello World!", key, signature)
 
-    def test_hmac_to_jwk_returns_correct_values(self):
+    @pytest.mark.parametrize("as_dict", (False, True))
+    def test_hmac_to_jwk_returns_correct_values(self, as_dict):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
-        key = algo.to_jwk("secret")
+        key = algo.to_jwk("secret", as_dict=as_dict)
 
-        assert json.loads(key) == {"kty": "oct", "k": "c2VjcmV0"}
+        if not as_dict:
+            key = json.loads(key)
+
+        assert key == {"kty": "oct", "k": "c2VjcmV0"}
 
     def test_hmac_from_jwk_should_raise_exception_if_not_hmac_key(self):
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
@@ -243,13 +247,17 @@ class TestAlgorithms:
         assert parsed_key.public_numbers() == orig_key.public_numbers()
 
     @crypto_required
-    def test_ec_to_jwk_returns_correct_values_for_public_key(self):
+    @pytest.mark.parametrize("as_dict", (False, True))
+    def test_ec_to_jwk_returns_correct_values_for_public_key(self, as_dict):
         algo = ECAlgorithm(ECAlgorithm.SHA256)
 
         with open(key_path("testkey_ec.pub")) as keyfile:
             pub_key = algo.prepare_key(keyfile.read())
 
-        key = algo.to_jwk(pub_key)
+        key = algo.to_jwk(pub_key, as_dict=as_dict)
+
+        if not as_dict:
+            key = json.loads(key)
 
         expected = {
             "kty": "EC",
@@ -258,16 +266,20 @@ class TestAlgorithms:
             "y": "t2G02kbWiOqimYfQAfnARdp2CTycsJPhwA8rn1Cn0SQ",
         }
 
-        assert json.loads(key) == expected
+        assert key == expected
 
     @crypto_required
-    def test_ec_to_jwk_returns_correct_values_for_private_key(self):
+    @pytest.mark.parametrize("as_dict", (False, True))
+    def test_ec_to_jwk_returns_correct_values_for_private_key(self, as_dict):
         algo = ECAlgorithm(ECAlgorithm.SHA256)
 
         with open(key_path("testkey_ec.priv")) as keyfile:
             priv_key = algo.prepare_key(keyfile.read())
 
-        key = algo.to_jwk(priv_key)
+        key = algo.to_jwk(priv_key, as_dict=as_dict)
+
+        if not as_dict:
+            key = json.loads(key)
 
         expected = {
             "kty": "EC",
@@ -277,7 +289,7 @@ class TestAlgorithms:
             "d": "2nninfu2jMHDwAbn9oERUhRADS6duQaJEadybLaa0YQ",
         }
 
-        assert json.loads(key) == expected
+        assert key == expected
 
     @crypto_required
     def test_ec_to_jwk_raises_exception_on_invalid_key(self):
@@ -287,7 +299,8 @@ class TestAlgorithms:
             algo.to_jwk({"not": "a valid key"})
 
     @crypto_required
-    def test_ec_to_jwk_with_valid_curves(self):
+    @pytest.mark.parametrize("as_dict", (False, True))
+    def test_ec_to_jwk_with_valid_curves(self, as_dict):
         tests = {
             "P-256": ECAlgorithm.SHA256,
             "P-384": ECAlgorithm.SHA384,
@@ -299,11 +312,21 @@ class TestAlgorithms:
 
             with open(key_path(f"jwk_ec_pub_{curve}.json")) as keyfile:
                 pub_key = algo.from_jwk(keyfile.read())
-                assert json.loads(algo.to_jwk(pub_key))["crv"] == curve
+                jwk = algo.to_jwk(pub_key, as_dict=as_dict)
+
+                if not as_dict:
+                    jwk = json.loads(jwk)
+
+                assert jwk["crv"] == curve
 
             with open(key_path(f"jwk_ec_key_{curve}.json")) as keyfile:
                 priv_key = algo.from_jwk(keyfile.read())
-                assert json.loads(algo.to_jwk(priv_key))["crv"] == curve
+                jwk = algo.to_jwk(priv_key, as_dict=as_dict)
+
+                if not as_dict:
+                    jwk = json.loads(jwk)
+
+                assert jwk["crv"] == curve
 
     @crypto_required
     def test_ec_to_jwk_with_invalid_curve(self):
@@ -420,13 +443,17 @@ class TestAlgorithms:
             algo.from_jwk('{"kty": "RSA"}')
 
     @crypto_required
-    def test_rsa_to_jwk_returns_correct_values_for_public_key(self):
+    @pytest.mark.parametrize("as_dict", (False, True))
+    def test_rsa_to_jwk_returns_correct_values_for_public_key(self, as_dict):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
         with open(key_path("testkey_rsa.pub")) as keyfile:
             pub_key = algo.prepare_key(keyfile.read())
 
-        key = algo.to_jwk(pub_key)
+        key = algo.to_jwk(pub_key, as_dict=as_dict)
+
+        if not as_dict:
+            key = json.loads(key)
 
         expected = {
             "e": "AQAB",
@@ -441,16 +468,20 @@ class TestAlgorithms:
                 "sNruF3ogJWNq1Lyn_ijPQnkPLpZHyhvuiycYcI3DiQ"
             ),
         }
-        assert json.loads(key) == expected
+        assert key == expected
 
     @crypto_required
-    def test_rsa_to_jwk_returns_correct_values_for_private_key(self):
+    @pytest.mark.parametrize("as_dict", (False, True))
+    def test_rsa_to_jwk_returns_correct_values_for_private_key(self, as_dict):
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
 
         with open(key_path("testkey_rsa.priv")) as keyfile:
             priv_key = algo.prepare_key(keyfile.read())
 
-        key = algo.to_jwk(priv_key)
+        key = algo.to_jwk(priv_key, as_dict=as_dict)
+
+        if not as_dict:
+            key = json.loads(key)
 
         expected = {
             "key_ops": ["sign"],
@@ -498,7 +529,7 @@ class TestAlgorithms:
                 "AuKhin-kc4mh9ssDXRQZwlMymZP0QtaxUDw_nlfVrUCZgO7L1_ZsUTk"
             ),
         }
-        assert json.loads(key) == expected
+        assert key == expected
 
     @crypto_required
     def test_rsa_to_jwk_raises_exception_on_invalid_key(self):

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -954,7 +954,8 @@ class TestOKPAlgorithms:
         with pytest.raises(InvalidKeyError):
             algo.from_jwk(v)
 
-    def test_okp_ed25519_to_jwk_works_with_from_jwk(self):
+    @pytest.mark.parametrize("as_dict", (False, True))
+    def test_okp_ed25519_to_jwk_works_with_from_jwk(self, as_dict):
         algo = OKPAlgorithm()
 
         with open(key_path("jwk_okp_key_Ed25519.json")) as keyfile:
@@ -963,9 +964,9 @@ class TestOKPAlgorithms:
         with open(key_path("jwk_okp_pub_Ed25519.json")) as keyfile:
             pub_key_1 = cast(Ed25519PublicKey, algo.from_jwk(keyfile.read()))
 
-        pub = algo.to_jwk(pub_key_1)
+        pub = algo.to_jwk(pub_key_1, as_dict=as_dict)
         pub_key_2 = algo.from_jwk(pub)
-        pri = algo.to_jwk(priv_key_1)
+        pri = algo.to_jwk(priv_key_1, as_dict=as_dict)
         priv_key_2 = cast(Ed25519PrivateKey, algo.from_jwk(pri))
 
         signature_1 = algo.sign(b"Hello World!", priv_key_1)
@@ -1063,7 +1064,8 @@ class TestOKPAlgorithms:
         with pytest.raises(InvalidKeyError):
             algo.from_jwk(v)
 
-    def test_okp_ed448_to_jwk_works_with_from_jwk(self):
+    @pytest.mark.parametrize("as_dict", (False, True))
+    def test_okp_ed448_to_jwk_works_with_from_jwk(self, as_dict):
         algo = OKPAlgorithm()
 
         with open(key_path("jwk_okp_key_Ed448.json")) as keyfile:
@@ -1072,9 +1074,9 @@ class TestOKPAlgorithms:
         with open(key_path("jwk_okp_pub_Ed448.json")) as keyfile:
             pub_key_1 = cast(Ed448PublicKey, algo.from_jwk(keyfile.read()))
 
-        pub = algo.to_jwk(pub_key_1)
+        pub = algo.to_jwk(pub_key_1, as_dict=as_dict)
         pub_key_2 = algo.from_jwk(pub)
-        pri = algo.to_jwk(priv_key_1)
+        pri = algo.to_jwk(priv_key_1, as_dict=as_dict)
         priv_key_2 = cast(Ed448PrivateKey, algo.from_jwk(pri))
 
         signature_1 = algo.sign(b"Hello World!", priv_key_1)


### PR DESCRIPTION
Fixes #880

This patch adds an optional `as_dict=False` keyword argument to `Algorithm.to_jwk()` functions.

Library API is still backwards compatible with this change: 
```
IPython 8.12.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import jwt
In [2]: algo = jwt.get_algorithm_by_name('HS256')
In [3]: jwk_json = algo.to_jwk('test')

In [4]: type(jwk_json), jwk_json
Out[4]: (str, '{"k": "dGVzdA", "kty": "oct"}')

In [5]: jwk_dict = algo.to_jwk('test', as_dict=True)

In [6]: type(jwk_dict), jwk_dict
Out[6]: (dict, {'k': 'dGVzdA', 'kty': 'oct'})
```