### PR TITLE
Thoroughly test type annotations, and resolve errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,12 +36,6 @@ repos:
       - id: check-manifest
         args: [--no-build-isolation]
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.18.2"
-    hooks:
-      - id: mypy
-        additional_dependencies: [cryptography>=3.4.0]
-
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: "v0.24.1"
     hooks:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ Fixed
 - Declare float supported type for lifespan and timeout by @nikitagashkov in `#1068 <https://github.com/jpadilla/pyjwt/pull/1068>`__
 - Fix ``SyntaxWarning``\s/``DeprecationWarning``\s caused by invalid escape sequences by @kurtmckee in `#1103 <https://github.com/jpadilla/pyjwt/pull/1103>`__
 - Development: Build a shared wheel once to speed up test suite setup times by @kurtmckee in `#1114 <https://github.com/jpadilla/pyjwt/pull/1114>`__
+- Development: Test type annotations across all supported Python versions,
+  increase the strictness of the type checking, and remove the mypy pre-commit hook
+  by @kurtmckee in `#1112 <https://github.com/jpadilla/pyjwt/pull/1112>`__
 
 Added
 ~~~~~

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -6,7 +6,7 @@ import warnings
 from calendar import timegm
 from collections.abc import Container, Iterable, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union, cast
 
 from . import api_jws
 from .exceptions import (
@@ -23,7 +23,13 @@ from .exceptions import (
 from .warnings import RemovedInPyjwt3Warning
 
 if TYPE_CHECKING or bool(os.getenv("SPHINX_BUILD", "")):
-    from typing import TypeAlias
+    import sys
+
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        # Python 3.9 and lower
+        from typing_extensions import TypeAlias
 
     from .algorithms import has_crypto
     from .api_jwk import PyJWK
@@ -32,11 +38,11 @@ if TYPE_CHECKING or bool(os.getenv("SPHINX_BUILD", "")):
     if has_crypto:
         from .algorithms import AllowedPrivateKeys, AllowedPublicKeys
 
-        AllowedPrivateKeyTypes: TypeAlias = AllowedPrivateKeys | PyJWK | str | bytes  # type: ignore
-        AllowedPublicKeyTypes: TypeAlias = AllowedPublicKeys | PyJWK | str | bytes  # type: ignore
+        AllowedPrivateKeyTypes: TypeAlias = Union[AllowedPrivateKeys, PyJWK, str, bytes]
+        AllowedPublicKeyTypes: TypeAlias = Union[AllowedPublicKeys, PyJWK, str, bytes]
     else:
-        AllowedPrivateKeyTypes: TypeAlias = PyJWK | str | bytes  # type: ignore
-        AllowedPublicKeyTypes: TypeAlias = PyJWK | str | bytes  # type: ignore
+        AllowedPrivateKeyTypes: TypeAlias = Union[PyJWK, str, bytes]  # type: ignore
+        AllowedPublicKeyTypes: TypeAlias = Union[PyJWK, str, bytes]  # type: ignore
 
 
 class PyJWT:
@@ -360,7 +366,7 @@ class PyJWT:
             issuer=issuer,
             leeway=leeway,
         )
-        return decoded["payload"]
+        return cast(dict[str, Any], decoded["payload"])
 
     def _validate_claims(
         self,

--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -46,10 +46,9 @@ class PyJWKClient:
 
         if cache_keys:
             # Cache signing keys
+            get_signing_key = lru_cache(maxsize=max_cached_keys)(self.get_signing_key)
             # Ignore mypy (https://github.com/python/mypy/issues/2427)
-            self.get_signing_key = lru_cache(maxsize=max_cached_keys)(
-                self.get_signing_key
-            )  # type: ignore
+            self.get_signing_key = get_signing_key  # type: ignore[method-assign]
 
     def fetch_data(self) -> Any:
         jwk_set: Any = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,20 +96,10 @@ combine_as_imports = true
 profile = "black"
 
 [tool.mypy]
-allow_incomplete_defs = true
-allow_untyped_defs = true
-disable_error_code = [
-    "method-assign",
-    "unused-ignore",
-]
+packages = "jwt"
 ignore_missing_imports = true
-no_implicit_optional = true
-overrides = [
-    { disallow_untyped_calls = false, module = "tests.*" },
-]
-python_version = 3.11
 strict = true
-warn_return_any = false
+warn_return_any = true
 warn_unused_ignores = true
 
 [tool.setuptools]

--- a/tox.ini
+++ b/tox.ini
@@ -27,10 +27,13 @@ envlist =
     lint
     typing
     py{39,310,311,312,313,314,py39,py310,py311}-{crypto,nocrypto}
+    py{39,310,311,312,313,314}{,-crypto}-mypy
     docs
     pypi-description
     coverage-report
 isolated_build = True
+labels =
+    mypy = py{39,310,311,312,313,314}{,-crypto}-mypy
 
 
 [testenv]
@@ -59,6 +62,16 @@ commands =
     sphinx-build -n -T -W -b doctest -d {envtmpdir}/doctrees docs docs/_build/html
     python -m doctest README.rst docs/usage.rst
 
+
+[testenv:py{39,310,311,312,313,314}{,-crypto}-mypy]
+extras =
+    crypto: crypto
+deps =
+    mypy
+set_env =
+    MYPY_FORCE_COLOR=1
+commands =
+    mypy
 
 [testenv:lint]
 basepython = python3.9


### PR DESCRIPTION
Type checking across all supported Pythons revealed errors:

* Python 3.9 doesn't have `typing.TypeAlias`.

  This is fixed by importing `typing_extensions.TypeAlias`.

* Python 3.9 doesn't support type alias `x | y` union syntax.

  This is fixed by using `Union[x, y]` syntax.

* Setting `warn-return-any = true` revealed that when `cryptography` isn't installed, `RSAPrivateKey.sign()` has an unknown signature. The return type cannot be `cast()` because it's redundant if `cryptography` is installed.

  This is fixed by adding `signature: bytes = key.sign()` and then returning `signature`.

* All disabled error codes have been removed.
* The pre-commit hook for mypy has been removed. It's less robust than running the test suite.
* All functions and methods are now fully type-annotated.