### PR TITLE
fix: match algorithm when looking up signing keys by kid

### DIFF
--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -169,9 +169,7 @@ class PyJWKClient:
 
         return signing_keys
 
-    def get_signing_key(
-        self, kid: str, algorithm: str | None = None
-    ) -> PyJWK:
+    def get_signing_key(self, kid: str, algorithm: str | None = None) -> PyJWK:
         """Return the signing key matching the given ``kid``.
 
         If no match is found in the current JWK Set, the set is

--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -169,7 +169,9 @@ class PyJWKClient:
 
         return signing_keys
 
-    def get_signing_key(self, kid: str) -> PyJWK:
+    def get_signing_key(
+        self, kid: str, algorithm: str | None = None
+    ) -> PyJWK:
         """Return the signing key matching the given ``kid``.
 
         If no match is found in the current JWK Set, the set is
@@ -177,18 +179,21 @@ class PyJWKClient:
 
         :param kid: The key ID to look up.
         :type kid: str
+        :param algorithm: Optional algorithm name to filter by. When
+            provided, the key must also match this algorithm.
+        :type algorithm: str or None
         :returns: The matching signing key.
         :rtype: PyJWK
         :raises PyJWKClientError: If no matching key is found after
             refreshing.
         """
         signing_keys = self.get_signing_keys()
-        signing_key = self.match_kid(signing_keys, kid)
+        signing_key = self.match_kid(signing_keys, kid, algorithm)
 
         if not signing_key:
             # If no matching signing key from the jwk set, refresh the jwk set and try again.
             signing_keys = self.get_signing_keys(refresh=True)
-            signing_key = self.match_kid(signing_keys, kid)
+            signing_key = self.match_kid(signing_keys, kid, algorithm)
 
             if not signing_key:
                 raise PyJWKClientError(
@@ -210,24 +215,34 @@ class PyJWKClient:
         """
         unverified = decode_token(token, options={"verify_signature": False})
         header = unverified["header"]
-        return self.get_signing_key(header.get("kid"))
+        return self.get_signing_key(header.get("kid"), header.get("alg"))
 
     @staticmethod
-    def match_kid(signing_keys: list[PyJWK], kid: str) -> PyJWK | None:
+    def match_kid(
+        signing_keys: list[PyJWK], kid: str, algorithm: str | None = None
+    ) -> PyJWK | None:
         """Find a key in *signing_keys* that matches *kid*.
+
+        When *algorithm* is provided, the key must also use that algorithm.
+        If no key matches both *kid* and *algorithm*, a key matching only
+        *kid* is returned as a fallback for backward compatibility.
 
         :param signing_keys: The list of keys to search.
         :type signing_keys: list[PyJWK]
         :param kid: The key ID to match.
         :type kid: str
+        :param algorithm: Optional algorithm name to filter by.
+        :type algorithm: str or None
         :returns: The matching key, or ``None`` if not found.
         :rtype: PyJWK or None
         """
-        signing_key = None
+        kid_match = None
 
         for key in signing_keys:
             if key.key_id == kid:
-                signing_key = key
-                break
+                if algorithm and key.algorithm_name == algorithm:
+                    return key
+                if kid_match is None:
+                    kid_match = key
 
-        return signing_key
+        return kid_match

--- a/tests/test_jwks_client.py
+++ b/tests/test_jwks_client.py
@@ -47,6 +47,31 @@ RESPONSE_DATA_NO_MATCHING_KID = {
     ]
 }
 
+RESPONSE_DATA_DUPLICATE_KID_DIFFERENT_ALG = {
+    "keys": [
+        {
+            "alg": "RS384",
+            "kty": "RSA",
+            "use": "sig",
+            "n": "0wtlJRY9-ru61LmOgieeI7_rD1oIna9QpBMAOWw8wTuoIhFQFwcIi7MFB7IEfelCPj08vkfLsuFtR8cG07EE4uvJ78bAqRjMsCvprWp4e2p7hqPnWcpRpDEyHjzirEJle1LPpjLLVaSWgkbrVaOD0lkWkP1T1TkrOset_Obh8BwtO-Ww-UfrEwxTyz1646AGkbT2nL8PX0trXrmira8GnrCkFUgTUS61GoTdb9bCJ19PLX9Gnxw7J0BtR0GubopXq8KlI0ThVql6ZtVGN2dvmrCPAVAZleM5TVB61m0VSXvGWaF6_GeOhbFoyWcyUmFvzWhBm8Q38vWgsSI7oHTkEw",
+            "e": "AQAB",
+            "kid": "NEE1QURBOTM4MzI5RkFDNTYxOTU1MDg2ODgwQ0UzMTk1QjYyRkRFQw",
+        },
+        {
+            "alg": "RS256",
+            "kty": "RSA",
+            "use": "sig",
+            "n": "0wtlJRY9-ru61LmOgieeI7_rD1oIna9QpBMAOWw8wTuoIhFQFwcIi7MFB7IEfelCPj08vkfLsuFtR8cG07EE4uvJ78bAqRjMsCvprWp4e2p7hqPnWcpRpDEyHjzirEJle1LPpjLLVaSWgkbrVaOD0lkWkP1T1TkrOset_Obh8BwtO-Ww-UfrEwxTyz1646AGkbT2nL8PX0trXrmira8GnrCkFUgTUS61GoTdb9bCJ19PLX9Gnxw7J0BtR0GubopXq8KlI0ThVql6ZtVGN2dvmrCPAVAZleM5TVB61m0VSXvGWaF6_GeOhbFoyWcyUmFvzWhBm8Q38vWgsSI7oHTkEw",
+            "e": "AQAB",
+            "kid": "NEE1QURBOTM4MzI5RkFDNTYxOTU1MDg2ODgwQ0UzMTk1QjYyRkRFQw",
+            "x5t": "NEE1QURBOTM4MzI5RkFDNTYxOTU1MDg2ODgwQ0UzMTk1QjYyRkRFQw",
+            "x5c": [
+                "MIIDBzCCAe+gAwIBAgIJNtD9Ozi6j2jJMA0GCSqGSIb3DQEBCwUAMCExHzAdBgNVBAMTFmRldi04N2V2eDlydS5hdXRoMC5jb20wHhcNMTkwNjIwMTU0NDU4WhcNMzMwMjI2MTU0NDU4WjAhMR8wHQYDVQQDExZkZXYtODdldng5cnUuYXV0aDAuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0wtlJRY9+ru61LmOgieeI7/rD1oIna9QpBMAOWw8wTuoIhFQFwcIi7MFB7IEfelCPj08vkfLsuFtR8cG07EE4uvJ78bAqRjMsCvprWp4e2p7hqPnWcpRpDEyHjzirEJle1LPpjLLVaSWgkbrVaOD0lkWkP1T1TkrOset/Obh8BwtO+Ww+UfrEwxTyz1646AGkbT2nL8PX0trXrmira8GnrCkFUgTUS61GoTdb9bCJ19PLX9Gnxw7J0BtR0GubopXq8KlI0ThVql6ZtVGN2dvmrCPAVAZleM5TVB61m0VSXvGWaF6/GeOhbFoyWcyUmFvzWhBm8Q38vWgsSI7oHTkEwIDAQABo0IwQDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQlGXpmYaXFB7Q3eG69Uhjd4cFp/jAOBgNVHQ8BAf8EBAMCAoQwDQYJKoZIhvcNAQELBQADggEBAIzQOF/h4T5WWAdjhcIwdNS7hS2Deq+UxxkRv+uavj6O9mHLuRG1q5onvSFShjECXaYT6OGibn7Ufw/JSm3+86ZouMYjBEqGh4OvWRkwARy1YTWUVDGpT2HAwtIq3lfYvhe8P4VfZByp1N4lfn6X2NcJflG+Q+mfXNmRFyyft3Oq51PCZyyAkU7bTun9FmMOyBtmJvQjZ8RXgBLvu9nUcZB8yTVoeUEg4cLczQlli/OkiFXhWgrhVr8uF0/9klslMFXtm78iYSgR8/oC+k1pSNd1+ESSt7n6+JiAQ2Co+ZNKta7LTDGAjGjNDymyoCrZpeuYQwwnHYEHu/0khjAxhXo="
+            ],
+        },
+    ]
+}
+
 
 @contextlib.contextmanager
 def mocked_success_response(data: object) -> Iterator[mock.Mock]:
@@ -177,6 +202,21 @@ class TestPyJWKClient:
         assert signing_key.key_type == "RSA"
         assert signing_key.key_id == kid
         assert signing_key.public_key_use == "sig"
+
+    def test_get_signing_key_prefers_matching_algorithm(self) -> None:
+        url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
+        kid = "NEE1QURBOTM4MzI5RkFDNTYxOTU1MDg2ODgwQ0UzMTk1QjYyRkRFQw"
+
+        with mocked_success_response(RESPONSE_DATA_DUPLICATE_KID_DIFFERENT_ALG):
+            jwks_client = PyJWKClient(url)
+            # Without algorithm, the first key (RS384) is returned
+            signing_key = jwks_client.get_signing_key(kid)
+            assert signing_key.algorithm_name == "RS384"
+
+            # With algorithm specified, the RS256 key is returned
+            signing_key = jwks_client.get_signing_key(kid, algorithm="RS256")
+            assert signing_key.algorithm_name == "RS256"
+            assert signing_key.key_id == kid
 
     def test_get_signing_key_caches_result(self) -> None:
         url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"

--- a/tests/test_jwks_client.py
+++ b/tests/test_jwks_client.py
@@ -236,6 +236,7 @@ class TestPyJWKClient:
             signing_key = jwks_client.get_signing_key_from_jwt(token)
             assert signing_key.algorithm_name == "RS256"
             assert signing_key.key_id == kid
+
     def test_get_signing_key_caches_result(self) -> None:
         url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
         kid = "NEE1QURBOTM4MzI5RkFDNTYxOTU1MDg2ODgwQ0UzMTk1QjYyRkRFQw"

--- a/tests/test_jwks_client.py
+++ b/tests/test_jwks_client.py
@@ -218,6 +218,24 @@ class TestPyJWKClient:
             assert signing_key.algorithm_name == "RS256"
             assert signing_key.key_id == kid
 
+    def test_get_signing_key_from_jwt_prefers_matching_algorithm(self) -> None:
+        url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
+        kid = "NEE1QURBOTM4MzI5RkFDNTYxOTU1MDg2ODgwQ0UzMTk1QjYyRkRFQw"
+
+        with mocked_success_response(RESPONSE_DATA_DUPLICATE_KID_DIFFERENT_ALG):
+            jwks_client = PyJWKClient(url)
+
+            # Create a JWT whose header specifies alg RS256 and the shared kid
+            token = jwt.encode(
+                {"some": "payload"},
+                "mock-secret",
+                algorithm="RS256",
+                headers={"kid": kid},
+            )
+
+            signing_key = jwks_client.get_signing_key_from_jwt(token)
+            assert signing_key.algorithm_name == "RS256"
+            assert signing_key.key_id == kid
     def test_get_signing_key_caches_result(self) -> None:
         url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
         kid = "NEE1QURBOTM4MzI5RkFDNTYxOTU1MDg2ODgwQ0UzMTk1QjYyRkRFQw"


### PR DESCRIPTION
Fixes #1129

When an identity provider exposes multiple JWKs with the same `kid` but different algorithms (which is allowed per [RFC 7517 §4.5](https://datatracker.ietf.org/doc/html/rfc7517#section-4.5)), `get_signing_key_from_jwt` would return the first match regardless of algorithm. This could cause verification to fail or use the wrong key.

This PR extracts the `alg` claim from the JWT header and passes it through to `match_kid`, which now prefers a key matching both `kid` and `alg`. If no exact match is found, it falls back to matching `kid` only, so existing behavior is preserved for endpoints that don't have duplicate key IDs.

Added a test with a JWKS response containing two keys sharing the same `kid` (one RS384, one RS256) to verify the correct key is returned when `algorithm` is specified.
