### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         platform: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8", "pypy3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.8", "pypy3.9"]
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
       USING_COVERAGE: '3.8'
 
     strategy:
+      fail-fast: false
       matrix:
         platform: ["ubuntu-latest", "windows-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.8", "pypy3.9"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Utilities
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ python =
     3.10: py310
     3.11: py311, docs
     3.12: py312
+    3.13: py313
     pypy3.8: pypy3
     pypy3.9: pypy3
 
@@ -21,7 +22,7 @@ python =
 envlist =
     lint
     typing
-    py{38,39,310,311,312,py3}-{crypto,nocrypto}
+    py{38,39,310,311,312,313,py3}-{crypto,nocrypto}
     docs
     pypi-description
     coverage-report


### PR DESCRIPTION
The Python 3.13 release candidate is out now! :rocket:

The Release Manager has issued a [call to action](https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703?u=hugovk]):

> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.13 compatibilities during this phase, and where necessary publish Python 3.13 wheels on PyPI to be ready for the final release of 3.13.0. Any binary wheels built against Python 3.13.0rc1 **will work** with future versions of Python 3.13. As always, report any issues to [the Python bug tracker](https://github.com/python/cpython/issues).