### PR TITLE
Fix a `SyntaxWarning` caused by invalid escape sequences

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Fixed
 - Validate `iss` claim is a string during encoding and decoding by @pachewise in `#1040 <https://github.com/jpadilla/pyjwt/pull/1040>`__
 - Improve typing/logic for `options` in decode, decode_complete by @pachewise in `#1045 <https://github.com/jpadilla/pyjwt/pull/1045>`__
 - Declare float supported type for lifespan and timeout by @nikitagashkov in `#1068 <https://github.com/jpadilla/pyjwt/pull/1068>`__
+- Fix ``SyntaxWarning``\s/``DeprecationWarning``\s caused by invalid escape sequences by @kurtmckee in `#1103 <https://github.com/jpadilla/pyjwt/pull/1103>`__
 
 Added
 ~~~~~

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -323,7 +323,7 @@ class PyJWT:
                configure it in the same place you configure the
                ``key``. Make sure not to mix symmetric and asymmetric
                algorithms that interpret the ``key`` in different ways
-               (e.g. HS\* and RS\*).
+               (e.g. HS\\* and RS\\*).
         :type algorithms: typing.Sequence[str] or None
 
         :param jwt.types.Options options: extended decoding and validation options


### PR DESCRIPTION
The warning is thrown when Python imports the file, and manifests in the test suite with this error [[recent CI example](https://github.com/jpadilla/pyjwt/actions/runs/18368001327/job/52324549178#step:5:46)]:

```
jwt/api_jwt.py:326
  /home/runner/work/pyjwt/pyjwt/jwt/api_jwt.py:326: SyntaxWarning: invalid escape sequence '\*'
    (e.g. HS\* and RS\*).
```

(This manifests as a `DeprecationWarning` as well, depending on the Python interpreter and version.)