### PR TITLE
Add an RTD config file to resolve RTD build failures

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+build:
+  os: "ubuntu-lts-latest"
+  tools:
+    python: "3.11"
+
+python:
+  install:
+    - method: "pip"
+      path: "."
+      extra_requirements:
+        - "docs"
+
+sphinx:
+  configuration: "docs/conf.py"
+  fail_on_warning: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include .pre-commit-config.yaml
+include .readthedocs.yaml
 include CODE_OF_CONDUCT.md
 include AUTHORS.rst
 include CHANGELOG.rst

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ commands = {envpython} -b -m coverage run -m pytest {posargs}
 
 
 [testenv:docs]
+# The tox config must match the ReadTheDocs config.
 basepython = python3.11
 extras = docs
 commands =


### PR DESCRIPTION
The documentation has been [failing to build on Read the Docs for a very long time](https://readthedocs.org/projects/pyjwt/builds/). The builds are failing for lack of a mandatory RTD configuration file ([link to final build attempt from 7 months ago](https://readthedocs.org/projects/pyjwt/builds/22963746/)).

This PR introduces a preliminary RTD config file.

----

Separately, I recommend changing the badge in the README, as well, so that it's more apparent when documentation builds are failing. Currently the docs badge is pointing to 'stable', but if it had pointed to 'latest' it would have been much more visible that builds have been failing.

* 'stable' badge currently in README:

  ```
  https://readthedocs.org/projects/pyjwt/badge/?version=stable
  ```

  ![stable badge](https://readthedocs.org/projects/pyjwt/badge/?version=stable)

* 'latest' badge recommendation:

  ```
  https://readthedocs.org/projects/pyjwt/badge/?version=latest
  ```

   ![latest badge](https://readthedocs.org/projects/pyjwt/badge/?version=latest)

If you want the README updated, let me know and I'll push an additional commit to update the README as well.