### PR TITLE
Improve type annotations for the option parameter in decode methods.

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -18,6 +18,7 @@ from .exceptions import (
     InvalidSignatureError,
     InvalidTokenError,
 )
+from .types import JwsOptions
 from .utils import base64url_decode, base64url_encode
 from .warnings import RemovedInPyjwt3Warning
 
@@ -31,7 +32,7 @@ class PyJWS:
     def __init__(
         self,
         algorithms: list[str] | None = None,
-        options: dict[str, Any] | None = None,
+        options: JwsOptions | None = None,
     ) -> None:
         self._algorithms = get_default_algorithms()
         self._valid_algs = (
@@ -44,11 +45,12 @@ class PyJWS:
                 del self._algorithms[key]
 
         if options is None:
-            options = {}
-        self.options = {**self._get_default_options(), **options}
+            self.options = self._get_default_options()
+        else:
+            self.options = options
 
     @staticmethod
-    def _get_default_options() -> dict[str, bool]:
+    def _get_default_options() -> JwsOptions:
         return {"verify_signature": True}
 
     def register_algorithm(self, alg_id: str, alg_obj: Algorithm) -> None:
@@ -175,7 +177,7 @@ class PyJWS:
         jwt: str | bytes,
         key: AllowedPublicKeys | PyJWK | str | bytes = "",
         algorithms: list[str] | None = None,
-        options: dict[str, Any] | None = None,
+        options: JwsOptions | None = None,
         detached_payload: bytes | None = None,
         **kwargs,
     ) -> dict[str, Any]:
@@ -187,9 +189,9 @@ class PyJWS:
                 RemovedInPyjwt3Warning,
             )
         if options is None:
-            options = {}
-        merged_options = {**self.options, **options}
-        verify_signature = merged_options["verify_signature"]
+            options = self.options
+
+        verify_signature = options["verify_signature"]
 
         if verify_signature and not algorithms and not isinstance(key, PyJWK):
             raise DecodeError(
@@ -220,7 +222,7 @@ class PyJWS:
         jwt: str | bytes,
         key: AllowedPublicKeys | PyJWK | str | bytes = "",
         algorithms: list[str] | None = None,
-        options: dict[str, Any] | None = None,
+        options: JwsOptions | None = None,
         detached_payload: bytes | None = None,
         **kwargs,
     ) -> Any:

--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -9,6 +9,7 @@ from .api_jwk import PyJWK, PyJWKSet
 from .api_jwt import decode_complete as decode_token
 from .exceptions import PyJWKClientConnectionError, PyJWKClientError
 from .jwk_set_cache import JWKSetCache
+from .types import JwtOptions
 
 
 class PyJWKClient:

--- a/jwt/types.py
+++ b/jwt/types.py
@@ -1,5 +1,21 @@
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, List, NotRequired, TypedDict
 
 JWKDict = Dict[str, Any]
 
 HashlibHash = Callable[..., Any]
+
+
+# TODO: Make fields mandatory in PyJWT3
+# See: https://peps.python.org/pep-0589/#inheritance
+class JwtOptionsEncode(TypedDict):
+    verify_signature: NotRequired[bool]
+    verify_exp: NotRequired[bool]
+    verify_nbf: NotRequired[bool]
+    verify_iat: NotRequired[bool]
+    verify_aud: NotRequired[bool]
+    verify_iss: NotRequired[bool]
+    require: NotRequired[List[str]]
+
+
+class JwsOptions(TypedDict):
+    verify_signature: NotRequired[bool]

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -83,10 +83,6 @@ class TestJWS:
 
         assert jws.options["verify_signature"]
 
-    def test_options_must_be_dict(self):
-        pytest.raises(TypeError, PyJWS, options=object())
-        pytest.raises((TypeError, ValueError), PyJWS, options=("something"))
-
     def test_encode_decode(self, jws, payload):
         secret = "secret"
         jws_message = jws.encode(payload, secret, algorithm="HS256")


### PR DESCRIPTION
Fixes: #869

***

Here's a minimal reproducible example you can try at the [MyPy Playground](https://mypy-play.net/?mypy=latest&python=3.12).

```python
#
# File: jwt/types.py
#

from typing import TypedDict, List

class JwtOptions(TypedDict):
    verify_signature: bool
    verify_exp: bool
    verify_nbf: bool
    verify_iat: bool
    verify_aud: bool
    verify_iss: bool
    require: List[str]

#
# File: jwt/api_jwt.py
#
# from .types import JwtOptions

class PyJWT:
    def __init__(self, options: JwtOptions | None = None) -> None:
        if options is None:
            self.options: JwtOptions = self._get_default_options()

    @staticmethod
    def _get_default_options() -> JwtOptions:
        return {
            "verify_signature": True,
            "verify_exp": True,
            "verify_nbf": True,
            "verify_iat": True,
            "verify_aud": True,
            "verify_iss": True,
            "require": [],
        }

    def decode(self, options: JwtOptions) -> None:
        pass

#
# Demo
#

pyJWT = PyJWT()

# Happy Path
# Success: no issues found in 1 source file
#
# pyJWT.decode(options={
#     'verify_signature': True,
#     'verify_exp': True,
#     'verify_nbf': True,
#     'verify_iat': True,
#     'verify_aud': True,
#     'verify_iss': True,
#     'require': []
# })

# Unhappy Path
# main.py:65: error: Missing key "require" for TypedDict "JwtOptions"  [typeddict-item]
# main.py:65: error: Extra key "required" for TypedDict "JwtOptions"  [typeddict-unknown-key]
# Found 2 errors in 1 file (checked 1 source file)
#
pyJWT.decode(options={
    'verify_signature': True,
    'verify_exp': True,
    'verify_nbf': True,
    'verify_iat': True,
    'verify_aud': True,
    'verify_iss': True,
    'required': [] # misspelled key
})
```

Signed-off-by: Pedro Aguiar <contact@codespearhead.com>