### PR TITLE
fix that match_kid allways return None

### DIFF
--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -114,10 +114,10 @@ class PyJWK:
         return self._jwk_data.get("kty", None)
 
     @property
-    def key_id(self) -> int | None:
+    def key_id(self) -> int | str | None:
         """The `kid` property from the JWK.
 
-        :rtype: str or None
+        :rtype: int, str, or None
         """
         return self._jwk_data.get("kid", None)
 

--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -114,7 +114,7 @@ class PyJWK:
         return self._jwk_data.get("kty", None)
 
     @property
-    def key_id(self) -> str | None:
+    def key_id(self) -> int | None:
         """The `kid` property from the JWK.
 
         :rtype: str or None

--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -121,7 +121,7 @@ class PyJWKClient:
         signing_key = None
 
         for key in signing_keys:
-            if key.key_id == kid:
+            if str(key.key_id) == kid:
                 signing_key = key
                 break
 


### PR DESCRIPTION
Hello ! I worked with auth using jwk client. I ran get_signing_key_from_jwt method to check token. I faced with error jwt.exceptions.PyJWKClientError: Unable to find a signing key that matches: "1399593380". I checked api from where i got jwks.json. And this kid was there. i began debugging process. As result i found that match_kid method return None every time. After a short time and several prints i found that key_id was int, but in type hints was string. The problem was that python couldn't compare sting and int correctly. I fix it using type conversion to string. And it works ! And i fix type hint for kid_id, too. I got it php service and library for jwt. As i understood kid could be as string as int, depending on implementation for different languages and libraries. Thanks

here is example of my keys
```json
"keys": [
    {
        "alg": "ES256",
        "crv": "P-256",
        "kid": 1399593380,
        "kty": "EC",
        "use": "sig",
        "x": "N_GHdF-7ExmKs-HgldA3LcDpTMjBHQSp9zUwyRhHyeYsaf",
        "y": "zFt09hBgGv0uRWerpGZSMPrYHhyAZMr5z3QgzJCasfKy2k"
    },
]
```