### PR TITLE
Inclusive IAT timestamp check.

### DIFF
--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -272,7 +272,7 @@ class PyJWT:
             iat = int(payload["iat"])
         except ValueError:
             raise InvalidIssuedAtError("Issued At claim (iat) must be an integer.")
-        if iat > (now + leeway):
+        if iat >= (now + leeway):
             raise ImmatureSignatureError("The token is not yet valid (iat)")
 
     def _validate_nbf(

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -225,7 +225,7 @@ class TestJWT:
 
         with pytest.raises(ImmatureSignatureError):
             jwt.decode(jwt_message, secret, algorithms=["HS256"])
-    
+
     def test_decode_not_raises_exception_if_iat_is_equal_to_now(self, jwt, payload):
         payload["iat"] = utc_timestamp()
         secret = "secret"

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -225,6 +225,13 @@ class TestJWT:
 
         with pytest.raises(ImmatureSignatureError):
             jwt.decode(jwt_message, secret, algorithms=["HS256"])
+    
+    def test_decode_not_raises_exception_if_iat_is_equal_to_now(self, jwt, payload):
+        payload["iat"] = utc_timestamp()
+        secret = "secret"
+        jwt_message = jwt.encode(payload, secret)
+
+        jwt.decode(jwt_message, secret, algorithms=["HS256"])
 
     def test_decode_works_if_iat_is_str_of_a_number(self, jwt, payload):
         payload["iat"] = "1638202770"


### PR DESCRIPTION
~~Currently, the iat-check will fail if the IAT timestamp is equal to "now". I believe it should use inclusive test to not fail if it's being validated immediately after being created.~~


Someone more "in-the-know" should validate that the tests and use-case is correct 