### PR TITLE
chore: use sequence for typing rather than list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`__.
 Changed
 ~~~~~~~
 
+- Use ``Sequence`` for parameter types rather than ``List`` where applicable by @imnotjames in `#970 <https://github.com/jpadilla/pyjwt/pull/970>`__
+
 Fixed
 ~~~~~
 

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import binascii
 import json
 import warnings
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from .algorithms import (
@@ -30,7 +31,7 @@ class PyJWS:
 
     def __init__(
         self,
-        algorithms: list[str] | None = None,
+        algorithms: Sequence[str] | None = None,
         options: dict[str, Any] | None = None,
     ) -> None:
         self._algorithms = get_default_algorithms()
@@ -174,7 +175,7 @@ class PyJWS:
         self,
         jwt: str | bytes,
         key: AllowedPublicKeys | PyJWK | str | bytes = "",
-        algorithms: list[str] | None = None,
+        algorithms: Sequence[str] | None = None,
         options: dict[str, Any] | None = None,
         detached_payload: bytes | None = None,
         **kwargs,
@@ -219,7 +220,7 @@ class PyJWS:
         self,
         jwt: str | bytes,
         key: AllowedPublicKeys | PyJWK | str | bytes = "",
-        algorithms: list[str] | None = None,
+        algorithms: Sequence[str] | None = None,
         options: dict[str, Any] | None = None,
         detached_payload: bytes | None = None,
         **kwargs,
@@ -291,7 +292,7 @@ class PyJWS:
         header: dict[str, Any],
         signature: bytes,
         key: AllowedPublicKeys | PyJWK | str | bytes = "",
-        algorithms: list[str] | None = None,
+        algorithms: Sequence[str] | None = None,
     ) -> None:
         if algorithms is None and isinstance(key, PyJWK):
             algorithms = [key.algorithm_name]

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import json
 import warnings
 from calendar import timegm
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, Any
 
 from . import api_jws
 from .exceptions import (
@@ -31,7 +31,7 @@ class PyJWT:
         self.options: dict[str, Any] = {**self._get_default_options(), **options}
 
     @staticmethod
-    def _get_default_options() -> dict[str, bool | list[str]]:
+    def _get_default_options() -> dict[str, bool | Sequence[str]]:
         return {
             "verify_signature": True,
             "verify_exp": True,
@@ -102,7 +102,7 @@ class PyJWT:
         self,
         jwt: str | bytes,
         key: AllowedPublicKeys | PyJWK | str | bytes = "",
-        algorithms: list[str] | None = None,
+        algorithms: Sequence[str] | None = None,
         options: dict[str, Any] | None = None,
         # deprecated arg, remove in pyjwt3
         verify: bool | None = None,
@@ -111,7 +111,7 @@ class PyJWT:
         # passthrough arguments to _validate_claims
         # consider putting in options
         audience: str | Iterable[str] | None = None,
-        issuer: str | List[str] | None = None,
+        issuer: str | Sequence[str] | None = None,
         leeway: float | timedelta = 0,
         # kwargs
         **kwargs: Any,
@@ -187,7 +187,7 @@ class PyJWT:
         self,
         jwt: str | bytes,
         key: AllowedPublicKeys | PyJWK | str | bytes = "",
-        algorithms: list[str] | None = None,
+        algorithms: Sequence[str] | None = None,
         options: dict[str, Any] | None = None,
         # deprecated arg, remove in pyjwt3
         verify: bool | None = None,
@@ -196,7 +196,7 @@ class PyJWT:
         # passthrough arguments to _validate_claims
         # consider putting in options
         audience: str | Iterable[str] | None = None,
-        issuer: str | List[str] | None = None,
+        issuer: str | Sequence[str] | None = None,
         leeway: float | timedelta = 0,
         # kwargs
         **kwargs: Any,
@@ -363,7 +363,7 @@ class PyJWT:
         if "iss" not in payload:
             raise MissingRequiredClaimError("iss")
 
-        if isinstance(issuer, list):
+        if isinstance(issuer, Sequence):
             if payload["iss"] not in issuer:
                 raise InvalidIssuerError("Invalid issuer")
         else:

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -31,7 +31,7 @@ class PyJWT:
         self.options: dict[str, Any] = {**self._get_default_options(), **options}
 
     @staticmethod
-    def _get_default_options() -> dict[str, bool | Sequence[str]]:
+    def _get_default_options() -> dict[str, bool | list[str]]:
         return {
             "verify_signature": True,
             "verify_exp": True,


### PR DESCRIPTION
this loosens up the typing for `issuers` & `algorithms` in the API

there's no reason we need to use `List` for the typing of issuers & other parameters - the `Sequence` type allows us to accept more types such as `tuple` and `set` which still support the behavior we need