### PR TITLE
Build a shared wheel once in the test suite

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Fixed
 - Improve typing/logic for `options` in decode, decode_complete by @pachewise in `#1045 <https://github.com/jpadilla/pyjwt/pull/1045>`__
 - Declare float supported type for lifespan and timeout by @nikitagashkov in `#1068 <https://github.com/jpadilla/pyjwt/pull/1068>`__
 - Fix ``SyntaxWarning``\s/``DeprecationWarning``\s caused by invalid escape sequences by @kurtmckee in `#1103 <https://github.com/jpadilla/pyjwt/pull/1103>`__
+- Development: Build a shared wheel once to speed up test suite setup times by @kurtmckee in `#1114 <https://github.com/jpadilla/pyjwt/pull/1114>`__
 
 Added
 ~~~~~

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,10 @@ isolated_build = True
 
 
 [testenv]
+# Build a shared wheel once, rather than building a .tar.gz file
+# and forcing each individual tox environment to convert it to a wheel.
+package = wheel
+wheel_build_env = build_wheel
 # Prevent random setuptools/pip breakages like
 # https://github.com/pypa/setuptools/issues/1042 from breaking our builds.
 setenv =


### PR DESCRIPTION
This cuts the setup times for tox environments roughly in half (from ~2s to ~1s when running locally), and reduces local `tox p` invocations from ~18s to ~14s.

----

Python 3.14 on Ubuntu examples in CI:

### BEFORE [[citation](https://github.com/jpadilla/pyjwt/actions/runs/18753546860/job/53499389816#step:5:191)]

```
  py314-crypto: OK (17.23=setup[11.03]+cmd[6.20] seconds)
  py314-nocrypto: OK (6.45=setup[5.68]+cmd[0.77] seconds)
  congratulations :) (23.72 seconds)
```

### AFTER [[citation](https://github.com/jpadilla/pyjwt/actions/runs/18783031992/job/53593956840#step:5:191)]

```
  py314-crypto: OK (13.84=setup[7.74]+cmd[6.10] seconds)
  py314-nocrypto: OK (4.31=setup[3.61]+cmd[0.70] seconds)
  congratulations :) (18.21 seconds)
```

----

Usage summaries in CI:

### BEFORE [[citation](https://github.com/jpadilla/pyjwt/actions/runs/18753546860/usage)]

Runtime: 25m 14s

### AFTER [[citation](https://github.com/jpadilla/pyjwt/actions/runs/18783031992/usage)]

Runtime: 22m 35s