### PR TITLE
Migrate from `pep517`, which is deprecated, to `build`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,11 +81,11 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: "Install pep517 and twine"
-        run: "python -m pip install pep517 twine"
+      - name: "Install build and twine"
+        run: "python -m pip install build twine"
 
       - name: "Build package"
-        run: "python -m pep517.build --source --binary ."
+        run: "python -m build"
 
       - name: "List result"
         run: "ls -l dist"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Added
 ~~~~~
 
 - Support Python 3.14, and test against PyPy 3.10 and 3.11 by @kurtmckee in `#1104 <https://github.com/jpadilla/pyjwt/pull/1104>`__
+- Development: Migrate to ``build`` to test package building in CI by @kurtmckee in `#1108 <https://github.com/jpadilla/pyjwt/pull/1108>`__
 - Docs: Standardize CHANGELOG links to PRs by @kurtmckee in `#1110 <https://github.com/jpadilla/pyjwt/pull/1110>`__
 - Docs: Add example of using leeway with nbf by @djw8605 in `#1034 <https://github.com/jpadilla/pyjwt/pull/1034>`__
 - Docs: Refactored docs with ``autodoc``; added ``PyJWS`` and ``jwt.algorithms`` docs by @pachewise in `#1045 <https://github.com/jpadilla/pyjwt/pull/1045>`__


### PR DESCRIPTION
CI throws deprecation warnings when running `pep517.build` [[recent example](https://github.com/jpadilla/pyjwt/actions/runs/18721671867/job/53395459345#step:5:12)]:

```
pep517.build is deprecated. Consider switching to https://pypi.org/project/build/
```

This replaces `pep517.build` with `build`.

> [!NOTE]
>
> This change seemed too trivial to warrant a CHANGELOG entry. However, I can add one if desired. Please let me know!