### PR TITLE
Fix #1022: Map `algorithm=None` to "none"

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -118,7 +118,7 @@ class PyJWS:
         self,
         payload: bytes,
         key: AllowedPrivateKeys | PyJWK | str | bytes,
-        algorithm: str | None = None,
+        algorithm: str | None = "HS256",
         headers: dict[str, Any] | None = None,
         json_encoder: type[json.JSONEncoder] | None = None,
         is_payload_detached: bool = False,
@@ -131,7 +131,7 @@ class PyJWS:
             if isinstance(key, PyJWK):
                 algorithm_ = key.algorithm_name
             else:
-                algorithm_ = "HS256"
+                algorithm_ = "none"
         else:
             algorithm_ = algorithm
 

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -80,7 +80,7 @@ class PyJWT:
         self,
         payload: dict[str, Any],
         key: AllowedPrivateKeyTypes,
-        algorithm: str | None = None,
+        algorithm: str | None = "HS256",
         headers: dict[str, Any] | None = None,
         json_encoder: type[json.JSONEncoder] | None = None,
         sort_headers: bool = True,


### PR DESCRIPTION
Reverts the changes introduced in #979, fixing #1022.