### PR TITLE
Support Python 3.14, and test against PyPy 3.10+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,16 @@ jobs:
       fail-fast: false
       matrix:
         platform: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9"]
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "pypy3.9"
+          - "pypy3.10"
+          - "pypy3.11"
 
     steps:
       - uses: "actions/checkout@v5"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Fixed
 Added
 ~~~~~
 
+- Support Python 3.14, and test against PyPy 3.10 and 3.11 by @kurtmckee in `#1104 <https://github.com/jpadilla/pyjwt/pull/1104>`__
 - Docs: Add example of using leeway with nbf by @djw8605 in `#1034 <https://github.com/jpadilla/pyjwt/pull/1034>`__
 - Docs: Refactored docs with ``autodoc``; added ``PyJWS`` and ``jwt.algorithms`` docs by @pachewise in `#1045 <https://github.com/jpadilla/pyjwt/pull/1045>`__
 - Docs: Documentation improvements for "sub" and "jti" claims by @cleder in `#1088 <https://github.com/jpadilla/pyjwt/pull/1088>`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Utilities",
 ]
 description = "JSON Web Token implementation in Python"
@@ -60,8 +61,8 @@ docs = [
     "zope.interface",
 ]
 tests = [
-    "coverage[toml]==5.0.4",
-    "pytest>=6.0.0,<7.0.0",
+    "coverage[toml]==7.10.7",
+    "pytest>=8.4.2,<9.0.0",
 ]
 
 [project.readme]

--- a/tox.ini
+++ b/tox.ini
@@ -17,14 +17,17 @@ python =
     3.11: py311, docs
     3.12: py312
     3.13: py313
-    pypy3.9: pypy3
+    3.14: py314
+    pypy3.9: pypy39
+    pypy3.10: pypy310
+    pypy3.11: pypy311
 
 
 [tox]
 envlist =
     lint
     typing
-    py{39,310,311,312,313,py3}-{crypto,nocrypto}
+    py{39,310,311,312,313,314,py39,py310,py311}-{crypto,nocrypto}
     docs
     pypi-description
     coverage-report
@@ -75,7 +78,7 @@ commands =
 [testenv:coverage-report]
 basepython = python3.9
 skip_install = true
-deps = coverage[toml]==5.0.4
+deps = coverage[toml]==7.10.7
 commands =
     coverage combine
     coverage report


### PR DESCRIPTION
This introduces the following changes:

* tox is configured to test CPython 3.14, PyPy 3.10, and PyPy 3.11.
* GitHub CI is configured to install those same interpreter versions.
* The PyPI trove classifiers are updated.
* The `tests` extra is updated to resolve Python 3.14 failures caused by old pytest code that used now-removed `ast` symbols. (The coverage version is updated as well.)