### PR TITLE
Removed redundant args in `_encode_payload` method

### DIFF
--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -129,7 +129,6 @@ class PyJWT:
 
         json_payload = self._encode_payload(
             payload,
-            headers=headers,
             json_encoder=json_encoder,
         )
 
@@ -145,7 +144,6 @@ class PyJWT:
     def _encode_payload(
         self,
         payload: dict[str, Any],
-        headers: dict[str, Any] | None = None,
         json_encoder: type[json.JSONEncoder] | None = None,
     ) -> bytes:
         """


### PR DESCRIPTION
Well, was just going through the basic implementation of the whole jwt flow. Just then I realised that there was an extra and unused argument headers being passed in the _encode_payload method. Removed that from both the function definition and the function call.