### PR TITLE
Prepare 2.10.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Changed
 - Remove algorithm requirement from JWT API, instead relying on JWS API for enforcement, by @luhn in `#975 <https://github.com/jpadilla/pyjwt/pull/975>`__
 - Use ``Sequence`` for parameter types rather than ``List`` where applicable by @imnotjames in `#970 <https://github.com/jpadilla/pyjwt/pull/970>`__
 - Add JWK support to JWT encode by @luhn in `#979 <https://github.com/jpadilla/pyjwt/pull/979>`__
-- Encoding and decoding payloads using the `none` algorithm by
+- Encoding and decoding payloads using the `none` algorithm by @jpadilla in `#c2629f6 <https://github.com/jpadilla/pyjwt/commit/c2629f66c593459e02616048443231ccbe18be16>`
 
   Before:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <https://semver.org/>`__.
 
 `Unreleased <https://github.com/jpadilla/pyjwt/compare/2.10.0...HEAD>`__
------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 
@@ -36,7 +36,7 @@ Changed
    >>> jwt.encode({"payload": "abc"}, key=None, algorithm="none")
 
 - Added validation for 'sub' (subject) and 'jti' (JWT ID) claims in tokens by @Divan009 in `#1005 <https://github.com/jpadilla/pyjwt/pull/1005>`__
-- Refactor project configuration files from ``setup.cfg`` to ``pyproject.toml``by @cleder in `#995 <https://github.com/jpadilla/pyjwt/pull/995>`__
+- Refactor project configuration files from ``setup.cfg`` to ``pyproject.toml`` by @cleder in `#995 <https://github.com/jpadilla/pyjwt/pull/995>`__
 - Ruff linter and formatter changes by @gagandeepp in `#1001 <https://github.com/jpadilla/pyjwt/pull/1001>`__
 - Drop support for Python 3.8 (EOL) by @kkirsche in `#1007 <https://github.com/jpadilla/pyjwt/pull/1007>`__
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,17 +4,22 @@ Changelog
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <https://semver.org/>`__.
 
-`Unreleased <https://github.com/jpadilla/pyjwt/compare/2.9.0...HEAD>`__
+`Unreleased <https://github.com/jpadilla/pyjwt/compare/2.10.0...HEAD>`__
 -----------------------------------------------------------------------
+
+
+
+`v2.10.0 <https://github.com/jpadilla/pyjwt/compare/2.9.0...2.10.0>`__
+-----------------------------------------------------------------------
+
 
 Changed
 ~~~~~~~
 
-- Drop support for Python 3.8 (EOL) by @kkirsche in `#1007 <https://github.com/jpadilla/pyjwt/pull/1007>`__
-- Use ``Sequence`` for parameter types rather than ``List`` where applicable by @imnotjames in `#970 <https://github.com/jpadilla/pyjwt/pull/970>`__
 - Remove algorithm requirement from JWT API, instead relying on JWS API for enforcement, by @luhn in `#975 <https://github.com/jpadilla/pyjwt/pull/975>`__
+- Use ``Sequence`` for parameter types rather than ``List`` where applicable by @imnotjames in `#970 <https://github.com/jpadilla/pyjwt/pull/970>`__
 - Add JWK support to JWT encode by @luhn in `#979 <https://github.com/jpadilla/pyjwt/pull/979>`__
-- Encoding and decoding payloads using the `none` algorithm
+- Encoding and decoding payloads using the `none` algorithm by
 
   Before:
 
@@ -30,17 +35,34 @@ Changed
    >>> import jwt
    >>> jwt.encode({"payload": "abc"}, key=None, algorithm="none")
 
-- Added validation for 'sub' (subject) and 'jti' (JWT ID) claims in tokens
+- Added validation for 'sub' (subject) and 'jti' (JWT ID) claims in tokens by @Divan009 in `#1005 <https://github.com/jpadilla/pyjwt/pull/1005>`__
+- Refactor project configuration files from ``setup.cfg`` to ``pyproject.toml``by @cleder in `#995 <https://github.com/jpadilla/pyjwt/pull/995>`__
+- Ruff linter and formatter changes by @gagandeepp in `#1001 <https://github.com/jpadilla/pyjwt/pull/1001>`__
+- Drop support for Python 3.8 (EOL) by @kkirsche in `#1007 <https://github.com/jpadilla/pyjwt/pull/1007>`__
+
 
 Fixed
 ~~~~~
 
 - Encode EC keys with a fixed bit length by @etianen in `#990 <https://github.com/jpadilla/pyjwt/pull/990>`__
+- Add an RTD config file to resolve Read the Docs build failures by @kurtmckee in `#977 <https://github.com/jpadilla/pyjwt/pull/977>`__
+- Docs: Update ``iat`` exception docs by @pachewise in `#974 <https://github.com/jpadilla/pyjwt/pull/974>`__
+- Docs: Fix ``decode_complete`` scope and algorithms by @RbnRncn in `#982 <https://github.com/jpadilla/pyjwt/pull/982>`__
+- Fix doctest for ``docs/usage.rst`` by @pachewise in `#986 <https://github.com/jpadilla/pyjwt/pull/986>`__
+- Fix ``test_utils.py`` not to xfail by @pachewise in `#987 <https://github.com/jpadilla/pyjwt/pull/987>`__
+- Docs: Correct `jwt.decode` audience param doc expression by @peter279k in `#994 <https://github.com/jpadilla/pyjwt/pull/994>`__
 
 Added
 ~~~~~
 
+
+- Add support for python 3.13 by @hugovk in `#972 <https://github.com/jpadilla/pyjwt/pull/972>`__
+- Create SECURITY.md by @auvipy and @jpadilla in `#973 <https://github.com/jpadilla/pyjwt/pull/973>`__
+- Docs: Add PS256 encoding and decoding usage by @peter279k in `#992 <https://github.com/jpadilla/pyjwt/pull/992>`__
+- Docs: Add API docs for PyJWK by @luhn in `#980 <https://github.com/jpadilla/pyjwt/pull/980>`__
+- Docs: Add EdDSA algorithm encoding/decoding usage by @peter279k in `#993 <https://github.com/jpadilla/pyjwt/pull/993>`__
 - Include checkers and linters for ``pyproject.toml`` in ``pre-commit`` by @cleder in `#1002 <https://github.com/jpadilla/pyjwt/pull/1002>`__
+- Docs: Add ES256 decoding usage by @Gautam-Hegde in `#1003 <https://github.com/jpadilla/pyjwt/pull/1003>`
 
 `v2.9.0 <https://github.com/jpadilla/pyjwt/compare/2.8.0...2.9.0>`__
 -----------------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -17,11 +17,13 @@ A Python implementation of `RFC 7519 <https://tools.ietf.org/html/rfc7519>`_. Or
 
 Sponsor
 -------
+
+.. |auth0-logo| image:: https://github.com/user-attachments/assets/ee98379e-ee76-4bcb-943a-e25c4ea6d174
+   :width: 160px
+
 +--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | |auth0-logo| | If you want to quickly add secure token-based authentication to Python projects, feel free to check Auth0's Python SDK and free plan at `auth0.com/signup <https://auth0.com/signup?utm_source=external_sites&utm_medium=pyjwt&utm_campaign=devn_signup>`_. |
 +--------------+-----------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-.. |auth0-logo| image:: https://github.com/user-attachments/assets/ee98379e-ee76-4bcb-943a-e25c4ea6d174
-   :width: 160px
 
 Installing
 ----------

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,10 @@
 
 The following versions of this project are currently being supported with security updates.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 2.9.x   | :white_check_mark: |
-| < 2.8   | :x:                |
+| Version  | Supported          |
+| -------  | ------------------ |
+| 2.10.x   | :white_check_mark: |
+| < 2.9    | :x:                |
 
 ## Reporting a Vulnerability
 In order for the vulnerability reports to reach maintainers as soon as possible, the preferred way is to use the "Report a vulnerability" button under the "Security" tab of the associated GitHub project. This creates a private communication channel between the reporter and the maintainers.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,11 +7,12 @@ claims securely between two parties.
 
 Sponsor
 -------
+.. |auth0-logo| image:: https://github.com/user-attachments/assets/ee98379e-ee76-4bcb-943a-e25c4ea6d174
+   :width: 160px
+
 +--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | |auth0-logo| | If you want to quickly add secure token-based authentication to Python projects, feel free to check Auth0's Python SDK and free plan at `auth0.com/signup <https://auth0.com/signup?utm_source=external_sites&utm_medium=pyjwt&utm_campaign=devn_signup>`_. |
 +--------------+-----------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-.. |auth0-logo| image:: https://github.com/user-attachments/assets/ee98379e-ee76-4bcb-943a-e25c4ea6d174
-   :width: 160px
 
 Installation
 ------------

--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -27,7 +27,7 @@ from .exceptions import (
 )
 from .jwks_client import PyJWKClient
 
-__version__ = "2.9.0"
+__version__ = "2.10.0"
 
 __title__ = "PyJWT"
 __description__ = "JSON Web Token implementation in Python"


### PR DESCRIPTION
Hi @jpadilla  and @auvipy ,

As there were some features currently merged to the master branch (i.e. mostly the `sub` and `jti` validation functionality), that were not part of a release yet, I thought I'd update the Changelog again.

I was not sure whether the example on the `"none"` algorithm should stay as part of the Changelog, or should move to `usage.rst` for now I just added some context on where it was introduced.

In case any changes are required, please let me know, I have some time work on this.

As I saw the CI was failing on how the Auth0 logo, I re-arranged the code a bit in README.rst, which fixed the pyroma RST linting errors. The logo still works. Also I fixed various other RST related issues.
