### PR TITLE
Handle load_pem_public_key ValueError

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -21,7 +21,7 @@ from .utils import (
 )
 
 try:
-    from cryptography.exceptions import InvalidSignature
+    from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import hashes
     from cryptography.hazmat.primitives.asymmetric import padding
@@ -343,7 +343,10 @@ if has_crypto:
                         RSAPrivateKey, load_pem_private_key(key_bytes, password=None)
                     )
             except ValueError:
-                return cast(RSAPublicKey, load_pem_public_key(key_bytes))
+                try:
+                    return cast(RSAPublicKey, load_pem_public_key(key_bytes))
+                except (ValueError, UnsupportedAlgorithm):
+                    raise InvalidKeyError("Could not parse the provided public key.")
 
         @overload
         @staticmethod

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -1100,3 +1100,14 @@ class TestOKPAlgorithms:
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
         computed_hash = algo.compute_hash_digest(b"foo")
         assert computed_hash == foo_hash
+
+    @crypto_required
+    def test_rsa_prepare_key_raises_invalid_key_error_on_invalid_pem(self):
+        algo = RSAAlgorithm(RSAAlgorithm.SHA256)
+        invalid_key = "invalid key"
+
+        with pytest.raises(InvalidKeyError) as excinfo:
+            algo.prepare_key(invalid_key)
+
+        # Check that the exception message is correct
+        assert "Could not parse the provided public key." in str(excinfo.value)


### PR DESCRIPTION
This is a stab at addressing the issue discussed here: [Consider cryptography 42.x.x new validation #948](https://github.com/jpadilla/pyjwt/issues/948)

All I did is raise a `InvalidKeyError` when there is a ValueError and `return cast(RSAPublicKey, load_pem_public_key(key_bytes))` fails.

fix https://github.com/jpadilla/pyjwt/issues/948