### PR TITLE
Escalate test suite warnings to errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,7 @@ ignore= E501, E203, W503, E704
 addopts = -ra
 testpaths = tests
 filterwarnings =
-    once::Warning
-    ignore:::pympler[.*]
+    error
 
 
 [gh-actions]


### PR DESCRIPTION
All existing warnings have recently been resolved, so escalating warnings to errors helps identify new issues early.

> [!NOTE]
>
> This change seemed too trivial to warrant a CHANGELOG entry. However, I can add one if desired. Please let me know!