### PR TITLE
Resolve package build warnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`__.
 
 Fixed
 ~~~~~
+
+- Fix build system warnings by @kurtmckee in `#1105 <https://github.com/jpadilla/pyjwt/pull/1105>`
 - Validate key against allowed types for Algorithm family in `#964 <https://github.com/jpadilla/pyjwt/pull/964>`__
 - Add iterator for JWKSet in `#1041 <https://github.com/jpadilla/pyjwt/pull/1041>`__
 - Validate `iss` claim is a string during encoding and decoding by @pachewise in `#1040 <https://github.com/jpadilla/pyjwt/pull/1040>`__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "setuptools",
+    "setuptools>=77.0.3",
 ]
 
 [project]
@@ -11,7 +11,6 @@ authors = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
@@ -35,11 +34,9 @@ keywords = [
     "token",
     "web",
 ]
+license = "MIT"
 name = "PyJWT"
 requires-python = ">=3.9"
-
-[project.license]
-text = "MIT"
 
 [project.optional-dependencies]
 crypto = [


### PR DESCRIPTION
When building pyjwt, a number of warnings are thrown:

```
SetuptoolsDeprecationWarning: License classifiers are deprecated.

********************************************************************************
Please consider removing the following classifiers in favor of a SPDX license expression:

License :: OSI Approved :: MIT License

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
********************************************************************************
```

```
SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated

********************************************************************************
Please use a simple string containing a SPDX expression for `project.license`.
You can also use `project.license-files`.
(Both options available on setuptools>=77.0.0).

By 2026-Feb-18, you need to update your project and remove deprecated calls
or your builds will no longer be supported.

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
********************************************************************************
```

These warnings are addressed in the obvious ways,
and the build system (`setuptools`) now requires 77.0.3 or higher
to ensure base compatibility with the changes.