### PR TITLE
Option to disable refresh/retry on kid mismatch

### DIFF
--- a/tests/test_jwks_client.py
+++ b/tests/test_jwks_client.py
@@ -308,6 +308,20 @@ class TestPyJWKClient:
 
         assert call_data.call_count == 2
 
+    def test_get_jwt_set_no_second_attempt(self):
+        url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
+        jwks_client = PyJWKClient(url)
+
+        kid = "NEE1QURBOTM4MzI5RkFDNTYxOTU1MDg2ODgwQ0UzMTk1QjYyRkRFQw"
+
+        with pytest.raises(PyJWKClientError):
+            with mocked_first_call_wrong_kid_second_call_correct_kid(
+                RESPONSE_DATA_NO_MATCHING_KID, RESPONSE_DATA_WITH_MATCHING_KID
+            ) as call_data:
+                jwks_client.get_signing_key(kid, False)
+
+            assert call_data.call_count == 1
+
     def test_get_jwt_set_no_matching_kid_after_second_attempt(self):
         url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
         jwks_client = PyJWKClient(url)


### PR DESCRIPTION
## Description

This PR allows user to selectively disable refresh of signing keys on `kid` mismatch. Fixes #929

## Changes
Default parameter of `retry: bool = True` has been added to two following methods.
```python3
def get_signing_key(self, kid: str, retry: bool = True) -> PyJWK: 
    ...

def get_signing_key_from_jwt(self, token: str, retry: bool = True) -> PyJWK:
    ...
```

**Note: No breaking change as the default behavior remains the same**