### PR TITLE
Update pre-commit hooks to lint pyproject.toml

### DIFF
--- a/.github/workflows/enforce-changelog-entry.yml
+++ b/.github/workflows/enforce-changelog-entry.yml
@@ -15,3 +15,4 @@ jobs:
       with:
         skipLabels: 'Skip-Changelog,dependencies,tests'
         versionPattern: ^`(v\\d?\\.\\d?\\.\\d|Unreleased) <\\S+>`__
+        changeLogPath: CHANGELOG.rst

--- a/.github/workflows/enforce-changelog-entry.yml
+++ b/.github/workflows/enforce-changelog-entry.yml
@@ -14,4 +14,4 @@ jobs:
     - uses: dangoslen/changelog-enforcer@204e7d3ef26579f4cd0fd759c57032656fdf23c7 # v3.6.1
       with:
         skipLabels: 'Skip-Changelog,dependencies,tests'
-        versionPattern: '^`Unreleased <\S+>`__$'
+        versionPattern: ^`(v\\d?\\.\\d?\\.\\d|Unreleased) <\\S+>`__

--- a/.github/workflows/enforce-changelog-entry.yml
+++ b/.github/workflows/enforce-changelog-entry.yml
@@ -14,3 +14,4 @@ jobs:
     - uses: dangoslen/changelog-enforcer@204e7d3ef26579f4cd0fd759c57032656fdf23c7 # v3.6.1
       with:
         skipLabels: 'Skip-Changelog,dependencies,tests'
+        versionPattern: '^`Unreleased <\S+>`__$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,27 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [cryptography>=3.4.0]
+
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: "v0.20.2"
+    hooks:
+      - id: validate-pyproject
+
+  - repo: https://github.com/kieran-ryan/pyprojectsort
+    rev: "v0.3.0"
+    hooks:
+      - id: pyprojectsort
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: "0.29.3"
+    hooks:
+      - id: check-github-workflows
+      - id: check-github-actions
+      - id: check-readthedocs
+
+  - repo: https://github.com/regebro/pyroma
+    rev: "4.2"
+    hooks:
+      - id: pyroma
+
+...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,6 @@ repos:
     rev: "0.29.3"
     hooks:
       - id: check-github-workflows
-      - id: check-github-actions
       - id: check-readthedocs
 
   - repo: https://github.com/regebro/pyroma

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ Fixed
 Added
 ~~~~~
 
+- Include checkers and linters for ``pyproject.toml`` in ``pre-commit`` by @cleder in `#1002 <https://github.com/jpadilla/pyjwt/pull/1002>`__
+
 `v2.9.0 <https://github.com/jpadilla/pyjwt/compare/2.8.0...2.9.0>`__
 -----------------------------------------------------------------------
 


### PR DESCRIPTION
Include checkers and linters for the `pyproject.toml`  and `yaml` configuration files

Follow up to #995 to ensure PEP-517/PEP-518 conformance