### PR TITLE
Add 2.9.0 changelog. Fixes #949.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <https://semver.org/>`__.
 
-`Unreleased <https://github.com/jpadilla/pyjwt/compare/2.7.0...HEAD>`__
+`Unreleased <https://github.com/jpadilla/pyjwt/compare/2.9.0...HEAD>`__
 -----------------------------------------------------------------------
 
 Changed
@@ -15,6 +15,33 @@ Fixed
 
 Added
 ~~~~~
+
+`v2.9.0 <https://github.com/jpadilla/pyjwt/compare/2.8.0...2.9.0>`__
+-----------------------------------------------------------------------
+
+Changed
+~~~~~~~
+
+- Drop support for Python 3.7 (EOL) by @hugovk in `#910 <https://github.com/jpadilla/pyjwt/pull/910>`__
+- Allow JWT issuer claim validation to accept a list of strings too by @mattpollak in `#913 <https://github.com/jpadilla/pyjwt/pull/913>`__
+
+Fixed
+~~~~~
+
+- Fix unnecessary string concatenation by @sirosen in `#904 <https://github.com/jpadilla/pyjwt/pull/904>`__
+- Fix docs for ``jwt.decode_complete`` to include ``strict_aud`` option by @woodruffw in `#923 <https://github.com/jpadilla/pyjwt/pull/923>`__
+- Fix docs step by @jpadilla in `#950 <https://github.com/jpadilla/pyjwt/pull/950>`__
+- Fix: Remove an unused variable from example code block by @kenkoooo in `#958 <https://github.com/jpadilla/pyjwt/pull/958>`
+
+Added
+~~~~~
+
+- Add support for Python 3.12 by @hugovk in `#910 <https://github.com/jpadilla/pyjwt/pull/910>`__
+- Improve performance of ``is_ssh_key`` + add unit test by @bdraco in `#940 <https://github.com/jpadilla/pyjwt/pull/940>`__
+- Allow ``jwt.decode()`` to accept a PyJWK object by @luhn in `#886 <https://github.com/jpadilla/pyjwt/pull/886>`__
+- Make ``algorithm_name`` attribute available on PyJWK by @luhn in `#886 <https://github.com/jpadilla/pyjwt/pull/886>`__ 
+- Raise ``InvalidKeyError`` on invalid PEM keys to be compatible with cryptography 42.x.x by @CollinEMac in `#952 <https://github.com/jpadilla/pyjwt/pull/952>`__
+- Raise an exception when required cryptography dependency is missing by @tobloef in `<https://github.com/jpadilla/pyjwt/pull/963>`__
 
 `v2.8.0 <https://github.com/jpadilla/pyjwt/compare/2.7.0...2.8.0>`__
 -----------------------------------------------------------------------


### PR DESCRIPTION
This PR:
- Adds a proposed changelog for a 2.9.0 release, as suggested by @jpadilla  in https://github.com/jpadilla/pyjwt/issues/949#issuecomment-2159140017

I noticed PR #910 apart from adding support for Python 3.12, also drops support for python 3.7 which might be considered as a backwards incompatible change. So not sure if you want to go 3.0 for that (instead of 2.9.0), or since none of of our own APIs break we stick with 2.9.0.

@jpadilla or @auvipy It would be great if you could review and release the next version of PyJWT...

Fixes #949.