### PR TITLE
Removed redundant args in `_encode_payload` method

### DIFF
--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -145,7 +145,6 @@ class PyJWT:
     def _encode_payload(
         self,
         payload: dict[str, Any],
-        headers: dict[str, Any] | None = None,
         json_encoder: type[json.JSONEncoder] | None = None,
     ) -> bytes:
         """


### PR DESCRIPTION
Well, was just going through the basic implementation of the whole JWT flow. Just then I realised that there was an extra and unused argument `headers` being passed in the `_encode_payload` method. Removed that.