### PR TITLE
api_jwt: add a `strict_aud` option

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -53,6 +53,7 @@ API Reference
         * ``verify_exp=verify_signature`` check that ``exp`` (expiration) claim value is in the future
         * ``verify_iat=verify_signature`` check that ``iat`` (issued at) claim value is an integer
         * ``verify_nbf=verify_signature`` check that ``nbf`` (not before) claim value is in the past
+        * ``strict_aud=False`` check that the ``aud`` claim is a single value (not a list), and matches ``audience`` exactly
 
         .. warning::
 


### PR DESCRIPTION
Key bits:

* There's a new `strict_aud` option, which defaults to `False`
* If `strict_aud` is `True`, then the following audience checking behavior applies:
    * `audience` MUST be a `str`;
    * The `aud` claim MUST be a `str`;
    * The audience and aud claim must match exactly.

Closes https://github.com/jpadilla/pyjwt/issues/894.