### PR TITLE
Fixes #964: Validate key against allowed types for Algorithm family

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -770,8 +770,9 @@ if has_crypto:
             pass
 
         def prepare_key(self, key: AllowedOKPKeys | str | bytes) -> AllowedOKPKeys:
-            if isinstance(key, self._crypto_key_types):
-                return key
+            if not isinstance(key, (str, bytes)):
+                self.check_crypto_key_type(key)
+                return cast("AllowedOKPKeys", key)
 
             key_str = key.decode("utf-8") if isinstance(key, bytes) else key
             key_bytes = key.encode("utf-8") if isinstance(key, str) else key

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -69,10 +69,27 @@ try:
     # in Py >= 3.10, we can replace this with the Union types below
     ALLOWED_RSA_KEY_TYPES = (RSAPrivateKey, RSAPublicKey)
     ALLOWED_EC_KEY_TYPES = (EllipticCurvePrivateKey, EllipticCurvePublicKey)
-    ALLOWED_OKP_KEY_TYPES = (Ed25519PrivateKey, Ed25519PublicKey, Ed448PrivateKey, Ed448PublicKey)
-    ALLOWED_KEY_TYPES = ALLOWED_RSA_KEY_TYPES + ALLOWED_EC_KEY_TYPES + ALLOWED_OKP_KEY_TYPES
-    ALLOWED_PRIVATE_KEY_TYPES = (RSAPrivateKey, EllipticCurvePrivateKey, Ed25519PrivateKey, Ed448PrivateKey)
-    ALLOWED_PUBLIC_KEY_TYPES = (RSAPublicKey, EllipticCurvePublicKey, Ed25519PublicKey, Ed448PublicKey)
+    ALLOWED_OKP_KEY_TYPES = (
+        Ed25519PrivateKey,
+        Ed25519PublicKey,
+        Ed448PrivateKey,
+        Ed448PublicKey,
+    )
+    ALLOWED_KEY_TYPES = (
+        ALLOWED_RSA_KEY_TYPES + ALLOWED_EC_KEY_TYPES + ALLOWED_OKP_KEY_TYPES
+    )
+    ALLOWED_PRIVATE_KEY_TYPES = (
+        RSAPrivateKey,
+        EllipticCurvePrivateKey,
+        Ed25519PrivateKey,
+        Ed448PrivateKey,
+    )
+    ALLOWED_PUBLIC_KEY_TYPES = (
+        RSAPublicKey,
+        EllipticCurvePublicKey,
+        Ed25519PublicKey,
+        Ed448PublicKey,
+    )
 
     has_crypto = True
 except ModuleNotFoundError:
@@ -81,7 +98,12 @@ except ModuleNotFoundError:
 
 if TYPE_CHECKING:
     from typing import TypeAlias
-    from cryptography.hazmat.primitives.asymmetric.types import PublicKeyTypes, PrivateKeyTypes
+
+    from cryptography.hazmat.primitives.asymmetric.types import (
+        PrivateKeyTypes,
+        PublicKeyTypes,
+    )
+
     # Type aliases for convenience in algorithms method signatures
     AllowedRSAKeys: TypeAlias = RSAPrivateKey | RSAPublicKey
     AllowedECKeys: TypeAlias = EllipticCurvePrivateKey | EllipticCurvePublicKey
@@ -195,7 +217,9 @@ class Algorithm(ABC):
             valid_classes = (cls.__name__ for cls in self._crypto_key_types)
             actual_class = key.__class__.__name__
             self_class = self.__class__.__name__
-            raise InvalidKeyError(f"Expected one of {valid_classes}, got: {actual_class}. Invalid Key type for {self_class}")
+            raise InvalidKeyError(
+                f"Expected one of {valid_classes}, got: {actual_class}. Invalid Key type for {self_class}"
+            )
 
     @abstractmethod
     def prepare_key(self, key: Any) -> Any:
@@ -377,7 +401,9 @@ if has_crypto:
                     self.check_crypto_key_type(public_key)
                     return cast(RSAPublicKey, public_key)
                 else:
-                    private_key: PrivateKeyTypes = load_pem_private_key(key_bytes, password=None)
+                    private_key: PrivateKeyTypes = load_pem_private_key(
+                        key_bytes, password=None
+                    )
                     self.check_crypto_key_type(private_key)
                     return cast(RSAPrivateKey, private_key)
             except ValueError:

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -788,7 +788,7 @@ if has_crypto:
 
             # Explicit check the key to prevent confusing errors from cryptography
             self.check_crypto_key_type(loaded_key)
-            return cast("AllowedOKPKeys", key)
+            return cast("AllowedOKPKeys", loaded_key)
 
         def sign(
             self, msg: str | bytes, key: Ed25519PrivateKey | Ed448PrivateKey

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -65,25 +65,29 @@ try:
         load_ssh_public_key,
     )
 
+    # pyjwt-964: we use these both for type checking below, as well as for validating the key passed in.
+    ALLOWED_RSA_KEY_TYPES = (RSAPrivateKey, RSAPublicKey)
+    ALLOWED_EC_KEY_TYPES = (EllipticCurvePrivateKey, EllipticCurvePublicKey)
+    ALLOWED_OKP_KEY_TYPES = (Ed25519PrivateKey, Ed25519PublicKey, Ed448PrivateKey, Ed448PublicKey)
+    ALLOWED_KEY_TYPES = ALLOWED_RSA_KEY_TYPES + ALLOWED_EC_KEY_TYPES + ALLOWED_OKP_KEY_TYPES
+    ALLOWED_PRIVATE_KEY_TYPES = (RSAPrivateKey, EllipticCurvePrivateKey, Ed25519PrivateKey, Ed448PrivateKey)
+    ALLOWED_PUBLIC_KEY_TYPES = (RSAPublicKey, EllipticCurvePublicKey, Ed25519PublicKey, Ed448PublicKey)
+
     has_crypto = True
 except ModuleNotFoundError:
     has_crypto = False
 
 
 if TYPE_CHECKING:
+    # TODO: should we move this to the top-level?
+    from typing import Union
     # Type aliases for convenience in algorithms method signatures
-    AllowedRSAKeys = RSAPrivateKey | RSAPublicKey
-    AllowedECKeys = EllipticCurvePrivateKey | EllipticCurvePublicKey
-    AllowedOKPKeys = (
-        Ed25519PrivateKey | Ed25519PublicKey | Ed448PrivateKey | Ed448PublicKey
-    )
-    AllowedKeys = AllowedRSAKeys | AllowedECKeys | AllowedOKPKeys
-    AllowedPrivateKeys = (
-        RSAPrivateKey | EllipticCurvePrivateKey | Ed25519PrivateKey | Ed448PrivateKey
-    )
-    AllowedPublicKeys = (
-        RSAPublicKey | EllipticCurvePublicKey | Ed25519PublicKey | Ed448PublicKey
-    )
+    AllowedRSAKeys = Union[ALLOWED_RSA_KEY_TYPES]
+    AllowedECKeys = Union[ALLOWED_EC_KEY_TYPES]
+    AllowedOKPKeys = Union[ALLOWED_OKP_KEY_TYPES]
+    AllowedKeys = Union[ALLOWED_KEY_TYPES]
+    AllowedPrivateKeys = Union[ALLOWED_PRIVATE_KEY_TYPES]
+    AllowedPublicKeys = Union[ALLOWED_PUBLIC_KEY_TYPES]
 
 
 requires_cryptography = {
@@ -141,6 +145,9 @@ class Algorithm(ABC):
     The interface for an algorithm used to sign and verify tokens.
     """
 
+    # pyjwt-964: Validate to ensure the key passed in was decoded to the correct cryptography key family
+    _crypto_key_types: tuple[AllowedKeys, ...] = None
+
     def compute_hash_digest(self, bytestr: bytes) -> bytes:
         """
         Compute a hash digest using the specified algorithm's hash algorithm.
@@ -162,6 +169,26 @@ class Algorithm(ABC):
             return bytes(digest.finalize())
         else:
             return bytes(hash_alg(bytestr).digest())
+
+    def check_crypto_key_type(self, key: Any):
+        """Check that the key belongs to the right cryptographic family.
+
+        Note that this method only works when cryptography is installed.
+
+        Args:
+            key (Any): Potentially a cryptography key
+        Raises:
+            InvalidKeyError: if the key doesn't match the expected key classes
+        """
+        if not has_crypto or self._crypto_key_types is None:
+            return
+
+        # TODO check for algo_type? (e.g., SHA256 vs SHA384)
+        if not isinstance(key, self._crypto_key_types):
+            valid_classes = (cls.__name__ for cls in self._crypto_key_types)
+            actual_class = key.__class__.__name__
+            self_class = self.__class__.__name__
+            raise InvalidKeyError(f"Expected one of {valid_classes}, got: {actual_class}. Invalid Key type for {self_class}")
 
     @abstractmethod
     def prepare_key(self, key: Any) -> Any:
@@ -323,11 +350,13 @@ if has_crypto:
         SHA384: ClassVar[type[hashes.HashAlgorithm]] = hashes.SHA384
         SHA512: ClassVar[type[hashes.HashAlgorithm]] = hashes.SHA512
 
+        _key_types = ALLOWED_RSA_KEY_TYPES
+
         def __init__(self, hash_alg: type[hashes.HashAlgorithm]) -> None:
             self.hash_alg = hash_alg
 
         def prepare_key(self, key: AllowedRSAKeys | str | bytes) -> AllowedRSAKeys:
-            if isinstance(key, (RSAPrivateKey, RSAPublicKey)):
+            if isinstance(key, self._crypto_key_types):
                 return key
 
             if not isinstance(key, (bytes, str)):
@@ -337,16 +366,19 @@ if has_crypto:
 
             try:
                 if key_bytes.startswith(b"ssh-rsa"):
-                    return cast(RSAPublicKey, load_ssh_public_key(key_bytes))
+                    loaded_key = cast(RSAPublicKey, load_ssh_public_key(key_bytes))
                 else:
-                    return cast(
+                    loaded_key = cast(
                         RSAPrivateKey, load_pem_private_key(key_bytes, password=None)
                     )
             except ValueError:
                 try:
-                    return cast(RSAPublicKey, load_pem_public_key(key_bytes))
+                    loaded_key = cast(RSAPublicKey, load_pem_public_key(key_bytes))
                 except (ValueError, UnsupportedAlgorithm):
                     raise InvalidKeyError("Could not parse the provided public key.")
+
+            self.check_crypto_key_type(loaded_key)
+            return loaded_key
 
         @overload
         @staticmethod
@@ -491,11 +523,13 @@ if has_crypto:
         SHA384: ClassVar[type[hashes.HashAlgorithm]] = hashes.SHA384
         SHA512: ClassVar[type[hashes.HashAlgorithm]] = hashes.SHA512
 
+        _crypto_key_types = ALLOWED_EC_KEY_TYPES
+
         def __init__(self, hash_alg: type[hashes.HashAlgorithm]) -> None:
             self.hash_alg = hash_alg
 
         def prepare_key(self, key: AllowedECKeys | str | bytes) -> AllowedECKeys:
-            if isinstance(key, (EllipticCurvePrivateKey, EllipticCurvePublicKey)):
+            if isinstance(key, self._crypto_key_types):
                 return key
 
             if not isinstance(key, (bytes, str)):
@@ -515,12 +549,7 @@ if has_crypto:
                 crypto_key = load_pem_private_key(key_bytes, password=None)  # type: ignore[assignment]
 
             # Explicit check the key to prevent confusing errors from cryptography
-            if not isinstance(
-                crypto_key, (EllipticCurvePrivateKey, EllipticCurvePublicKey)
-            ):
-                raise InvalidKeyError(
-                    "Expecting a EllipticCurvePrivateKey/EllipticCurvePublicKey. Wrong key provided for ECDSA algorithms"
-                )
+            self.check_crypto_key_type(crypto_key)
 
             return crypto_key
 
@@ -700,6 +729,8 @@ if has_crypto:
         This class requires ``cryptography>=2.6`` to be installed.
         """
 
+        _crypto_key_types = ALLOWED_OKP_KEY_TYPES
+
         def __init__(self, **kwargs: Any) -> None:
             pass
 
@@ -716,13 +747,7 @@ if has_crypto:
                     key = load_ssh_public_key(key_bytes)  # type: ignore[assignment]
 
             # Explicit check the key to prevent confusing errors from cryptography
-            if not isinstance(
-                key,
-                (Ed25519PrivateKey, Ed25519PublicKey, Ed448PrivateKey, Ed448PublicKey),
-            ):
-                raise InvalidKeyError(
-                    "Expecting a EllipticCurvePrivateKey/EllipticCurvePublicKey. Wrong key provided for EdDSA algorithms"
-                )
+            self.check_crypto_key_type(key)
 
             return key
 


### PR DESCRIPTION
- [ ] add tests, make sure current test suite passes
- [ ] remove TODOs

Following discussion in #964, this PR adds checks to make sure the key loaded by any of the `has_crypto = True` Algorithm children is of the correct type for that Algorithm family. I still need to figure out how to check whether it's the right "flavor" of the algo family (for example, that the SHA256 algo is encoding/decoding using a key generated via SHA256).