### PR TITLE
Fixes #660: Improve typing/logic for `options` in decode, decode_complete; Improve docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Added
 ~~~~~
 
 - Docs: Add example of using leeway with nbf by @djw8605 in `#1034 <https://github.com/jpadilla/pyjwt/pull/1034>`__
-- Docs: Refactored docs with ``autodoc``, added ``PyJWS`` and ``jwt.algorithms`` docs by @pachewise in `#1045 <https://github.com/jpadilla/pyjwt/pull/1045>`__
+- Docs: Refactored docs with ``autodoc``; added ``PyJWS`` and ``jwt.algorithms`` docs by @pachewise in `#1045 <https://github.com/jpadilla/pyjwt/pull/1045>`__
 
 `v2.10.1 <https://github.com/jpadilla/pyjwt/compare/2.10.0...2.10.1>`__
 -----------------------------------------------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Added
 ~~~~~
 
 - Docs: Add example of using leeway with nbf by @djw8605 in `#1034 <https://github.com/jpadilla/pyjwt/pull/1034>`__
+- Docs: Refactored docs with ``autodoc``, added ``PyJWS`` and ``jwt.algorithms`` docs by @pachewise in `#1045 <https://github.com/jpadilla/pyjwt/pull/1045>`__
 
 `v2.10.1 <https://github.com/jpadilla/pyjwt/compare/2.10.0...2.10.1>`__
 -----------------------------------------------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Fixed
 - Validate key against allowed types for Algorithm family in `#964 <https://github.com/jpadilla/pyjwt/pull/964>`__
 - Add iterator for JWKSet in `#1041 <https://github.com/jpadilla/pyjwt/pull/1041>`__
 - Validate `iss` claim is a string during encoding and decoding by @pachewise in `#1040 <https://github.com/jpadilla/pyjwt/pull/1040>`__
+- Improve typing/logic for `options` in decode, decode_complete by @pachewise in `#1045 <https://github.com/jpadilla/pyjwt/pull/1045>`__
 
 Added
 ~~~~~

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,54 +24,19 @@ API Reference
 
 .. autofunction:: decode(jwt, key="", algorithms=None, options=None, audience=None, issuer=None, leeway=0) -> dict[str, typing.Any]
 
+.. autoclass:: PyJWK
+    :class-doc-from: init
+    :members:
 
-.. class:: PyJWK
+    .. property:: algorithm_name
 
-  A class that represents a `JSON Web Key <https://www.rfc-editor.org/rfc/rfc7517>`_.
+        :type: str
 
-  .. method:: __init__(self, jwk_data, algorithm=None)
+        The name of the algorithm used by the key.
 
-    :param dict data:  The decoded JWK data.
-    :param algorithm:  The key algorithm.  If not specific, the key's ``alg`` will be used.
-    :type algorithm: str or None
+    .. property:: Algorithm
 
-  .. staticmethod:: from_json(data, algorithm=None)
-
-    :param str data: The JWK data, as a JSON string.
-    :param algorithm:  The key algorithm.  If not specific, the key's ``alg`` will be used.
-    :type algorithm: str or None
-
-    :returntype: jwt.PyJWK
-
-    Create a :class:`jwt.PyJWK` object from a JSON string.
-
-  .. property:: algorithm_name
-
-    :type: str
-
-    The name of the algorithm used by the key.
-
-  .. property:: Algorithm
-
-    The ``Algorithm`` class associated with the key.
-
-  .. property:: key_type
-
-    :type: str or None
-
-    The ``kty`` property from the JWK.
-
-  .. property:: key_id
-
-    :type: str or None
-
-    The ``kid`` property from the JWK.
-
-  .. property:: public_key_use
-
-    :type: str or None
-
-    The ``use`` property from the JWK.
+        The :py:class:`jwt.algorithms.Algorithm` class associated with the key.
 
 .. module:: jwt.api_jwt
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,24 +3,7 @@ API Reference
 
 .. module:: jwt
 
-.. function:: encode(payload, key, algorithm="HS256", headers=None, json_encoder=None)
-
-    Encode the ``payload`` as JSON Web Token.
-
-    :param dict payload: JWT claims, e.g. ``dict(iss=..., aud=..., sub=...)``
-    :param key: a key suitable for the chosen algorithm:
-
-        * for **asymmetric algorithms**: PEM-formatted private key, a multiline string
-        * for **symmetric algorithms**: plain string, sufficiently long for security
-
-    :type key: str or bytes or jwt.PyJWK
-    :param str algorithm: algorithm to sign the token with, e.g. ``"ES256"``.
-        If ``headers`` includes ``alg``, it will be preferred to this parameter.
-        If ``key`` is a :class:`jwt.PyJWK` object, by default the key algorithm will be used.
-    :param dict headers: additional JWT header fields, e.g. ``dict(kid="my-key-id")``.
-    :param json.JSONEncoder json_encoder: custom JSON encoder for ``payload`` and ``headers``
-    :rtype: str
-    :returns: a JSON Web Token
+.. autofunction:: encode(payload, key, algorithm="HS256", headers=None, json_encoder=None) -> str
 
 .. autofunction:: decode(jwt, key="", algorithms=None, options=None, audience=None, issuer=None, leeway=0) -> dict[str, typing.Any]
 
@@ -36,19 +19,27 @@ API Reference
 
     .. property:: Algorithm
 
-        The :py:class:`jwt.algorithms.Algorithm` class associated with the key.
+        The :py:class:`Algorithm` class associated with the key.
 
 .. module:: jwt.api_jwt
 
 .. autofunction:: decode_complete(jwt, key="", algorithms=None, options=None, audience=None, issuer=None, leeway=0) -> dict[str, typing.Any]
 
-
-
-.. note:: TODO: Document PyJWS class
+.. note:: TODO: Finish documenting PyJWS class
 .. module:: jwt.api_jws
 
 .. autoclass:: jwt.api_jws.PyJWS
     :members:
+
+Algorithms
+----------
+
+.. automodule:: jwt.algorithms
+    :members: Algorithm, AllowedPrivateKeys, AllowedPublicKeys
+
+
+Types
+----------
 
 .. module:: jwt.types
     :synopsis: Type validation used in the JWT API
@@ -62,52 +53,7 @@ API Reference
 Exceptions
 ----------
 
-.. currentmodule:: jwt.exceptions
-
-
-.. class:: InvalidTokenError
-
-    Base exception when ``decode()`` fails on a token
-
-.. class:: DecodeError
-
-    Raised when a token cannot be decoded because it failed validation
-
-.. class:: InvalidSignatureError
-
-    Raised when a token's signature doesn't match the one provided as part of
-    the token.
-
-.. class:: ExpiredSignatureError
-
-    Raised when a token's ``exp`` claim indicates that it has expired
-
-.. class:: InvalidAudienceError
-
-    Raised when a token's ``aud`` claim does not match one of the expected
-    audience values
-
-.. class:: InvalidIssuerError
-
-    Raised when a token's ``iss`` claim does not match the expected issuer
-
-.. class:: InvalidIssuedAtError
-
-    Raised when a token's ``iat`` claim is non-numeric
-
-.. class:: ImmatureSignatureError
-
-    Raised when a token's ``nbf`` or ``iat`` claims represent a time in the future
-
-.. class:: InvalidKeyError
-
-    Raised when the specified key is not in the proper format
-
-.. class:: InvalidAlgorithmError
-
-    Raised when the specified algorithm is not recognized by PyJWT
-
-.. class:: MissingRequiredClaimError
-
-    Raised when a claim that is required to be present is not contained
-    in the claimset
+.. automodule:: jwt.exceptions
+    :members:
+    :inherited-members:
+    :show-inheritance:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -22,59 +22,8 @@ API Reference
     :rtype: str
     :returns: a JSON Web Token
 
-.. function:: decode(jwt, key="", algorithms=None, options=None, audience=None, issuer=None, leeway=0)
+.. autofunction:: decode(jwt, key="", algorithms=None, options=None, audience=None, issuer=None, leeway=0) -> dict[str, typing.Any]
 
-    Verify the ``jwt`` token signature and return the token claims.
-
-    :param str jwt: the token to be decoded
-    :param key: the key suitable for the allowed algorithm
-    :type key: str or bytes or jwt.PyJWK
-
-    :param list algorithms: allowed algorithms, e.g. ``["ES256"]``
-        If ``key`` is a :class:`jwt.PyJWK` object, allowed algorithms will default to the key algorithm.
-
-        .. warning::
-
-           Do **not** compute the ``algorithms`` parameter based on
-           the ``alg`` from the token itself, or on any other data
-           that an attacker may be able to influence, as that might
-           expose you to various vulnerabilities (see `RFC 8725 §2.1
-           <https://www.rfc-editor.org/rfc/rfc8725.html#section-2.1>`_). Instead,
-           either hard-code a fixed value for ``algorithms``, or
-           configure it in the same place you configure the
-           ``key``. Make sure not to mix symmetric and asymmetric
-           algorithms that interpret the ``key`` in different ways
-           (e.g. HS\* and RS\*).
-
-    :param dict options: extended decoding and validation options
-
-        * ``verify_signature=True`` verify the JWT cryptographic signature
-        * ``require=[]`` list of claims that must be present.
-          Example: ``require=["exp", "iat", "nbf"]``.
-          **Only verifies that the claims exists**. Does not verify that the claims are valid.
-        * ``verify_aud=verify_signature`` check that ``aud`` (audience) claim matches ``audience``
-        * ``verify_iss=verify_signature`` check that ``iss`` (issuer) claim matches ``issuer``
-        * ``verify_exp=verify_signature`` check that ``exp`` (expiration) claim value is in the future
-        * ``verify_iat=verify_signature`` check that ``iat`` (issued at) claim value is an integer
-        * ``verify_nbf=verify_signature`` check that ``nbf`` (not before) claim value is in the past
-        * ``verify_sub=verify_signature`` (if in payload) check that ``sub`` (subject) claim is a str and matches `subject`
-        * ``verify_jti=verify_signature`` (if in payload) check that ``jti`` (JWT ID) claim is a str
-        * ``strict_aud=False`` (requires ``verify_aud=True``) check that the ``aud`` claim is a single value (not a list), and matches ``audience`` exactly
-
-        .. warning::
-
-            ``exp``, ``iat`` and ``nbf`` will only be verified if present.
-            Please pass respective value to ``require`` if you want to make
-            sure that they are always present (and therefore always verified
-            if ``verify_exp``, ``verify_iat``, and ``verify_nbf`` respectively
-            is set to ``True``).
-
-    :param audience: optional, the value for ``verify_aud`` check
-    :type audience: Union[str, Iterable]
-    :param str issuer: optional, the value for ``verify_iss`` check
-    :param float leeway: a time margin in seconds for the expiration check
-    :rtype: dict
-    :returns: the JWT claims
 
 .. class:: PyJWK
 
@@ -126,59 +75,24 @@ API Reference
 
 .. module:: jwt.api_jwt
 
-.. function:: decode_complete(jwt, key="", algorithms=None, options=None, audience=None, issuer=None, leeway=0)
+.. autofunction:: decode_complete(jwt, key="", algorithms=None, options=None, audience=None, issuer=None, leeway=0) -> dict[str, typing.Any]
 
-    Identical to ``jwt.decode`` except for return value which is a dictionary containing the token header (JOSE Header),
-    the token payload (JWT Payload), and token signature (JWT Signature) on the keys "header", "payload",
-    and "signature" respectively.
 
-    :param str jwt: the token to be decoded
-    :param str key: the key suitable for the allowed algorithm
-
-    :param list algorithms: allowed algorithms, e.g. ``["ES256"]``
-
-        .. warning::
-
-           Do **not** compute the ``algorithms`` parameter based on
-           the ``alg`` from the token itself, or on any other data
-           that an attacker may be able to influence, as that might
-           expose you to various vulnerabilities (see `RFC 8725 §2.1
-           <https://www.rfc-editor.org/rfc/rfc8725.html#section-2.1>`_). Instead,
-           either hard-code a fixed value for ``algorithms``, or
-           configure it in the same place you configure the
-           ``key``. Make sure not to mix symmetric and asymmetric
-           algorithms that interpret the ``key`` in different ways
-           (e.g. HS\* and RS\*).
-
-    :param dict options: extended decoding and validation options
-
-        * ``verify_signature=True`` verify the JWT cryptographic signature
-        * ``require=[]`` list of claims that must be present.
-          Example: ``require=["exp", "iat", "nbf"]``.
-          **Only verifies that the claims exists**. Does not verify that the claims are valid.
-        * ``verify_aud=verify_signature`` check that ``aud`` (audience) claim matches ``audience``
-        * ``verify_iss=verify_signature`` check that ``iss`` (issuer) claim matches ``issuer``
-        * ``verify_exp=verify_signature`` check that ``exp`` (expiration) claim value is in the future
-        * ``verify_iat=verify_signature`` check that ``iat`` (issued at) claim value is an integer
-        * ``verify_nbf=verify_signature`` check that ``nbf`` (not before) claim value is in the past
-        * ``strict_aud=False`` check that the ``aud`` claim is a single value (not a list), and matches ``audience`` exactly
-
-        .. warning::
-
-            ``exp``, ``iat`` and ``nbf`` will only be verified if present.
-            Please pass respective value to ``require`` if you want to make
-            sure that they are always present (and therefore always verified
-            if ``verify_exp``, ``verify_iat``, and ``verify_nbf`` respectively
-            is set to ``True``).
-
-    :param Iterable audience: optional, the value for ``verify_aud`` check
-    :param str issuer: optional, the value for ``verify_iss`` check
-    :param float leeway: a time margin in seconds for the expiration check
-    :rtype: dict
-    :returns: Decoded JWT with the JOSE Header on the key ``header``, the JWS
-     Payload on the key ``payload``, and the JWS Signature on the key ``signature``.
 
 .. note:: TODO: Document PyJWS class
+.. module:: jwt.api_jws
+
+.. autoclass:: jwt.api_jws.PyJWS
+    :members:
+
+.. module:: jwt.types
+    :synopsis: Type validation used in the JWT API
+.. autoclass:: jwt.types.SigOptions
+    :members:
+    :undoc-members:
+.. autoclass:: jwt.types.Options
+    :members:
+    :undoc-members:
 
 Exceptions
 ----------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -57,7 +57,9 @@ API Reference
         * ``verify_exp=verify_signature`` check that ``exp`` (expiration) claim value is in the future
         * ``verify_iat=verify_signature`` check that ``iat`` (issued at) claim value is an integer
         * ``verify_nbf=verify_signature`` check that ``nbf`` (not before) claim value is in the past
-        * ``strict_aud=False`` check that the ``aud`` claim is a single value (not a list), and matches ``audience`` exactly
+        * ``verify_sub=verify_signature`` (if in payload) check that ``sub`` (subject) claim is a str and matches `subject`
+        * ``verify_jti=verify_signature`` (if in payload) check that ``jti`` (JWT ID) claim is a str
+        * ``strict_aud=False`` (requires ``verify_aud=True``) check that the ``aud`` claim is a single value (not a list), and matches ``audience`` exactly
 
         .. warning::
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,7 @@ intersphinx_mapping = {
 }
 
 # Hack for allowing aliases within TYPE_CHECKING to be documented
-os.environ['SPHINX_BUILD'] = '1'
+os.environ["SPHINX_BUILD"] = "1"
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,11 @@ todo_include_todos = False
 # Intersphinx extension.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
+    "cryptography": ("https://cryptography.io/en/latest/", None),
 }
+
+# Hack for allowing aliases within TYPE_CHECKING to be documented
+os.environ['SPHINX_BUILD'] = '1'
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -91,32 +91,31 @@ try:
         Ed448PublicKey,
     )
 
+    if TYPE_CHECKING:
+        from typing import TypeAlias
+
+        from cryptography.hazmat.primitives.asymmetric.types import (
+            PrivateKeyTypes,
+            PublicKeyTypes,
+        )
+
+        # Type aliases for convenience in algorithms method signatures
+        AllowedRSAKeys: TypeAlias = RSAPrivateKey | RSAPublicKey
+        AllowedECKeys: TypeAlias = EllipticCurvePrivateKey | EllipticCurvePublicKey
+        AllowedOKPKeys: TypeAlias = (
+            Ed25519PrivateKey | Ed25519PublicKey | Ed448PrivateKey | Ed448PublicKey
+        )
+        AllowedKeys: TypeAlias = AllowedRSAKeys | AllowedECKeys | AllowedOKPKeys
+        AllowedPrivateKeys: TypeAlias = (
+            RSAPrivateKey | EllipticCurvePrivateKey | Ed25519PrivateKey | Ed448PrivateKey
+        )
+        AllowedPublicKeys: TypeAlias = (
+            RSAPublicKey | EllipticCurvePublicKey | Ed25519PublicKey | Ed448PublicKey
+        )
+
     has_crypto = True
 except ModuleNotFoundError:
     has_crypto = False
-
-
-if TYPE_CHECKING:
-    from typing import TypeAlias
-
-    from cryptography.hazmat.primitives.asymmetric.types import (
-        PrivateKeyTypes,
-        PublicKeyTypes,
-    )
-
-    # Type aliases for convenience in algorithms method signatures
-    AllowedRSAKeys: TypeAlias = RSAPrivateKey | RSAPublicKey
-    AllowedECKeys: TypeAlias = EllipticCurvePrivateKey | EllipticCurvePublicKey
-    AllowedOKPKeys: TypeAlias = (
-        Ed25519PrivateKey | Ed25519PublicKey | Ed448PrivateKey | Ed448PublicKey
-    )
-    AllowedKeys: TypeAlias = AllowedRSAKeys | AllowedECKeys | AllowedOKPKeys
-    AllowedPrivateKeys: TypeAlias = (
-        RSAPrivateKey | EllipticCurvePrivateKey | Ed25519PrivateKey | Ed448PrivateKey
-    )
-    AllowedPublicKeys: TypeAlias = (
-        RSAPublicKey | EllipticCurvePublicKey | Ed25519PublicKey | Ed448PublicKey
-    )
 
 
 requires_cryptography = {
@@ -139,7 +138,7 @@ def get_default_algorithms() -> dict[str, Algorithm]:
     """
     Returns the algorithms that are implemented by the library.
     """
-    default_algorithms = {
+    default_algorithms: dict[str, Algorithm] = {
         "none": NoneAlgorithm(),
         "HS256": HMACAlgorithm(HMACAlgorithm.SHA256),
         "HS384": HMACAlgorithm(HMACAlgorithm.SHA384),

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-
+import os
 import hashlib
 import hmac
 import json
@@ -91,7 +91,7 @@ try:
         Ed448PublicKey,
     )
 
-    if TYPE_CHECKING:
+    if TYPE_CHECKING or bool(os.getenv("SPHINX_BUILD", "")):
         from typing import TypeAlias
 
         from cryptography.hazmat.primitives.asymmetric.types import (
@@ -106,12 +106,14 @@ try:
             Ed25519PrivateKey | Ed25519PublicKey | Ed448PrivateKey | Ed448PublicKey
         )
         AllowedKeys: TypeAlias = AllowedRSAKeys | AllowedECKeys | AllowedOKPKeys
+        #: Type alias for allowed ``cryptography`` private keys
         AllowedPrivateKeys: TypeAlias = (
             RSAPrivateKey
             | EllipticCurvePrivateKey
             | Ed25519PrivateKey
             | Ed448PrivateKey
         )
+        #: Type alias for allowed ``cryptography`` public keys
         AllowedPublicKeys: TypeAlias = (
             RSAPublicKey | EllipticCurvePublicKey | Ed25519PublicKey | Ed448PublicKey
         )
@@ -204,13 +206,12 @@ class Algorithm(ABC):
     def check_crypto_key_type(self, key: PublicKeyTypes | PrivateKeyTypes):
         """Check that the key belongs to the right cryptographic family.
 
-        Note that this method only works when `cryptography` is installed.
+        Note that this method only works when ``cryptography`` is installed.
 
-        Args:
-            key (Any): Potentially a cryptography key
-        Raises:
-            ValueError: if `cryptography` is not installed, or this method is called by a non-cryptography algorithm
-            InvalidKeyError: if the key doesn't match the expected key classes
+        :param key: Potentially a cryptography key
+        :type key: PublicKeyTypes | PrivateKeyTypes
+        :raises ValueError: if ``cryptography`` is not installed, or this method is called by a non-cryptography algorithm
+        :raises InvalidKeyError: if the key doesn't match the expected key classes
         """
         if not has_crypto or self._crypto_key_types is None:
             raise ValueError(

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -107,7 +107,10 @@ try:
         )
         AllowedKeys: TypeAlias = AllowedRSAKeys | AllowedECKeys | AllowedOKPKeys
         AllowedPrivateKeys: TypeAlias = (
-            RSAPrivateKey | EllipticCurvePrivateKey | Ed25519PrivateKey | Ed448PrivateKey
+            RSAPrivateKey
+            | EllipticCurvePrivateKey
+            | Ed25519PrivateKey
+            | Ed448PrivateKey
         )
         AllowedPublicKeys: TypeAlias = (
             RSAPublicKey | EllipticCurvePublicKey | Ed25519PublicKey | Ed448PublicKey

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
-import os
+
 import hashlib
 import hmac
 import json
+import os
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, NoReturn, cast, overload
 
@@ -106,14 +107,14 @@ try:
             Ed25519PrivateKey | Ed25519PublicKey | Ed448PrivateKey | Ed448PublicKey
         )
         AllowedKeys: TypeAlias = AllowedRSAKeys | AllowedECKeys | AllowedOKPKeys
-        #: Type alias for allowed ``cryptography`` private keys
+        #: Type alias for allowed ``cryptography`` private keys (requires ``cryptography`` to be installed)
         AllowedPrivateKeys: TypeAlias = (
             RSAPrivateKey
             | EllipticCurvePrivateKey
             | Ed25519PrivateKey
             | Ed448PrivateKey
         )
-        #: Type alias for allowed ``cryptography`` public keys
+        #: Type alias for allowed ``cryptography`` public keys (requires ``cryptography`` to be installed)
         AllowedPublicKeys: TypeAlias = (
             RSAPublicKey | EllipticCurvePublicKey | Ed25519PublicKey | Ed448PublicKey
         )
@@ -209,7 +210,7 @@ class Algorithm(ABC):
         Note that this method only works when ``cryptography`` is installed.
 
         :param key: Potentially a cryptography key
-        :type key: PublicKeyTypes | PrivateKeyTypes
+        :type key: :py:data:`PublicKeyTypes <cryptography.hazmat.primitives.asymmetric.types.PublicKeyTypes>` | :py:data:`PrivateKeyTypes <cryptography.hazmat.primitives.asymmetric.types.PrivateKeyTypes>`
         :raises ValueError: if ``cryptography`` is not installed, or this method is called by a non-cryptography algorithm
         :raises InvalidKeyError: if the key doesn't match the expected key classes
         """

--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -24,7 +24,7 @@ class PyJWK:
         :param algorithm: The key algorithm. If not specified, the key's ``alg`` will be used.
         :type algorithm: str or None
         :raises InvalidKeyError: If the key type (``kty``) is not found or unsupported, or if the curve (``crv``) is not found or unsupported.
-        :raises MissingCryptographyError: If the algorithm requires `cryptography` to be installed and it is not available.
+        :raises MissingCryptographyError: If the algorithm requires ``cryptography`` to be installed and it is not available.
         :raises PyJWKError: If unable to find an algorithm for the key.
         """
         self._algorithms = get_default_algorithms()

--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -17,6 +17,16 @@ from .types import JWKDict
 
 class PyJWK:
     def __init__(self, jwk_data: JWKDict, algorithm: str | None = None) -> None:
+        """A class that represents a `JSON Web Key <https://www.rfc-editor.org/rfc/rfc7517>`_.
+
+        :param jwk_data: The decoded JWK data.
+        :type jwk_data: dict[str, typing.Any]
+        :param algorithm: The key algorithm. If not specified, the key's ``alg`` will be used.
+        :type algorithm: str or None
+        :raises InvalidKeyError: If the key type (``kty``) is not found or unsupported, or if the curve (``crv``) is not found or unsupported.
+        :raises MissingCryptographyError: If the algorithm requires `cryptography` to be installed and it is not available.
+        :raises PyJWKError: If unable to find an algorithm for the key.
+        """
         self._algorithms = get_default_algorithms()
         self._jwk_data = jwk_data
 
@@ -71,23 +81,52 @@ class PyJWK:
 
     @staticmethod
     def from_dict(obj: JWKDict, algorithm: str | None = None) -> PyJWK:
+        """Creates a :class:`jwt.PyJWK` object from a JSON-like dictionary.
+
+        :param obj: The JWK data, as a dictionary
+        :type obj: dict[str, typing.Any]
+        :param algorithm: The key algorithm. If not specified, the key's ``alg`` will be used.
+        :type algorithm: str or None
+        :rtype: jwt.PyJWK
+        """
         return PyJWK(obj, algorithm)
 
     @staticmethod
     def from_json(data: str, algorithm: None = None) -> PyJWK:
+        """Create a :class:`jwt.PyJWK` object from a JSON string.
+        Implicitly calls :meth:`jwt.PyJWK.from_dict()`.
+
+        :param str data: The JWK data, as a JSON string.
+        :param algorithm:  The key algorithm.  If not specific, the key's ``alg`` will be used.
+        :type algorithm: str or None
+
+        :rtype: jwt.PyJWK
+        """
         obj = json.loads(data)
         return PyJWK.from_dict(obj, algorithm)
 
     @property
     def key_type(self) -> str | None:
+        """The `kty` property from the JWK.
+
+        :rtype: str or None
+        """
         return self._jwk_data.get("kty", None)
 
     @property
     def key_id(self) -> str | None:
+        """The `kid` property from the JWK.
+
+        :rtype: str or None
+        """
         return self._jwk_data.get("kid", None)
 
     @property
     def public_key_use(self) -> str | None:
+        """The `use` property from the JWK.
+
+        :rtype: str or None
+        """
         return self._jwk_data.get("use", None)
 
 

--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -81,26 +81,26 @@ class PyJWK:
 
     @staticmethod
     def from_dict(obj: JWKDict, algorithm: str | None = None) -> PyJWK:
-        """Creates a :class:`jwt.PyJWK` object from a JSON-like dictionary.
+        """Creates a :class:`PyJWK` object from a JSON-like dictionary.
 
         :param obj: The JWK data, as a dictionary
         :type obj: dict[str, typing.Any]
         :param algorithm: The key algorithm. If not specified, the key's ``alg`` will be used.
         :type algorithm: str or None
-        :rtype: jwt.PyJWK
+        :rtype: PyJWK
         """
         return PyJWK(obj, algorithm)
 
     @staticmethod
     def from_json(data: str, algorithm: None = None) -> PyJWK:
-        """Create a :class:`jwt.PyJWK` object from a JSON string.
-        Implicitly calls :meth:`jwt.PyJWK.from_dict()`.
+        """Create a :class:`PyJWK` object from a JSON string.
+        Implicitly calls :meth:`PyJWK.from_dict()`.
 
         :param str data: The JWK data, as a JSON string.
         :param algorithm:  The key algorithm.  If not specific, the key's ``alg`` will be used.
         :type algorithm: str or None
 
-        :rtype: jwt.PyJWK
+        :rtype: PyJWK
         """
         obj = json.loads(data)
         return PyJWK.from_dict(obj, algorithm)

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -98,7 +98,7 @@ class PyJWS:
         For a given string name, return the matching Algorithm object.
 
         Example usage:
-
+        >>> jws_obj = PyJWS()
         >>> jws_obj.get_algorithm_by_name("RS256")
 
         :param alg_name: The name of the algorithm to retrieve

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -23,8 +23,8 @@ from .utils import base64url_decode, base64url_encode
 from .warnings import RemovedInPyjwt3Warning
 
 if TYPE_CHECKING:
-    from .types import SigOptions
     from .algorithms import AllowedPrivateKeys, AllowedPublicKeys
+    from .types import SigOptions
 
 
 class PyJWS:
@@ -197,10 +197,12 @@ class PyJWS:
                 RemovedInPyjwt3Warning,
                 stacklevel=2,
             )
+        merged_options: SigOptions
         if options is None:
             merged_options = self.options
         else:
-            merged_options: SigOptions = {**self.options, **options}
+            merged_options = {**self.options, **options}
+
         verify_signature = merged_options["verify_signature"]
 
         if verify_signature and not algorithms and not isinstance(key, PyJWK):

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -56,6 +56,10 @@ class PyJWS:
     def register_algorithm(self, alg_id: str, alg_obj: Algorithm) -> None:
         """
         Registers a new Algorithm for use when creating and verifying tokens.
+
+        :param str alg_id: the ID of the Algorithm
+        :param alg_obj: the Algorithm object
+        :type alg_obj: Algorithm
         """
         if alg_id in self._algorithms:
             raise ValueError("Algorithm already has a handler.")
@@ -69,7 +73,8 @@ class PyJWS:
     def unregister_algorithm(self, alg_id: str) -> None:
         """
         Unregisters an Algorithm for use when creating and verifying tokens
-        Throws KeyError if algorithm is not registered.
+        :param str alg_id: the ID of the Algorithm
+        :raises KeyError: if algorithm is not registered.
         """
         if alg_id not in self._algorithms:
             raise KeyError(
@@ -82,7 +87,9 @@ class PyJWS:
 
     def get_algorithms(self) -> list[str]:
         """
-        Returns a list of supported values for the 'alg' parameter.
+        Returns a list of supported values for the `alg` parameter.
+
+        :rtype: list[str]
         """
         return list(self._valid_algs)
 
@@ -93,6 +100,10 @@ class PyJWS:
         Example usage:
 
         >>> jws_obj.get_algorithm_by_name("RS256")
+
+        :param alg_name: The name of the algorithm to retrieve
+        :type alg_name: str
+        :rtype: Algorithm
         """
         try:
             return self._algorithms[alg_name]
@@ -252,7 +263,7 @@ class PyJWS:
         return decoded["payload"]
 
     def get_unverified_header(self, jwt: str | bytes) -> dict[str, Any]:
-        """Returns back the JWT header parameters as a dict()
+        """Returns back the JWT header parameters as a `dict`
 
         Note: The signature is not verified so the header parameters
         should not be fully trusted until signature verification is complete

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -42,10 +42,9 @@ if TYPE_CHECKING or bool(os.getenv("SPHINX_BUILD", "")):
 class PyJWT:
     def __init__(self, options: Options | None = None) -> None:
         self.options: FullOptions
-        if options is None:
-            self.options = self._get_default_options()
-        else:
-            self.options = {**self._get_default_options(), **options}
+        self.options = self._get_default_options()
+        if options is not None:
+            self.options = self._merge_options(options)
 
     @staticmethod
     def _get_default_options() -> FullOptions:

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -155,6 +155,43 @@ class PyJWT:
         # kwargs
         **kwargs: Any,
     ) -> dict[str, Any]:
+        """Identical to ``jwt.decode`` except for return value which is a dictionary containing the token header (JOSE Header),
+    the token payload (JWT Payload), and token signature (JWT Signature) on the keys "header", "payload",
+    and "signature" respectively.
+
+    :param jwt: the token to be decoded
+    :type jwt: str or bytes
+    :param key: the key suitable for the allowed algorithm
+    :type key: str or bytes or jwt.PyJWK or jwt.algorithms.AllowedPublicKeys
+
+    :param algorithms: allowed algorithms, e.g. ``["ES256"]``
+
+        .. warning::
+
+           Do **not** compute the ``algorithms`` parameter based on
+           the ``alg`` from the token itself, or on any other data
+           that an attacker may be able to influence, as that might
+           expose you to various vulnerabilities (see `RFC 8725 §2.1
+           <https://www.rfc-editor.org/rfc/rfc8725.html#section-2.1>`_). Instead,
+           either hard-code a fixed value for ``algorithms``, or
+           configure it in the same place you configure the
+           ``key``. Make sure not to mix symmetric and asymmetric
+           algorithms that interpret the ``key`` in different ways
+           (e.g. HS\* and RS\*).
+    :type algorithms: typing.Sequence[str] or None
+
+    :param jwt.types.Options options: extended decoding and validation options
+        Refer to :py:class:`jwt.types.Options` for more information.
+
+    :param audience: optional, the value for ``verify_aud`` check
+    :type audience: str or typing.Iterable[str] or None
+    :param issuer: optional, the value for ``verify_iss`` check
+    :type issuer: str or typing.Sequence[str] or None
+    :param leeway: a time margin in seconds for the expiration check
+    :type leeway: float or datetime.timedelta
+    :rtype: dict[str, typing.Any]
+    :returns: Decoded JWT with the JOSE Header on the key ``header``, the JWS
+     Payload on the key ``payload``, and the JWS Signature on the key ``signature``."""
         if kwargs:
             warnings.warn(
                 "passing additional kwargs to decode_complete() is deprecated "
@@ -239,7 +276,45 @@ class PyJWT:
         leeway: float | timedelta = 0,
         # kwargs
         **kwargs: Any,
-    ) -> Any:
+    ) -> dict[str, Any]:
+        """Verify the ``jwt`` token signature and return the token claims.
+
+    :param jwt: the token to be decoded
+    :type jwt: str or bytes
+    :param key: the key suitable for the allowed algorithm
+    :type key: str or bytes or jwt.PyJWK or jwt.algorithms.AllowedPublicKeys
+
+    :param algorithms: allowed algorithms, e.g. ``["ES256"]``
+        If ``key`` is a :class:`jwt.PyJWK` object, allowed algorithms will default to the key algorithm.
+
+        .. warning::
+
+           Do **not** compute the ``algorithms`` parameter based on
+           the ``alg`` from the token itself, or on any other data
+           that an attacker may be able to influence, as that might
+           expose you to various vulnerabilities (see `RFC 8725 §2.1
+           <https://www.rfc-editor.org/rfc/rfc8725.html#section-2.1>`_). Instead,
+           either hard-code a fixed value for ``algorithms``, or
+           configure it in the same place you configure the
+           ``key``. Make sure not to mix symmetric and asymmetric
+           algorithms that interpret the ``key`` in different ways
+           (e.g. HS\* and RS\*).
+    :type algorithms: typing.Sequence[str] or None
+
+    :param jwt.types.Options options: extended decoding and validation options
+        Refer to :py:class:`jwt.types.Options` for more information.
+
+    :param audience: optional, the value for ``verify_aud`` check
+    :type audience: str or typing.Iterable[str] or None
+    :param subject: optional, the value for ``verify_sub`` check
+    :type subject: str or None
+    :param issuer: optional, the value for ``verify_iss`` check
+    :type issuer: str or typing.Sequence[str] or None
+    :param leeway: a time margin in seconds for the expiration check
+    :type leeway: float or datetime.timedelta
+    :rtype: dict[str, typing.Any]
+    :returns: the JWT claims
+        """
         if kwargs:
             warnings.warn(
                 "passing additional kwargs to decode() is deprecated "

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-import os
+
 import json
+import os
 import warnings
 from calendar import timegm
 from collections.abc import Iterable, Sequence
@@ -180,42 +181,43 @@ class PyJWT:
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Identical to ``jwt.decode`` except for return value which is a dictionary containing the token header (JOSE Header),
-    the token payload (JWT Payload), and token signature (JWT Signature) on the keys "header", "payload",
-    and "signature" respectively.
+        the token payload (JWT Payload), and token signature (JWT Signature) on the keys "header", "payload",
+        and "signature" respectively.
 
-    :param jwt: the token to be decoded
-    :type jwt: str or bytes
-    :param key: the key suitable for the allowed algorithm
-    :type key: str or bytes or PyJWK or :py:class:`jwt.algorithms.AllowedPublicKeys`
+        :param jwt: the token to be decoded
+        :type jwt: str or bytes
+        :param key: the key suitable for the allowed algorithm
+        :type key: str or bytes or PyJWK or :py:class:`jwt.algorithms.AllowedPublicKeys`
 
-    :param algorithms: allowed algorithms, e.g. ``["ES256"]``
+        :param algorithms: allowed algorithms, e.g. ``["ES256"]``
 
-        .. warning::
+            .. warning::
 
-           Do **not** compute the ``algorithms`` parameter based on
-           the ``alg`` from the token itself, or on any other data
-           that an attacker may be able to influence, as that might
-           expose you to various vulnerabilities (see `RFC 8725 §2.1
-           <https://www.rfc-editor.org/rfc/rfc8725.html#section-2.1>`_). Instead,
-           either hard-code a fixed value for ``algorithms``, or
-           configure it in the same place you configure the
-           ``key``. Make sure not to mix symmetric and asymmetric
-           algorithms that interpret the ``key`` in different ways
-           (e.g. HS\* and RS\*).
-    :type algorithms: typing.Sequence[str] or None
+               Do **not** compute the ``algorithms`` parameter based on
+               the ``alg`` from the token itself, or on any other data
+               that an attacker may be able to influence, as that might
+               expose you to various vulnerabilities (see `RFC 8725 §2.1
+               <https://www.rfc-editor.org/rfc/rfc8725.html#section-2.1>`_). Instead,
+               either hard-code a fixed value for ``algorithms``, or
+               configure it in the same place you configure the
+               ``key``. Make sure not to mix symmetric and asymmetric
+               algorithms that interpret the ``key`` in different ways
+               (e.g. HS\* and RS\*).
+        :type algorithms: typing.Sequence[str] or None
 
-    :param jwt.types.Options options: extended decoding and validation options
-        Refer to :py:class:`jwt.types.Options` for more information.
+        :param jwt.types.Options options: extended decoding and validation options
+            Refer to :py:class:`jwt.types.Options` for more information.
 
-    :param audience: optional, the value for ``verify_aud`` check
-    :type audience: str or typing.Iterable[str] or None
-    :param issuer: optional, the value for ``verify_iss`` check
-    :type issuer: str or typing.Sequence[str] or None
-    :param leeway: a time margin in seconds for the expiration check
-    :type leeway: float or datetime.timedelta
-    :rtype: dict[str, typing.Any]
-    :returns: Decoded JWT with the JOSE Header on the key ``header``, the JWS
-     Payload on the key ``payload``, and the JWS Signature on the key ``signature``."""
+        :param audience: optional, the value for ``verify_aud`` check
+        :type audience: str or typing.Iterable[str] or None
+        :param issuer: optional, the value for ``verify_iss`` check
+        :type issuer: str or typing.Sequence[str] or None
+        :param leeway: a time margin in seconds for the expiration check
+        :type leeway: float or datetime.timedelta
+        :rtype: dict[str, typing.Any]
+        :returns: Decoded JWT with the JOSE Header on the key ``header``, the JWS
+         Payload on the key ``payload``, and the JWS Signature on the key ``signature``.
+        """
         if kwargs:
             warnings.warn(
                 "passing additional kwargs to decode_complete() is deprecated "
@@ -303,41 +305,41 @@ class PyJWT:
     ) -> dict[str, Any]:
         """Verify the ``jwt`` token signature and return the token claims.
 
-    :param jwt: the token to be decoded
-    :type jwt: str or bytes
-    :param key: the key suitable for the allowed algorithm
-    :type key: str or bytes or PyJWK or :py:class:`jwt.algorithms.AllowedPublicKeys`
+        :param jwt: the token to be decoded
+        :type jwt: str or bytes
+        :param key: the key suitable for the allowed algorithm
+        :type key: str or bytes or PyJWK or :py:class:`jwt.algorithms.AllowedPublicKeys`
 
-    :param algorithms: allowed algorithms, e.g. ``["ES256"]``
-        If ``key`` is a :class:`PyJWK` object, allowed algorithms will default to the key algorithm.
+        :param algorithms: allowed algorithms, e.g. ``["ES256"]``
+            If ``key`` is a :class:`PyJWK` object, allowed algorithms will default to the key algorithm.
 
-        .. warning::
+            .. warning::
 
-           Do **not** compute the ``algorithms`` parameter based on
-           the ``alg`` from the token itself, or on any other data
-           that an attacker may be able to influence, as that might
-           expose you to various vulnerabilities (see `RFC 8725 §2.1
-           <https://www.rfc-editor.org/rfc/rfc8725.html#section-2.1>`_). Instead,
-           either hard-code a fixed value for ``algorithms``, or
-           configure it in the same place you configure the
-           ``key``. Make sure not to mix symmetric and asymmetric
-           algorithms that interpret the ``key`` in different ways
-           (e.g. HS\* and RS\*).
-    :type algorithms: typing.Sequence[str] or None
+               Do **not** compute the ``algorithms`` parameter based on
+               the ``alg`` from the token itself, or on any other data
+               that an attacker may be able to influence, as that might
+               expose you to various vulnerabilities (see `RFC 8725 §2.1
+               <https://www.rfc-editor.org/rfc/rfc8725.html#section-2.1>`_). Instead,
+               either hard-code a fixed value for ``algorithms``, or
+               configure it in the same place you configure the
+               ``key``. Make sure not to mix symmetric and asymmetric
+               algorithms that interpret the ``key`` in different ways
+               (e.g. HS\* and RS\*).
+        :type algorithms: typing.Sequence[str] or None
 
-    :param jwt.types.Options options: extended decoding and validation options
-        Refer to :py:class:`jwt.types.Options` for more information.
+        :param jwt.types.Options options: extended decoding and validation options
+            Refer to :py:class:`jwt.types.Options` for more information.
 
-    :param audience: optional, the value for ``verify_aud`` check
-    :type audience: str or typing.Iterable[str] or None
-    :param subject: optional, the value for ``verify_sub`` check
-    :type subject: str or None
-    :param issuer: optional, the value for ``verify_iss`` check
-    :type issuer: str or typing.Sequence[str] or None
-    :param leeway: a time margin in seconds for the expiration check
-    :type leeway: float or datetime.timedelta
-    :rtype: dict[str, typing.Any]
-    :returns: the JWT claims
+        :param audience: optional, the value for ``verify_aud`` check
+        :type audience: str or typing.Iterable[str] or None
+        :param subject: optional, the value for ``verify_sub`` check
+        :type subject: str or None
+        :param issuer: optional, the value for ``verify_iss`` check
+        :type issuer: str or typing.Sequence[str] or None
+        :param leeway: a time margin in seconds for the expiration check
+        :type leeway: float or datetime.timedelta
+        :rtype: dict[str, typing.Any]
+        :returns: the JWT claims
         """
         if kwargs:
             warnings.warn(

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -267,7 +267,7 @@ class PyJWT:
         payload: dict[str, Any],
         options: FullOptions,
         audience: Iterable[str] | str | None = None,
-        issuer: Iterable[str] | str | None = None,
+        issuer: Container[str] | str | None = None,
         subject: str | None = None,
         leeway: float | timedelta = 0,
     ) -> None:

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -174,7 +174,7 @@ class PyJWT:
         # passthrough arguments to _validate_claims
         # consider putting in options
         audience: str | Iterable[str] | None = None,
-        issuer: str | Sequence[str] | None = None,
+        issuer: str | Container[str] | None = None,
         subject: str | None = None,
         leeway: float | timedelta = 0,
         # kwargs
@@ -202,7 +202,7 @@ class PyJWT:
                configure it in the same place you configure the
                ``key``. Make sure not to mix symmetric and asymmetric
                algorithms that interpret the ``key`` in different ways
-               (e.g. HS\* and RS\*).
+               (e.g. HS\\* and RS\\*).
         :type algorithms: typing.Sequence[str] or None
 
         :param jwt.types.Options options: extended decoding and validation options
@@ -211,7 +211,7 @@ class PyJWT:
         :param audience: optional, the value for ``verify_aud`` check
         :type audience: str or typing.Iterable[str] or None
         :param issuer: optional, the value for ``verify_iss`` check
-        :type issuer: str or typing.Sequence[str] or None
+        :type issuer: str or typing.Container[str] or None
         :param leeway: a time margin in seconds for the expiration check
         :type leeway: float or datetime.timedelta
         :rtype: dict[str, typing.Any]
@@ -298,7 +298,7 @@ class PyJWT:
         # consider putting in options
         audience: str | Iterable[str] | None = None,
         subject: str | None = None,
-        issuer: str | Sequence[str] | None = None,
+        issuer: str | Container[str] | None = None,
         leeway: float | timedelta = 0,
         # kwargs
         **kwargs: Any,
@@ -335,7 +335,7 @@ class PyJWT:
         :param subject: optional, the value for ``verify_sub`` check
         :type subject: str or None
         :param issuer: optional, the value for ``verify_iss`` check
-        :type issuer: str or typing.Sequence[str] or None
+        :type issuer: str or typing.Container[str] or None
         :param leeway: a time margin in seconds for the expiration check
         :type leeway: float or datetime.timedelta
         :rtype: dict[str, typing.Any]

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -23,12 +23,14 @@ from .warnings import RemovedInPyjwt3Warning
 
 if TYPE_CHECKING:
     from typing import TypeAlias
+
     from .algorithms import has_crypto
     from .api_jwk import PyJWK
     from .types import FullOptions, Options, SigOptions
 
     if has_crypto:
         from .algorithms import AllowedPrivateKeys, AllowedPublicKeys
+
         AllowedPrivateKeyTypes: TypeAlias = AllowedPrivateKeys | PyJWK | str | bytes  # type: ignore
         AllowedPublicKeyTypes: TypeAlias = AllowedPublicKeys | PyJWK | str | bytes  # type: ignore
     else:
@@ -36,13 +38,13 @@ if TYPE_CHECKING:
         AllowedPublicKeyTypes: TypeAlias = PyJWK | str | bytes  # type: ignore
 
 
-
 class PyJWT:
     def __init__(self, options: Options | None = None) -> None:
+        self.options: FullOptions
         if options is None:
             self.options = self._get_default_options()
         else:
-            self.options: FullOptions = {**self._get_default_options(), **options}
+            self.options = {**self._get_default_options(), **options}
 
     @staticmethod
     def _get_default_options() -> FullOptions:
@@ -73,7 +75,6 @@ class PyJWT:
             options["verify_sub"] = options.get("verify_sub", False)
             options["verify_jti"] = options.get("verify_jti", False)
         return {**self.options, **options}
-
 
     def encode(
         self,
@@ -167,7 +168,6 @@ class PyJWT:
             verify_signature = True
         else:
             verify_signature = options.get("verify_signature", True)
-
 
         # If the user has set the legacy `verify` argument, and it doesn't match
         # what the relevant `options` entry for the argument is, inform the user
@@ -266,8 +266,8 @@ class PyJWT:
         self,
         payload: dict[str, Any],
         options: FullOptions,
-        audience: Iterable[str] | str | None=None,
-        issuer: Iterable[str] | str | None =None,
+        audience: Iterable[str] | str | None = None,
+        issuer: Iterable[str] | str | None = None,
         subject: str | None = None,
         leeway: float | timedelta = 0,
     ) -> None:
@@ -313,7 +313,9 @@ class PyJWT:
             if payload.get(claim) is None:
                 raise MissingRequiredClaimError(claim)
 
-    def _validate_sub(self, payload: dict[str, Any], subject: str | None = None) -> None:
+    def _validate_sub(
+        self, payload: dict[str, Any], subject: str | None = None
+    ) -> None:
         """
         Checks whether "sub" if in the payload is valid or not.
         This is an Optional claim

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-
+import os
 import json
 import warnings
 from calendar import timegm
@@ -21,7 +21,7 @@ from .exceptions import (
 )
 from .warnings import RemovedInPyjwt3Warning
 
-if TYPE_CHECKING:
+if TYPE_CHECKING or bool(os.getenv("SPHINX_BUILD", "")):
     from typing import TypeAlias
 
     from .algorithms import has_crypto
@@ -85,6 +85,30 @@ class PyJWT:
         json_encoder: type[json.JSONEncoder] | None = None,
         sort_headers: bool = True,
     ) -> str:
+        """Encode the ``payload`` as JSON Web Token.
+
+        :param payload: JWT claims, e.g. ``dict(iss=..., aud=..., sub=...)``
+        :type payload: dict[str, typing.Any]
+        :param key: a key suitable for the chosen algorithm:
+
+            * for **asymmetric algorithms**: PEM-formatted private key, a multiline string
+            * for **symmetric algorithms**: plain string, sufficiently long for security
+
+        :type key: str or bytes or PyJWK or :py:class:`jwt.algorithms.AllowedPrivateKeys`
+        :param algorithm: algorithm to sign the token with, e.g. ``"ES256"``.
+            If ``headers`` includes ``alg``, it will be preferred to this parameter.
+            If ``key`` is a :class:`PyJWK` object, by default the key algorithm will be used.
+        :type algorithm: str or None
+        :param headers: additional JWT header fields, e.g. ``dict(kid="my-key-id")``.
+        :type headers: dict[str, typing.Any] or None
+        :param json_encoder: custom JSON encoder for ``payload`` and ``headers``
+        :type json_encoder: json.JSONEncoder or None
+
+        :rtype: str
+        :returns: a JSON Web Token
+
+        :raises TypeError: if ``payload`` is not a ``dict``
+        """
         # Check that we get a dict
         if not isinstance(payload, dict):
             raise TypeError(
@@ -162,7 +186,7 @@ class PyJWT:
     :param jwt: the token to be decoded
     :type jwt: str or bytes
     :param key: the key suitable for the allowed algorithm
-    :type key: str or bytes or jwt.PyJWK or jwt.algorithms.AllowedPublicKeys
+    :type key: str or bytes or PyJWK or :py:class:`jwt.algorithms.AllowedPublicKeys`
 
     :param algorithms: allowed algorithms, e.g. ``["ES256"]``
 
@@ -282,10 +306,10 @@ class PyJWT:
     :param jwt: the token to be decoded
     :type jwt: str or bytes
     :param key: the key suitable for the allowed algorithm
-    :type key: str or bytes or jwt.PyJWK or jwt.algorithms.AllowedPublicKeys
+    :type key: str or bytes or PyJWK or :py:class:`jwt.algorithms.AllowedPublicKeys`
 
     :param algorithms: allowed algorithms, e.g. ``["ES256"]``
-        If ``key`` is a :class:`jwt.PyJWK` object, allowed algorithms will default to the key algorithm.
+        If ``key`` is a :class:`PyJWK` object, allowed algorithms will default to the key algorithm.
 
         .. warning::
 

--- a/jwt/exceptions.py
+++ b/jwt/exceptions.py
@@ -7,46 +7,60 @@ class PyJWTError(Exception):
 
 
 class InvalidTokenError(PyJWTError):
+    """Base exception when ``decode()`` fails on a token"""
     pass
 
 
 class DecodeError(InvalidTokenError):
+    """Raised when a token cannot be decoded because it failed validation"""
     pass
 
 
 class InvalidSignatureError(DecodeError):
+    """Raised when a token's signature doesn't match the one provided as part of
+    the token. """
     pass
 
 
 class ExpiredSignatureError(InvalidTokenError):
+    """Raised when a token's ``exp`` claim indicates that it has expired"""
     pass
 
 
 class InvalidAudienceError(InvalidTokenError):
+    """Raised when a token's ``aud`` claim does not match one of the expected
+    audience values"""
     pass
 
 
 class InvalidIssuerError(InvalidTokenError):
+    """Raised when a token's ``iss`` claim does not match the expected issuer"""
     pass
 
 
 class InvalidIssuedAtError(InvalidTokenError):
+    """Raised when a token's ``iat`` claim is non-numeric"""
     pass
 
 
 class ImmatureSignatureError(InvalidTokenError):
+    """Raised when a token's ``nbf`` or ``iat`` claims represent a time in the future"""
     pass
 
 
 class InvalidKeyError(PyJWTError):
+    """Raised when the specified key is not in the proper format"""
     pass
 
 
 class InvalidAlgorithmError(InvalidTokenError):
+    """Raised when the specified algorithm is not recognized by PyJWT"""
     pass
 
 
 class MissingRequiredClaimError(InvalidTokenError):
+    """Raised when a claim that is required to be present is not contained
+    in the claimset"""
     def __init__(self, claim: str) -> None:
         self.claim = claim
 
@@ -59,6 +73,7 @@ class PyJWKError(PyJWTError):
 
 
 class MissingCryptographyError(PyJWKError):
+    """Raised if the algorithm requires `cryptography` to be installed and it is not available."""
     pass
 
 
@@ -75,8 +90,10 @@ class PyJWKClientConnectionError(PyJWKClientError):
 
 
 class InvalidSubjectError(InvalidTokenError):
+    """Raised when a token's ``sub`` claim is not a string or doesn't match the expected ``subject``"""
     pass
 
 
 class InvalidJTIError(InvalidTokenError):
+    """Raised when a token's ``jti`` claim is not a string"""
     pass

--- a/jwt/exceptions.py
+++ b/jwt/exceptions.py
@@ -8,59 +8,70 @@ class PyJWTError(Exception):
 
 class InvalidTokenError(PyJWTError):
     """Base exception when ``decode()`` fails on a token"""
+
     pass
 
 
 class DecodeError(InvalidTokenError):
     """Raised when a token cannot be decoded because it failed validation"""
+
     pass
 
 
 class InvalidSignatureError(DecodeError):
     """Raised when a token's signature doesn't match the one provided as part of
-    the token. """
+    the token."""
+
     pass
 
 
 class ExpiredSignatureError(InvalidTokenError):
     """Raised when a token's ``exp`` claim indicates that it has expired"""
+
     pass
 
 
 class InvalidAudienceError(InvalidTokenError):
     """Raised when a token's ``aud`` claim does not match one of the expected
     audience values"""
+
     pass
 
 
 class InvalidIssuerError(InvalidTokenError):
     """Raised when a token's ``iss`` claim does not match the expected issuer"""
+
     pass
 
 
 class InvalidIssuedAtError(InvalidTokenError):
     """Raised when a token's ``iat`` claim is non-numeric"""
+
     pass
 
 
 class ImmatureSignatureError(InvalidTokenError):
     """Raised when a token's ``nbf`` or ``iat`` claims represent a time in the future"""
+
     pass
 
 
 class InvalidKeyError(PyJWTError):
     """Raised when the specified key is not in the proper format"""
+
     pass
 
 
 class InvalidAlgorithmError(InvalidTokenError):
     """Raised when the specified algorithm is not recognized by PyJWT"""
+
     pass
 
 
 class MissingRequiredClaimError(InvalidTokenError):
     """Raised when a claim that is required to be present is not contained
     in the claimset"""
+
     def __init__(self, claim: str) -> None:
         self.claim = claim
 
@@ -74,6 +85,7 @@ class PyJWKError(PyJWTError):
 
 class MissingCryptographyError(PyJWKError):
     """Raised if the algorithm requires `cryptography` to be installed and it is not available."""
+
     pass
 
 
@@ -91,9 +103,11 @@ class PyJWKClientConnectionError(PyJWKClientError):
 
 class InvalidSubjectError(InvalidTokenError):
     """Raised when a token's ``sub`` claim is not a string or doesn't match the expected ``subject``"""
+
     pass
 
 
 class InvalidJTIError(InvalidTokenError):
     """Raised when a token's ``jti`` claim is not a string"""
+
     pass

--- a/jwt/exceptions.py
+++ b/jwt/exceptions.py
@@ -84,7 +84,7 @@ class PyJWKError(PyJWTError):
 
 
 class MissingCryptographyError(PyJWKError):
-    """Raised if the algorithm requires `cryptography` to be installed and it is not available."""
+    """Raised if the algorithm requires ``cryptography`` to be installed and it is not available."""
 
     pass
 

--- a/jwt/types.py
+++ b/jwt/types.py
@@ -7,7 +7,8 @@ HashlibHash = Callable[..., Any]
 
 class SigOptions(TypedDict):
     """Options for PyJWS class (TypedDict). Note that this is a smaller set of options than
-    for :py:func:`jwt.decode()`. """
+    for :py:func:`jwt.decode()`."""
+
     verify_signature: bool
     """verify the JWT cryptographic signature"""
 
@@ -23,6 +24,7 @@ class Options(TypedDict, total=False):
         if you want to make sure that they are always present (and therefore always verified
         if ``verify_{claim} = True`` for that claim).
     """
+
     verify_signature: bool
     """Default: ``True``. Verify the JWT cryptographic signature."""
     require: list[str]

--- a/jwt/types.py
+++ b/jwt/types.py
@@ -6,20 +6,45 @@ HashlibHash = Callable[..., Any]
 
 
 class SigOptions(TypedDict):
+    """(TypedDict) Options for PyJWS class. Note that this is a smaller set of options than
+    for :py:func:`jwt.decode()`. """
     verify_signature: bool
+    """verify the JWT cryptographic signature"""
 
 
 class Options(TypedDict, total=False):
+    """(TypedDict) Options for :py:func:`jwt.decode()` and :py:func:`jwt.api_jwt.decode_complete()`.
+
+    .. warning::
+
+        Some claims, such as ``exp``, ``iat``, ``jti``, ``nbf``, and ``sub``,
+        will only be verified if present. Please refer to the documentation below
+        for which ones, and make sure to include them in the ``require`` param
+        if you want to make sure that they are always present (and therefore always verified
+        if ``verify_{claim} = True`` for that claim).
+    """
     verify_signature: bool
+    """Default: ``True``. Verify the JWT cryptographic signature."""
     require: list[str]
+    """Default: ``[]``. List of claims that must be present.
+          Example: ``require=["exp", "iat", "nbf"]``.
+          **Only verifies that the claims exists**. Does not verify that the claims are valid."""
     strict_aud: bool
+    """Default: ``False``. (requires ``verify_aud=True``) Check that the ``aud`` claim is a single value (not a list), and matches ``audience`` exactly."""
     verify_aud: bool
+    """Default: ``verify_signature``. Check that ``aud`` (audience) claim matches ``audience``."""
     verify_exp: bool
+    """Default: ``verify_signature``. Check that ``exp`` (expiration) claim value is in the future (if present in payload). """
     verify_iat: bool
+    """Default: ``verify_signature``. Check that ``iat`` (issued at) claim value is an integer (if present in payload). """
     verify_iss: bool
+    """Default: ``verify_signature``. Check that ``iss`` (issuer) claim matches ``issuer``. """
     verify_jti: bool
+    """Default: ``verify_signature``. Check that ``jti`` (JWT ID) claim is a string (if present in payload). """
     verify_nbf: bool
+    """Default: ``verify_signature``. Check that ``nbf`` (not before) claim value is in the past (if present in payload). """
     verify_sub: bool
+    """Default: ``verify_signature``. Check that ``sub`` (subject) claim is a string and matches ``subject`` (if present in payload). """
 
 
 # The only difference between Options and FullOptions is that FullOptions

--- a/jwt/types.py
+++ b/jwt/types.py
@@ -8,6 +8,7 @@ HashlibHash = Callable[..., Any]
 class SigOptions(TypedDict):
     verify_signature: bool
 
+
 class Options(TypedDict, total=False):
     verify_signature: bool
     require: list[str]

--- a/jwt/types.py
+++ b/jwt/types.py
@@ -1,5 +1,36 @@
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, TypedDict
 
 JWKDict = Dict[str, Any]
 
 HashlibHash = Callable[..., Any]
+
+
+class SigOptions(TypedDict):
+    verify_signature: bool
+
+class Options(TypedDict, total=False):
+    verify_signature: bool
+    require: list[str]
+    strict_aud: bool
+    verify_aud: bool
+    verify_exp: bool
+    verify_iat: bool
+    verify_iss: bool
+    verify_jti: bool
+    verify_nbf: bool
+    verify_sub: bool
+
+
+# The only difference between Options and FullOptions is that FullOptions
+# required _every_ value to be there; Options doesn't require any
+class FullOptions(TypedDict):
+    verify_signature: bool
+    require: list[str]
+    strict_aud: bool
+    verify_aud: bool
+    verify_exp: bool
+    verify_iat: bool
+    verify_iss: bool
+    verify_jti: bool
+    verify_nbf: bool
+    verify_sub: bool

--- a/jwt/types.py
+++ b/jwt/types.py
@@ -6,14 +6,14 @@ HashlibHash = Callable[..., Any]
 
 
 class SigOptions(TypedDict):
-    """(TypedDict) Options for PyJWS class. Note that this is a smaller set of options than
+    """Options for PyJWS class (TypedDict). Note that this is a smaller set of options than
     for :py:func:`jwt.decode()`. """
     verify_signature: bool
     """verify the JWT cryptographic signature"""
 
 
 class Options(TypedDict, total=False):
-    """(TypedDict) Options for :py:func:`jwt.decode()` and :py:func:`jwt.api_jwt.decode_complete()`.
+    """Options for :py:func:`jwt.decode()` and :py:func:`jwt.api_jwt.decode_complete()` (TypedDict).
 
     .. warning::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ source = [
 
 [tool.coverage.report]
 exclude_lines = [
-    "if TYPE_CHECKING:",
+    "if TYPE_CHECKING",
     "pragma: no cover",
 ]
 show_missing = true

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -36,6 +36,14 @@ def payload():
 
 
 class TestJWT:
+    def test_jwt_with_options(self):
+        jwt = PyJWT(options={"verify_signature": False})
+        assert jwt.options["verify_signature"] is False
+        # assert that unrelated option is unchanged from default
+        assert jwt.options["strict_aud"] is False
+        # assert that verify_signature is respected unless verify_exp is overridden
+        assert jwt.options["verify_exp"] is False
+
     def test_decodes_valid_jwt(self, jwt):
         example_payload = {"hello": "world"}
         example_secret = "secret"


### PR DESCRIPTION
Basically trying to remove "Unknown" or "partially unknown" pylance issues. Mostly with `options`, but there were a few simple other fixes (kwargs, segments, etc). This showed some minor bugs and a few code smells (passing too many args to `api_jws.decode_complete`, for example).

- [x] We should include Options / SigOptions / FullOptions in the docs somehow
- [x] `PyJWT()` is used as a singleton. Do we want to keep the `options` param in that case? Wondering because codecov is warning that we don't have a test for `options is not None` case. 