### PR TITLE
chore(docs): update documentations on leeway

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -352,6 +352,23 @@ Issued At Claim (iat)
     >>> token = jwt.encode({"iat": 1371720939}, "secret")
     >>> token = jwt.encode({"iat": datetime.datetime.now(tz=timezone.utc)}, "secret")
 
+The `iat` claim also supports the leeway feature similar to the `exp` and `nbf` claims.
+This allows you to validate an "issued at" time that is slightly in the future. Using
+leeway with the iat claim can be particularly helpful in scenarios where clock
+synchronization between the token issuer and the validator is imprecise.
+
+.. code-block:: pycon
+
+    >>> import time, datetime
+    >>> from datetime import timezone
+    >>> payload = {
+    ...     "iat": datetime.datetime.now(tz=timezone.utc) + datetime.timedelta(seconds=3)
+    ... }
+    >>> token = jwt.encode(payload, "secret")
+    >>> # JWT was issued in the future (due to clock skew)
+    >>> # But with some leeway, it will still validate
+    >>> decoded = jwt.decode(token, "secret", leeway=5, algorithms=["HS256"])
+
 Subject Claim (sub)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -360,7 +360,7 @@ imprecise.
 
 .. code-block:: pycon
 
-    >>> import time, datetime
+    >>> import datetime
     >>> from datetime import timezone
     >>> payload = {
     ...     "iat": datetime.datetime.now(tz=timezone.utc) + datetime.timedelta(seconds=3)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -352,10 +352,11 @@ Issued At Claim (iat)
     >>> token = jwt.encode({"iat": 1371720939}, "secret")
     >>> token = jwt.encode({"iat": datetime.datetime.now(tz=timezone.utc)}, "secret")
 
-The `iat` claim also supports the leeway feature similar to the `exp` and `nbf` claims.
-This allows you to validate an "issued at" time that is slightly in the future. Using
-leeway with the iat claim can be particularly helpful in scenarios where clock
-synchronization between the token issuer and the validator is imprecise.
+The `iat` claim also supports the leeway feature similar to the `exp` and `nbf`
+claims. This allows you to validate an "issued at" time that is slightly in the
+future. Using leeway with the iat claim can be particularly helpful in scenarios
+where clock synchronization between the token issuer and the validator is
+imprecise.
 
 .. code-block:: pycon
 

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -211,7 +211,7 @@ class PyJWT:
         :type audience: str or typing.Iterable[str] or None
         :param issuer: optional, the value for ``verify_iss`` check
         :type issuer: str or typing.Container[str] or None
-        :param leeway: a time margin in seconds for the expiration check
+        :param leeway: a time margin in seconds for time-based claims (exp, nbf, iat) to account for clock skew
         :type leeway: float or datetime.timedelta
         :rtype: dict[str, typing.Any]
         :returns: Decoded JWT with the JOSE Header on the key ``header``, the JWS
@@ -335,7 +335,7 @@ class PyJWT:
         :type subject: str or None
         :param issuer: optional, the value for ``verify_iss`` check
         :type issuer: str or typing.Container[str] or None
-        :param leeway: a time margin in seconds for the expiration check
+        :param leeway: a time margin in seconds for time-based claims (exp, nbf, iat) to account for clock skew
         :type leeway: float or datetime.timedelta
         :rtype: dict[str, typing.Any]
         :returns: the JWT claims

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -336,7 +336,8 @@ class PyJWT:
         :type subject: str or None
         :param issuer: optional, the value for ``verify_iss`` check
         :type issuer: str or typing.Container[str] or None
-        :param leeway: a time margin in seconds for time-based claims (exp, nbf, iat) to account for clock skew
+        :param leeway: a time margin in seconds for time-based claims (exp, nbf, iat)
+            to account for clock skew
         :type leeway: float or datetime.timedelta
         :rtype: dict[str, typing.Any]
         :returns: the JWT claims

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -211,7 +211,8 @@ class PyJWT:
         :type audience: str or typing.Iterable[str] or None
         :param issuer: optional, the value for ``verify_iss`` check
         :type issuer: str or typing.Container[str] or None
-        :param leeway: a time margin in seconds for time-based claims (exp, nbf, iat) to account for clock skew
+        :param leeway: a time margin in seconds for time-based claims (exp, nbf, iat)
+            to account for clock skew
         :type leeway: float or datetime.timedelta
         :rtype: dict[str, typing.Any]
         :returns: Decoded JWT with the JOSE Header on the key ``header``, the JWS


### PR DESCRIPTION
Hi, first of all, thank you for the great library! 

I made this PR as I was having some troubles navigating around the documentation. For the context:

1. I am using this library in a project I'm working at right now.
2. I was having some problems with clock drifts, some of my clients were sending in `iat` that are faster than my server time.
3. I wanted to fix this by using the `leeway` property, but got confused as in "does this library support it or not?"
4. Documentations for `leeway` only exists for `nbf` and `exp`, so I was thinking "oh, then, `leeway` doesn't work for `iat`"
5. I cloned the codebase to take a look at myself and found out that in the function `_validate_iat` actually does! (see appendix A)
6. I figured out, "it probably would be helpful if the documentation states this."
7. Then I also realized that in the API docs it's stating that `leeway` is only for `expiration` which might be misleading.

See appendix B for the screenshots of the updated documentation.

Apologies for any mistakes if I'm contributing the wrong way (do I need to create an issue first, etc.) - this is my first time contributing to one. This PR was mostly inspired by https://github.com/jpadilla/pyjwt/pull/1034 which adds documentation for `nbf`.

## Appendix A

```py
    def _validate_iat(
        self,
        payload: dict[str, Any],
        now: float,
        leeway: float,
    ) -> None:
        try:
            iat = int(payload["iat"])
        except ValueError:
            raise InvalidIssuedAtError(
                "Issued At claim (iat) must be an integer."
            ) from None
        if iat > (now + leeway): # <-- leeway validation is done for iat too!
            raise ImmatureSignatureError("The token is not yet valid (iat)")
```

## Appendix B

<img width="736" height="592" alt="image" src="https://github.com/user-attachments/assets/07c54441-819c-4ee9-be7f-0e54f5ee7116" />

<img width="734" height="777" alt="image" src="https://github.com/user-attachments/assets/a99eeca5-55d6-4a7d-bdab-8b7ce685f6cb" />

<img width="736" height="795" alt="image" src="https://github.com/user-attachments/assets/4afa0c2d-7c54-4989-b26f-74a3e2df39bb" />

