### PR TITLE
Fix invalid URL handling in PyJWKClient.fetch_data()

### DIFF
--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -54,6 +54,10 @@ class PyJWKClient:
         jwk_set: Any = None
         try:
             r = urllib.request.Request(url=self.uri, headers=self.headers)
+        except ValueError as e:
+            raise PyJWKClientError(f'Invalid URL "{self.uri}", err: "{e}"') from e
+
+        try:
             with urllib.request.urlopen(
                 r, timeout=self.timeout, context=self.ssl_context
             ) as response:

--- a/tests/test_jwks_client.py
+++ b/tests/test_jwks_client.py
@@ -357,3 +357,13 @@ class TestPyJWKClient:
             )
             with pytest.raises(PyJWKClientError):
                 jwks_client.get_jwk_set()
+
+    def test_fetch_data_invalide_uri(self):
+        url = "obviously_wrong_url"
+
+        jwks_client = PyJWKClient(url)
+
+        with pytest.raises(PyJWKClientError) as exc:
+            jwks_client.fetch_data()
+
+        assert f'Invalid URL "{url}"' in str(exc.value)

--- a/tests/test_jwks_client.py
+++ b/tests/test_jwks_client.py
@@ -358,7 +358,7 @@ class TestPyJWKClient:
             with pytest.raises(PyJWKClientError):
                 jwks_client.get_jwk_set()
 
-    def test_fetch_data_invalide_uri(self):
+    def test_fetch_data_invalid_url(self):
         url = "obviously_wrong_url"
 
         jwks_client = PyJWKClient(url)


### PR DESCRIPTION
### Problem
When `PyJWKClient` is initialized with an invalid URL string and `fetch_data()` is called, `urllib.request.Request` raises a `ValueError`, which is not caught or handled gracefully.

### Solution
- Isolated URL validation into a separate try-except block to explicitly catch `ValueError` when constructing the request
- Converts the `ValueError` to `PyJWKClientError` with a descriptive message that includes the invalid URL and the original error
- Prevents `None` from being cached on invalid URLs (by returning early)

### Testing
- Added `test_fetch_data_invalid_url()` to verify that invalid URLs raise `PyJWKClientError` with the appropriate error message

### Benefits
- Clearer error handling for invalid URL configurations
- Consistent error types across the API (all errors raised as `PyJWKClientError`)
- Better debugging experience with detailed error messages