### PR TITLE
Improve coverage config and eliminate unused test suite code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Added
 
 - Support Python 3.14, and test against PyPy 3.10 and 3.11 by @kurtmckee in `#1104 <https://github.com/jpadilla/pyjwt/pull/1104>`__
 - Development: Migrate to ``build`` to test package building in CI by @kurtmckee in `#1108 <https://github.com/jpadilla/pyjwt/pull/1108>`__
+- Development: Improve coverage config and eliminate unused test suite code by @kurtmckee in `#1115 <https://github.com/jpadilla/pyjwt/pull/1115>`__
 - Docs: Standardize CHANGELOG links to PRs by @kurtmckee in `#1110 <https://github.com/jpadilla/pyjwt/pull/1110>`__
 - Docs: Add example of using leeway with nbf by @djw8605 in `#1034 <https://github.com/jpadilla/pyjwt/pull/1034>`__
 - Docs: Refactored docs with ``autodoc``; added ``PyJWS`` and ``jwt.algorithms`` docs by @pachewise in `#1045 <https://github.com/jpadilla/pyjwt/pull/1045>`__

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -251,12 +251,12 @@ class Algorithm(ABC):
     @overload
     @staticmethod
     @abstractmethod
-    def to_jwk(key_obj, as_dict: Literal[True]) -> JWKDict: ...  # pragma: no cover
+    def to_jwk(key_obj, as_dict: Literal[True]) -> JWKDict: ...
 
     @overload
     @staticmethod
     @abstractmethod
-    def to_jwk(key_obj, as_dict: Literal[False] = False) -> str: ...  # pragma: no cover
+    def to_jwk(key_obj, as_dict: Literal[False] = False) -> str: ...
 
     @staticmethod
     @abstractmethod
@@ -329,15 +329,11 @@ class HMACAlgorithm(Algorithm):
 
     @overload
     @staticmethod
-    def to_jwk(
-        key_obj: str | bytes, as_dict: Literal[True]
-    ) -> JWKDict: ...  # pragma: no cover
+    def to_jwk(key_obj: str | bytes, as_dict: Literal[True]) -> JWKDict: ...
 
     @overload
     @staticmethod
-    def to_jwk(
-        key_obj: str | bytes, as_dict: Literal[False] = False
-    ) -> str: ...  # pragma: no cover
+    def to_jwk(key_obj: str | bytes, as_dict: Literal[False] = False) -> str: ...
 
     @staticmethod
     def to_jwk(key_obj: str | bytes, as_dict: bool = False) -> JWKDict | str:
@@ -424,15 +420,11 @@ if has_crypto:
 
         @overload
         @staticmethod
-        def to_jwk(
-            key_obj: AllowedRSAKeys, as_dict: Literal[True]
-        ) -> JWKDict: ...  # pragma: no cover
+        def to_jwk(key_obj: AllowedRSAKeys, as_dict: Literal[True]) -> JWKDict: ...
 
         @overload
         @staticmethod
-        def to_jwk(
-            key_obj: AllowedRSAKeys, as_dict: Literal[False] = False
-        ) -> str: ...  # pragma: no cover
+        def to_jwk(key_obj: AllowedRSAKeys, as_dict: Literal[False] = False) -> str: ...
 
         @staticmethod
         def to_jwk(key_obj: AllowedRSAKeys, as_dict: bool = False) -> JWKDict | str:
@@ -620,15 +612,11 @@ if has_crypto:
 
         @overload
         @staticmethod
-        def to_jwk(
-            key_obj: AllowedECKeys, as_dict: Literal[True]
-        ) -> JWKDict: ...  # pragma: no cover
+        def to_jwk(key_obj: AllowedECKeys, as_dict: Literal[True]) -> JWKDict: ...
 
         @overload
         @staticmethod
-        def to_jwk(
-            key_obj: AllowedECKeys, as_dict: Literal[False] = False
-        ) -> str: ...  # pragma: no cover
+        def to_jwk(key_obj: AllowedECKeys, as_dict: Literal[False] = False) -> str: ...
 
         @staticmethod
         def to_jwk(key_obj: AllowedECKeys, as_dict: bool = False) -> JWKDict | str:
@@ -853,15 +841,11 @@ if has_crypto:
 
         @overload
         @staticmethod
-        def to_jwk(
-            key: AllowedOKPKeys, as_dict: Literal[True]
-        ) -> JWKDict: ...  # pragma: no cover
+        def to_jwk(key: AllowedOKPKeys, as_dict: Literal[True]) -> JWKDict: ...
 
         @overload
         @staticmethod
-        def to_jwk(
-            key: AllowedOKPKeys, as_dict: Literal[False] = False
-        ) -> str: ...  # pragma: no cover
+        def to_jwk(key: AllowedOKPKeys, as_dict: Literal[False] = False) -> str: ...
 
         @staticmethod
         def to_jwk(key: AllowedOKPKeys, as_dict: bool = False) -> JWKDict | str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,10 @@ crypto = [
     "cryptography>=3.4.0",
 ]
 dev = [
-    "coverage[toml]==5.0.4",
+    "coverage[toml]==7.10.7",
     "cryptography>=3.4.0",
     "pre-commit",
-    "pytest>=6.0.0,<7.0.0",
+    "pytest>=8.4.2,<9.0.0",
     "sphinx",
     "sphinx-rtd-theme",
     "zope.interface",
@@ -71,22 +71,23 @@ Homepage = "https://github.com/jpadilla/pyjwt"
 
 [tool.coverage.paths]
 source = [
-    ".tox/*/site-packages",
     "jwt",
+    "*/site-packages",
 ]
 
 [tool.coverage.report]
-exclude_lines = [
+skip_covered = true
+exclude_also = [
     "if TYPE_CHECKING",
-    "pragma: no cover",
 ]
-show_missing = true
 
 [tool.coverage.run]
 branch = true
 parallel = true
+relative_files = true
 source = [
     "jwt",
+    "tests",
 ]
 
 [tool.isort]

--- a/tests/keys/__init__.py
+++ b/tests/keys/__init__.py
@@ -27,24 +27,9 @@ def load_hmac_key():
     return base64url_decode(keyobj["k"])
 
 
-def load_rsa_key():
-    with open(os.path.join(BASE_PATH, "jwk_rsa_key.json")) as infile:
-        return RSAAlgorithm.from_jwk(infile.read())
-
-
 def load_rsa_pub_key():
     with open(os.path.join(BASE_PATH, "jwk_rsa_pub.json")) as infile:
         return RSAAlgorithm.from_jwk(infile.read())
-
-
-def load_ec_key():
-    with open(os.path.join(BASE_PATH, "jwk_ec_key.json")) as infile:
-        keyobj = json.load(infile)
-
-    return ec.EllipticCurvePrivateNumbers(
-        private_value=decode_value(keyobj["d"]),
-        public_numbers=load_ec_pub_key_p_521().public_numbers(),
-    )
 
 
 def load_ec_pub_key_p_521():

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -709,9 +709,8 @@ class TestJWS:
     def test_custom_json_encoder(self, jws, payload):
         class CustomJSONEncoder(json.JSONEncoder):
             def default(self, o):
-                if isinstance(o, Decimal):
-                    return "it worked"
-                return super().default(o)
+                assert isinstance(o, Decimal)
+                return "it worked"
 
         data = {"some_decimal": Decimal("2.2")}
 
@@ -732,14 +731,9 @@ class TestJWS:
         headers = {"testheader": True}
         token = jws.encode(payload, "secret", headers=headers)
 
-        if not isinstance(token, str):
-            token = token.decode()
-
         header = token[0 : token.index(".")].encode()
         header = base64url_decode(header)
-
-        if not isinstance(header, str):
-            header = header.decode()
+        header = header.decode()
 
         header_obj = json.loads(header)
 

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -658,9 +658,8 @@ class TestJWT:
     def test_custom_json_encoder(self, jwt):
         class CustomJSONEncoder(json.JSONEncoder):
             def default(self, o):
-                if isinstance(o, Decimal):
-                    return "it worked"
-                return super().default(o)
+                assert isinstance(o, Decimal)
+                return "it worked"
 
         data = {"some_decimal": Decimal("2.2")}
 


### PR DESCRIPTION
This introduces the following changes:

* Fix duplicate, overlooked coverage and pytest dependencies in the `dev` dependency
* Remove now-unnecessary `pragma: no cover` comments
  _(coverage now auto-ignores functions with `...` as their sole line)_
* Configure coverage to watch the code in `tests/` as well
* Remove unused helper functions in the test suite
* Refactor test suite code to eliminate impossible-to-reach code