### PR TITLE
Correct jwt.decode audience param doc expression

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -63,7 +63,8 @@ API Reference
             if ``verify_exp``, ``verify_iat``, and ``verify_nbf`` respectively
             is set to ``True``).
 
-    :param Union[str, Iterable] audience: optional, the value for ``verify_aud`` check
+    :param audience: optional, the value for ``verify_aud`` check
+    :type audience: Union[str, Iterable]
     :param str issuer: optional, the value for ``verify_iss`` check
     :param float leeway: a time margin in seconds for the expiration check
     :rtype: dict


### PR DESCRIPTION
As title, correcting the `audience` parameter type expression in the `jwt.decode` method.

Before:

![image](https://github.com/user-attachments/assets/f1fc7102-2d51-4daf-ba31-e753b26cc37b)

After:

![image](https://github.com/user-attachments/assets/f02b910e-8014-4f12-b248-61d93e662d73)
