### PR TITLE
Remove algorithm requirement for JWT API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Changed
 ~~~~~~~
 
 - Use ``Sequence`` for parameter types rather than ``List`` where applicable by @imnotjames in `#970 <https://github.com/jpadilla/pyjwt/pull/970>`__
+- Remove algorithm requirement from JWT API, instead relying on JWS API for enforcement, by @luhn in `#975 <https://github.com/jpadilla/pyjwt/pull/975>`__
 
 Fixed
 ~~~~~

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -144,11 +144,6 @@ class PyJWT:
             options.setdefault("verify_aud", False)
             options.setdefault("verify_iss", False)
 
-        if options["verify_signature"] and not algorithms:
-            raise DecodeError(
-                'It is required that you pass in a value for the "algorithms" argument when calling decode().'
-            )
-
         decoded = api_jws.decode_complete(
             jwt,
             key=key,


### PR DESCRIPTION
Followup on #886.  Although I updated the JWS API, the JWT API independently requires a non-empty algorithms list.  This PR just removes that enforcement entirely—We can rely on the JWS API to make sure an appropriate algorithms list is passed in.

