### PR TITLE
Decode with PyJWK

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -291,8 +291,7 @@ Retrieve RSA signing keys from a JWKS endpoint
     >>> signing_key = jwks_client.get_signing_key_from_jwt(token)
     >>> data = jwt.decode(
     ...     token,
-    ...     signing_key.key,
-    ...     algorithms=["RS256"],
+    ...     signing_key,
     ...     audience="https://expenses-api",
     ...     options={"verify_exp": False},
     ... )
@@ -356,8 +355,7 @@ is not built into pyjwt.
     # now, decode_complete to get payload + header
     data = jwt.decode_complete(
         id_token,
-        key=signing_key.key,
-        algorithms=signing_algos,
+        key=signing_key,
         audience=client_id,
     )
     payload, header = data["payload"], data["header"]

--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -52,7 +52,7 @@ class PyJWK:
         if not has_crypto and algorithm in requires_cryptography:
             raise PyJWKError(f"{algorithm} requires 'cryptography' to be installed.")
 
-        self.algorithm = algorithm
+        self.algorithm_name = algorithm
         self.Algorithm = self._algorithms.get(algorithm)
 
         if not self.Algorithm:

--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -52,6 +52,7 @@ class PyJWK:
         if not has_crypto and algorithm in requires_cryptography:
             raise PyJWKError(f"{algorithm} requires 'cryptography' to be installed.")
 
+        self.algorithm = algorithm
         self.Algorithm = self._algorithms.get(algorithm)
 
         if not self.Algorithm:

--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -53,9 +53,10 @@ class PyJWK:
             raise PyJWKError(f"{algorithm} requires 'cryptography' to be installed.")
 
         self.algorithm_name = algorithm
-        self.Algorithm = self._algorithms.get(algorithm)
 
-        if not self.Algorithm:
+        if algorithm in self._algorithms:
+            self.Algorithm = self._algorithms[algorithm]
+        else:
             raise PyJWKError(f"Unable to find an algorithm for key: {self._jwk_data}")
 
         self.key = self.Algorithm.from_jwk(self._jwk_data)

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -192,7 +192,10 @@ class PyJWS:
         verify_signature = merged_options["verify_signature"]
 
         if isinstance(key, PyJWK):
+            if algorithms is None:
+                algorithms = [key.algorithm]
             key = key.key
+
         if verify_signature and not algorithms:
             raise DecodeError(
                 'It is required that you pass in a value for the "algorithms" argument when calling decode().'

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -11,6 +11,7 @@ from .algorithms import (
     has_crypto,
     requires_cryptography,
 )
+from .api_jwk import PyJWK
 from .exceptions import (
     DecodeError,
     InvalidAlgorithmError,
@@ -172,7 +173,7 @@ class PyJWS:
     def decode_complete(
         self,
         jwt: str | bytes,
-        key: AllowedPublicKeys | str | bytes = "",
+        key: AllowedPublicKeys | PyJWK | str | bytes = "",
         algorithms: list[str] | None = None,
         options: dict[str, Any] | None = None,
         detached_payload: bytes | None = None,
@@ -190,6 +191,8 @@ class PyJWS:
         merged_options = {**self.options, **options}
         verify_signature = merged_options["verify_signature"]
 
+        if isinstance(key, PyJWK):
+            key = key.key
         if verify_signature and not algorithms:
             raise DecodeError(
                 'It is required that you pass in a value for the "algorithms" argument when calling decode().'
@@ -217,7 +220,7 @@ class PyJWS:
     def decode(
         self,
         jwt: str | bytes,
-        key: AllowedPublicKeys | str | bytes = "",
+        key: AllowedPublicKeys | PyJWK | str | bytes = "",
         algorithms: list[str] | None = None,
         options: dict[str, Any] | None = None,
         detached_payload: bytes | None = None,

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -193,7 +193,7 @@ class PyJWS:
 
         if isinstance(key, PyJWK):
             if algorithms is None:
-                algorithms = [key.algorithm]
+                algorithms = [key.algorithm_name]
             key = key.key
 
         if verify_signature and not algorithms:

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
-from . import api_jws
+from . import api_jws, api_jwk
 from .exceptions import (
     DecodeError,
     ExpiredSignatureError,
@@ -21,6 +21,7 @@ from .warnings import RemovedInPyjwt3Warning
 
 if TYPE_CHECKING:
     from .algorithms import AllowedPrivateKeys, AllowedPublicKeys
+    from .api_jwk import PyJWK
 
 
 class PyJWT:
@@ -100,7 +101,7 @@ class PyJWT:
     def decode_complete(
         self,
         jwt: str | bytes,
-        key: AllowedPublicKeys | str | bytes = "",
+        key: AllowedPublicKeys | PyJWK | str | bytes = "",
         algorithms: list[str] | None = None,
         options: dict[str, Any] | None = None,
         # deprecated arg, remove in pyjwt3
@@ -185,7 +186,7 @@ class PyJWT:
     def decode(
         self,
         jwt: str | bytes,
-        key: AllowedPublicKeys | str | bytes = "",
+        key: AllowedPublicKeys | PyJWK | str | bytes = "",
         algorithms: list[str] | None = None,
         options: dict[str, Any] | None = None,
         # deprecated arg, remove in pyjwt3

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
-from . import api_jws, api_jwk
+from . import api_jwk, api_jws
 from .exceptions import (
     DecodeError,
     ExpiredSignatureError,

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
-from . import api_jwk, api_jws
+from . import api_jws
 from .exceptions import (
     DecodeError,
     ExpiredSignatureError,

--- a/tests/test_api_jwk.py
+++ b/tests/test_api_jwk.py
@@ -65,6 +65,7 @@ class TestPyJWK:
         assert jwk.key_type == "RSA"
         assert isinstance(jwk.Algorithm, RSAAlgorithm)
         assert jwk.Algorithm.hash_alg == RSAAlgorithm.SHA256
+        assert jwk.algorithm_name == "RS256"
 
     @crypto_required
     def test_should_load_key_from_dict_with_algorithm(self):
@@ -76,6 +77,7 @@ class TestPyJWK:
         assert jwk.key_type == "RSA"
         assert isinstance(jwk.Algorithm, RSAAlgorithm)
         assert jwk.Algorithm.hash_alg == RSAAlgorithm.SHA256
+        assert jwk.algorithm_name == "RS256"
 
     @crypto_required
     def test_should_load_key_ec_p256_from_dict(self):
@@ -87,6 +89,7 @@ class TestPyJWK:
         assert jwk.key_type == "EC"
         assert isinstance(jwk.Algorithm, ECAlgorithm)
         assert jwk.Algorithm.hash_alg == ECAlgorithm.SHA256
+        assert jwk.algorithm_name == "ES256"
 
     @crypto_required
     def test_should_load_key_ec_p384_from_dict(self):
@@ -98,6 +101,7 @@ class TestPyJWK:
         assert jwk.key_type == "EC"
         assert isinstance(jwk.Algorithm, ECAlgorithm)
         assert jwk.Algorithm.hash_alg == ECAlgorithm.SHA384
+        assert jwk.algorithm_name == "ES384"
 
     @crypto_required
     def test_should_load_key_ec_p521_from_dict(self):
@@ -109,6 +113,7 @@ class TestPyJWK:
         assert jwk.key_type == "EC"
         assert isinstance(jwk.Algorithm, ECAlgorithm)
         assert jwk.Algorithm.hash_alg == ECAlgorithm.SHA512
+        assert jwk.algorithm_name == "ES512"
 
     @crypto_required
     def test_should_load_key_ec_secp256k1_from_dict(self):
@@ -120,6 +125,7 @@ class TestPyJWK:
         assert jwk.key_type == "EC"
         assert isinstance(jwk.Algorithm, ECAlgorithm)
         assert jwk.Algorithm.hash_alg == ECAlgorithm.SHA256
+        assert jwk.algorithm_name == "ES256K"
 
     @crypto_required
     def test_should_load_key_hmac_from_dict(self):
@@ -131,6 +137,7 @@ class TestPyJWK:
         assert jwk.key_type == "oct"
         assert isinstance(jwk.Algorithm, HMACAlgorithm)
         assert jwk.Algorithm.hash_alg == HMACAlgorithm.SHA256
+        assert jwk.algorithm_name == "HS256"
 
     @crypto_required
     def test_should_load_key_hmac_without_alg_from_dict(self):
@@ -143,6 +150,7 @@ class TestPyJWK:
         assert jwk.key_type == "oct"
         assert isinstance(jwk.Algorithm, HMACAlgorithm)
         assert jwk.Algorithm.hash_alg == HMACAlgorithm.SHA256
+        assert jwk.algorithm_name == "HS256"
 
     @crypto_required
     def test_should_load_key_okp_without_alg_from_dict(self):
@@ -153,6 +161,7 @@ class TestPyJWK:
 
         assert jwk.key_type == "OKP"
         assert isinstance(jwk.Algorithm, OKPAlgorithm)
+        assert jwk.algorithm_name == "EdDSA"
 
     @crypto_required
     def test_from_dict_should_throw_exception_if_arg_is_invalid(self):

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -267,6 +267,40 @@ class TestJWS:
 
         assert decoded_payload == payload
 
+
+    def test_decodes_with_jwk_and_no_algorithm(self, jws, payload):
+        jwk = PyJWK({
+            "kty": "oct",
+            "alg": "HS256",
+            "k": "c2VjcmV0",  # "secret"
+        })
+        example_jws = (
+            b"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
+            b"aGVsbG8gd29ybGQ."
+            b"gEW0pdU4kxPthjtehYdhxB9mMOGajt1xCKlGGXDJ8PM"
+        )
+
+        decoded_payload = jws.decode(example_jws, jwk)
+
+        assert decoded_payload == payload
+
+
+    def test_decodes_with_jwk_and_mismatched_algorithm(self, jws, payload):
+        jwk = PyJWK({
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "PTTjIY84aLtaZCxLTrG_d8I0G6YKCV7lg8M4xkKfwQ4",
+            "y": "ank6KA34vv24HZLXlChVs85NEGlpg2sbqNmR_BcgyJU"
+        })
+        example_jws = (
+            b"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
+            b"aGVsbG8gd29ybGQ."
+            b"gEW0pdU4kxPthjtehYdhxB9mMOGajt1xCKlGGXDJ8PM"
+        )
+
+        with pytest.raises(InvalidAlgorithmError):
+            jws.decode(example_jws, jwk)
+
     # 'Control' Elliptic Curve jws created by another library.
     # Used to test for regressions that could affect both
     # encoding / decoding operations equally (causing tests

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -290,10 +290,9 @@ class TestJWS:
     def test_decodes_with_jwk_and_mismatched_algorithm(self, jws, payload):
         jwk = PyJWK(
             {
-                "kty": "EC",
-                "crv": "P-256",
-                "x": "PTTjIY84aLtaZCxLTrG_d8I0G6YKCV7lg8M4xkKfwQ4",
-                "y": "ank6KA34vv24HZLXlChVs85NEGlpg2sbqNmR_BcgyJU",
+                "kty": "oct",
+                "alg": "HS512",
+                "k": "c2VjcmV0",  # "secret"
             }
         )
         example_jws = (

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -5,6 +5,7 @@ import pytest
 
 from jwt.algorithms import NoneAlgorithm, has_crypto
 from jwt.api_jws import PyJWS
+from jwt.api_jwk import PyJWK
 from jwt.exceptions import (
     DecodeError,
     InvalidAlgorithmError,
@@ -249,6 +250,22 @@ class TestJWS:
                 b"\x1ff0\xe1\x9a\x8e\xddq\x08\xa9F\x19p\xc9\xf0\xf3"
             ),
         }
+
+    def test_decodes_with_jwk(self, jws, payload):
+        jwk = PyJWK({
+            "kty": "oct",
+            "alg": "HS256",
+            "k": "c2VjcmV0",  # "secret"
+        })
+        example_jws = (
+            b"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
+            b"aGVsbG8gd29ybGQ."
+            b"gEW0pdU4kxPthjtehYdhxB9mMOGajt1xCKlGGXDJ8PM"
+        )
+
+        decoded_payload = jws.decode(example_jws, jwk, algorithms=["HS256"])
+
+        assert decoded_payload == payload
 
     # 'Control' Elliptic Curve jws created by another library.
     # Used to test for regressions that could affect both

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -4,8 +4,8 @@ from decimal import Decimal
 import pytest
 
 from jwt.algorithms import NoneAlgorithm, has_crypto
-from jwt.api_jws import PyJWS
 from jwt.api_jwk import PyJWK
+from jwt.api_jws import PyJWS
 from jwt.exceptions import (
     DecodeError,
     InvalidAlgorithmError,
@@ -252,11 +252,13 @@ class TestJWS:
         }
 
     def test_decodes_with_jwk(self, jws, payload):
-        jwk = PyJWK({
-            "kty": "oct",
-            "alg": "HS256",
-            "k": "c2VjcmV0",  # "secret"
-        })
+        jwk = PyJWK(
+            {
+                "kty": "oct",
+                "alg": "HS256",
+                "k": "c2VjcmV0",  # "secret"
+            }
+        )
         example_jws = (
             b"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
             b"aGVsbG8gd29ybGQ."
@@ -267,13 +269,14 @@ class TestJWS:
 
         assert decoded_payload == payload
 
-
     def test_decodes_with_jwk_and_no_algorithm(self, jws, payload):
-        jwk = PyJWK({
-            "kty": "oct",
-            "alg": "HS256",
-            "k": "c2VjcmV0",  # "secret"
-        })
+        jwk = PyJWK(
+            {
+                "kty": "oct",
+                "alg": "HS256",
+                "k": "c2VjcmV0",  # "secret"
+            }
+        )
         example_jws = (
             b"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
             b"aGVsbG8gd29ybGQ."
@@ -284,14 +287,15 @@ class TestJWS:
 
         assert decoded_payload == payload
 
-
     def test_decodes_with_jwk_and_mismatched_algorithm(self, jws, payload):
-        jwk = PyJWK({
-            "kty": "EC",
-            "crv": "P-256",
-            "x": "PTTjIY84aLtaZCxLTrG_d8I0G6YKCV7lg8M4xkKfwQ4",
-            "y": "ank6KA34vv24HZLXlChVs85NEGlpg2sbqNmR_BcgyJU"
-        })
+        jwk = PyJWK(
+            {
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "PTTjIY84aLtaZCxLTrG_d8I0G6YKCV7lg8M4xkKfwQ4",
+                "y": "ank6KA34vv24HZLXlChVs85NEGlpg2sbqNmR_BcgyJU",
+            }
+        )
         example_jws = (
             b"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
             b"aGVsbG8gd29ybGQ."


### PR DESCRIPTION
This PR contains three proposed changes.  You can accept or reject any of them as you see fit.  This is just a rough draft, once the functionality is approved I'll clean it up, add tests, and document.

1) Add `algorithm` string to `PyJWK`.  This is useful in determine the appropriate `algorithms` value to pass into `decode()`.

2) Allow a `PyJWK` to be passed directly into `decode()`, so it's not necessary to pull `PyJWK.key`.  (This would fix #864)

3) If a `PyJWK` is passed into `decode()` and `algorithms` is not set, use the algorithm from the JWK.  This change makes the API more convenient and reduces room for error:  There's no reason that you should use any algorithm *but* the JWK's algorithm and doing otherwise is problematic at best and a possible security threat at worst.