### PR TITLE
Fix #1126: Fix microseconds lose on jwt.encode for known time claims

### DIFF
--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -125,9 +125,9 @@ class PyJWT:
         # Payload
         payload = payload.copy()
         for time_claim in ["exp", "iat", "nbf"]:
-            # Convert datetime to a intDate value in known time-format claims
+            # Convert datetime to a float value in known time-format claims
             if isinstance(payload.get(time_claim), datetime):
-                payload[time_claim] = timegm(payload[time_claim].utctimetuple())
+                payload[time_claim] = payload[time_claim].timestamp()
 
         # Issue #1039, iss being set to non-string
         if "iss" in payload and not isinstance(payload["iss"], str):

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import os
 import warnings
-from calendar import timegm
 from collections.abc import Container, Iterable, Sequence
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Union, cast


### PR DESCRIPTION
## Summary

Fixes #1126 by using the native `timestamp` package function to convert the datetime directly to a float number, avoiding the lose of microseconds precision.

A very similar change was merged at #821.

Converting directly to float should be no problem since you can already bypass this limitation by converting the datetimes to float yourselt. Code
```python
import datetime as dt
import jwt

ts_iat = dt.datetime(2025, 1, 1, 0, 0, 0, 123456, dt.UTC).timestamp()

result = jwt.decode(jwt.encode({'iat': ts_iat}, 'secret'), 'secret', algorithms = ['HS256'])
decoded_ts_iat = result['iat']

print(f'Original timestamp: {ts_iat}')
print(f'Decoded  timestamp: {decoded_ts_iat}')
```
produces
```
Original timestamp: 1735689600.123456
Decoded  timestamp: 1735689600.123456
```