### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,13 @@ jobs:
     name: "Python ${{ matrix.python-version }} on ${{ matrix.platform }}"
     runs-on: "${{ matrix.platform }}"
     env:
-      USING_COVERAGE: '3.8'
+      USING_COVERAGE: '3.9'
 
     strategy:
       fail-fast: false
       matrix:
         platform: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.8", "pypy3.9"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9"]
 
     steps:
       - uses: "actions/checkout@v4"
@@ -43,7 +43,7 @@ jobs:
       # parsing errors in older versions for modern code.
       - uses: "actions/setup-python@v5"
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: "Combine coverage"
         run: |
@@ -70,7 +70,7 @@ jobs:
       - uses: "actions/setup-python@v5"
 
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: "Install pep517 and twine"
         run: "python -m pip install pep517 twine"
@@ -97,7 +97,7 @@ jobs:
       - uses: "actions/setup-python@v5"
 
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: "Install in dev mode"
         run: "python -m pip install -e .[dev]"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,13 @@ repos:
     rev: 24.10.0
     hooks:
       - id: black
-        args: ["--target-version=py38"]
+        args: ["--target-version=py39"]
 
   - repo: https://github.com/asottile/blacken-docs
     rev: 1.19.0
     hooks:
       - id: blacken-docs
-        args: ["--target-version=py38"]
+        args: ["--target-version=py39"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`__.
 Changed
 ~~~~~~~
 
+- Drop support for Python 3.8 (EOL) by @kkirsche in `#1007 <https://github.com/jpadilla/pyjwt/pull/1007>`__
 - Use ``Sequence`` for parameter types rather than ``List`` where applicable by @imnotjames in `#970 <https://github.com/jpadilla/pyjwt/pull/970>`__
 - Remove algorithm requirement from JWT API, instead relying on JWS API for enforcement, by @luhn in `#975 <https://github.com/jpadilla/pyjwt/pull/975>`__
 - Add JWK support to JWT encode by @luhn in `#979 <https://github.com/jpadilla/pyjwt/pull/979>`__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -37,7 +36,7 @@ keywords = [
     "web",
 ]
 name = "PyJWT"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.license]
 text = "MIT"

--- a/ruff.toml
+++ b/ruff.toml
@@ -32,8 +32,8 @@ exclude = [
 line-length = 88
 indent-width = 4
 
-# Assume Python 3.8
-target-version = "py38"
+# Assume Python 3.9
+target-version = "py39"
 
 [lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [flake8]
-min_python_version = 3.8
+min_python_version = 3.9
 ignore= E501, E203, W503, E704
 
 [pytest]
@@ -12,13 +12,11 @@ filterwarnings =
 
 [gh-actions]
 python =
-    3.8: py38, typing
     3.9: py39
     3.10: py310
     3.11: py311, docs
     3.12: py312
     3.13: py313
-    pypy3.8: pypy3
     pypy3.9: pypy3
 
 
@@ -26,7 +24,7 @@ python =
 envlist =
     lint
     typing
-    py{38,39,310,311,312,313,py3}-{crypto,nocrypto}
+    py{39,310,311,312,313,py3}-{crypto,nocrypto}
     docs
     pypi-description
     coverage-report
@@ -57,14 +55,14 @@ commands =
 
 
 [testenv:lint]
-basepython = python3.8
+basepython = python3.9
 extras = dev
 passenv = HOMEPATH  # needed on Windows
 commands = pre-commit run --all-files
 
 
 [testenv:pypi-description]
-basepython = python3.8
+basepython = python3.9
 skip_install = true
 deps =
     twine
@@ -75,7 +73,7 @@ commands =
 
 
 [testenv:coverage-report]
-basepython = python3.8
+basepython = python3.9
 skip_install = true
 deps = coverage[toml]==5.0.4
 commands =


### PR DESCRIPTION
With the release of Python 3.13, Python 3.8 is now end of life, as shown on https://devguide.python.org/versions/

By dropping Python 3.8, this expands the available features for unconditional use in the library to include (but is not limited to):

- [Dictionary merge and update operators](https://docs.python.org/3/whatsnew/3.9.html#dictionary-merge-update-operators)
- [Type Hinting Generics in Standard Collections](https://docs.python.org/3/whatsnew/3.9.html#type-hinting-generics-in-standard-collections)
- [New string methods to remove prefixes and suffixes](https://docs.python.org/3/whatsnew/3.9.html#new-string-methods-to-remove-prefixes-and-suffixes)
- [`hashlib` now can use SHA3 and SHAKE XOF from OpenSSL](https://docs.python.org/3/whatsnew/3.9.html#hashlib)
- [`typing.Annotated` is now supported](https://docs.python.org/3/whatsnew/3.9.html#typing)

If more complete typing information is desired, additional work can be done to incorporate `typing-extensions` so that things like `kwargs` can be strongly typed via `Unpack`