### PR TITLE
Fix an unnecessary str concat

### DIFF
--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -300,7 +300,7 @@ class PyJWT:
         try:
             exp = int(payload["exp"])
         except ValueError:
-            raise DecodeError("Expiration Time claim (exp) must be an" " integer.")
+            raise DecodeError("Expiration Time claim (exp) must be an integer.")
 
         if exp <= (now - leeway):
             raise ExpiredSignatureError("Signature has expired")


### PR DESCRIPTION
Just something I noticed while checking behavior -- an unnecessary str concat.

This was likely introduced by `black`ening the code. It's a non-issue but "looks weird" and something I like to weed out from my own projects.

I have [a linter](https://github.com/sirosen/dotfiles/blob/04bf5f8/bin/bin/check-bad-str-concat) I keep around for exactly this issue, and it runs successfully after this change, so we can be confident that this is the only case of this.