### PR TITLE
Allow validating JWT against JWKS without kid

### DIFF
--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -114,7 +114,7 @@ class PyJWKClient:
     def get_signing_key_from_jwt(self, token: str | bytes) -> PyJWK:
         unverified = decode_token(token, options={"verify_signature": False})
         header = unverified["header"]
-        return self.get_signing_key(header.get("kid", None))
+        return self.get_signing_key(header.get("kid"))
 
     @staticmethod
     def match_kid(signing_keys: List[PyJWK], kid: Optional[str]) -> Optional[PyJWK]:


### PR DESCRIPTION
Fixes #1072 

`get_signing_key` Now accepts `None` for the `kid` and will match to the only JWKS signing key if there is only one. Otherwise it will not match.

`get_signing_keys` Now returns keys with a `None` `kid` to support this.

`get_signing_key_from_jwt` Now defaults the `kid` to `None` when it looks for it in the token.

`match_kid` now accepts None likewise.