### PR TITLE
Add missing use of "typing.Literal"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Fixed
 ~~~~~
 
 - Encode EC keys with a fixed bit length by @etianen in `#990 <https://github.com/jpadilla/pyjwt/pull/990>`__
+- Use `typing.Literal` when exact string types are expected in utility functions by @kkirsche in `#1008 <https://github.com/jpadilla/pyjwt/pull/1008>`__
 
 Added
 ~~~~~

--- a/jwt/utils.py
+++ b/jwt/utils.py
@@ -1,7 +1,7 @@
 import base64
 import binascii
 import re
-from typing import Optional, Union
+from typing import Optional, Union, Literal
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
@@ -71,7 +71,7 @@ def bytes_from_int(val: int, *, bit_length: Optional[int] = None) -> bytes:
     return val.to_bytes(byte_length, "big", signed=False)
 
 
-def der_to_raw_signature(der_sig: bytes, curve: "EllipticCurve") -> bytes:
+def der_to_raw_signature(der_sig: bytes, curve: Literal["EllipticCurve"]) -> bytes:
     num_bits = curve.key_size
     num_bytes = (num_bits + 7) // 8
 
@@ -80,7 +80,7 @@ def der_to_raw_signature(der_sig: bytes, curve: "EllipticCurve") -> bytes:
     return number_to_bytes(r, num_bytes) + number_to_bytes(s, num_bytes)
 
 
-def raw_to_der_signature(raw_sig: bytes, curve: "EllipticCurve") -> bytes:
+def raw_to_der_signature(raw_sig: bytes, curve: Literal["EllipticCurve"]) -> bytes:
     num_bits = curve.key_size
     num_bytes = (num_bits + 7) // 8
 

--- a/jwt/utils.py
+++ b/jwt/utils.py
@@ -1,7 +1,7 @@
 import base64
 import binascii
 import re
-from typing import Optional, Union, Literal
+from typing import Literal, Optional, Union
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve


### PR DESCRIPTION
Add missing use of `typing.Literal` in jwt.utils.py

This feature was added in Python 3.8 per https://docs.python.org/3/library/typing.html#typing.Literal