### PR TITLE
feat: strict encode, lenient decode for JWT subject claim

### DIFF
--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -127,6 +127,10 @@ class PyJWT:
         if "iss" in payload and not isinstance(payload["iss"], str):
             raise TypeError("Issuer (iss) must be a string.")
 
+        # Validate sub must be string
+        if "sub" in payload and not isinstance(payload["sub"], str):
+            raise TypeError("Subject (sub) must be a string.")
+
         json_payload = self._encode_payload(
             payload,
             headers=headers,
@@ -426,9 +430,6 @@ class PyJWT:
 
         if "sub" not in payload:
             return
-
-        if not isinstance(payload["sub"], str):
-            raise InvalidSubjectError("Subject must be a string")
 
         if subject is not None:
             if payload.get("sub") != subject:

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -876,15 +876,16 @@ class TestJWT:
                 token, secret, algorithms=["HS256"], options={"require": ["sub"]}
             )
 
-    def test_decode_invalid_int_sub_claim(self, jwt):
+    def test_encode_with_invalid_int_sub_claim(self, jwt):
         payload = {
             "sub": 1224344,
         }
         secret = "your-256-bit-secret"
-        token = jwt.encode(payload, secret, algorithm="HS256")
 
-        with pytest.raises(InvalidSubjectError):
-            jwt.decode(token, secret, algorithms=["HS256"])
+        with pytest.raises(TypeError) as exc_info:
+            jwt.encode(payload, secret, algorithm="HS256")
+
+        assert "Subject (sub) must be a string" in str(exc_info.value)
 
     def test_decode_with_valid_sub_claim(self, jwt):
         payload = {


### PR DESCRIPTION
Apply "strict with self, lenient with others" philosophy to JWT subject validation:

- **Encode (strict)**: Validate `sub` must be string, raise `TypeError` if not
- **Decode (lenient)**: Remove string type validation for `sub` claim in `_validate_sub`
- **Tests**: Update test to expect `TypeError` during encoding instead of decode error

Philosophy

This change embodies the principle of "严于律己，宽以待人" (be strict with yourself, lenient with others):

- **Strict encoding**: Ensures PyJWT generates standards-compliant tokens
- **Lenient decoding**: Allows PyJWT to consume tokens from other systems that may use non-string subject identifiers
