### PR TITLE
Fix Read the Docs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,7 @@ python:
       path: "."
       extra_requirements:
         - "docs"
+        - "crypto"
 
 sphinx:
   configuration: "docs/conf.py"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Added
 
 - Support Python 3.14, and test against PyPy 3.10 and 3.11 by @kurtmckee in `#1104 <https://github.com/jpadilla/pyjwt/pull/1104>`__
 - Docs: Standardize CHANGELOG links to PRs by @kurtmckee in `#1110 <https://github.com/jpadilla/pyjwt/pull/1110>`__
+- Docs: Fix Read the Docs builds by @kurtmckee in `#1111 <https://github.com/jpadilla/pyjwt/pull/1111>`__
 - Docs: Add example of using leeway with nbf by @djw8605 in `#1034 <https://github.com/jpadilla/pyjwt/pull/1034>`__
 - Docs: Refactored docs with ``autodoc``; added ``PyJWS`` and ``jwt.algorithms`` docs by @pachewise in `#1045 <https://github.com/jpadilla/pyjwt/pull/1045>`__
 - Docs: Documentation improvements for "sub" and "jti" claims by @cleder in `#1088 <https://github.com/jpadilla/pyjwt/pull/1088>`__


### PR DESCRIPTION
> [!NOTE]
>
> Read the Docs builds [have been failing for the last seven months](https://app.readthedocs.org/projects/pyjwt/builds)!

This fixes two warnings that were causing Read the Docs builds to fail [[recent example](https://app.readthedocs.org/projects/pyjwt/builds/30055877/#291298539--18)]:

```
WARNING: missing attribute mentioned in :members: option: module jwt.algorithms, attribute AllowedPrivateKeys [autodoc]
WARNING: missing attribute mentioned in :members: option: module jwt.algorithms, attribute AllowedPublicKeys [autodoc]
```

The warnings occurred because the `crypto` extra was not configured to be installed in the Read the Docs config file.

The problem was overlooked because the tox `docs` environment installed the `crypto` extra, so CI never failed.