### PR TITLE
Migrate development extras to dependency groups

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
         run: "python -c 'import jwt; print(jwt.__version__)'"
 
       - name: "Install in dev mode"
-        run: "python -m pip install -e .[dev]"
+        run: "python -m pip install -e . --group dev"
 
       - name: "Import package in dev mode"
         run: "python -c 'import jwt; print(jwt.__version__)'"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,14 +6,10 @@ build:
   os: "ubuntu-lts-latest"
   tools:
     python: "3.11"
-
-python:
-  install:
-    - method: "pip"
-      path: "."
-      extra_requirements:
-        - "docs"
-        - "crypto"
+  jobs:
+    install:
+      - "pip install --upgrade pip"
+      - "pip install .[crypto] --group 'docs'"
 
 sphinx:
   configuration: "docs/conf.py"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ This project adheres to `Semantic Versioning <https://semver.org/>`__.
 `Unreleased <https://github.com/jpadilla/pyjwt/compare/2.12.1...HEAD>`__
 ------------------------------------------------------------------------
 
+Changed
+~~~~~~~
+
+- Migrate the ``dev``, ``docs``, and ``tests`` package extras to dependency groups by @kurtmckee in `#1152 <https://github.com/jpadilla/pyjwt/pull/1152>`__
+
 `v2.12.1 <https://github.com/jpadilla/pyjwt/compare/2.12.0...2.12.1>`__
 ------------------------------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,26 @@ requires = [
     "setuptools>=77.0.3",
 ]
 
+[dependency-groups]
+dev = [
+    "coverage[toml]==7.10.7",
+    "cryptography>=3.4.0",
+    "pre-commit",
+    "pytest>=8.4.2,<9.0.0",
+    "sphinx",
+    "sphinx-rtd-theme",
+    "zope.interface",
+]
+docs = [
+    "sphinx",
+    "sphinx-rtd-theme",
+    "zope.interface",
+]
+tests = [
+    "coverage[toml]==7.10.7",
+    "pytest>=8.4.2,<9.0.0",
+]
+
 [project]
 authors = [
     { email = "hello@jpadilla.com", name = "Jose Padilla" },
@@ -45,24 +65,6 @@ requires-python = ">=3.9"
 [project.optional-dependencies]
 crypto = [
     "cryptography>=3.4.0",
-]
-dev = [
-    "coverage[toml]==7.10.7",
-    "cryptography>=3.4.0",
-    "pre-commit",
-    "pytest>=8.4.2,<9.0.0",
-    "sphinx",
-    "sphinx-rtd-theme",
-    "zope.interface",
-]
-docs = [
-    "sphinx",
-    "sphinx-rtd-theme",
-    "zope.interface",
-]
-tests = [
-    "coverage[toml]==7.10.7",
-    "pytest>=8.4.2,<9.0.0",
 ]
 
 [project.readme]

--- a/tox.ini
+++ b/tox.ini
@@ -39,8 +39,9 @@ wheel_build_env = build_wheel
 # https://github.com/pypa/setuptools/issues/1042 from breaking our builds.
 setenv =
     VIRTUALENV_NO_DOWNLOAD=1
-extras =
+dependency_groups =
     tests
+extras =
     crypto: crypto
 commands = {envpython} -b -m coverage run -m pytest {posargs}
 
@@ -48,8 +49,9 @@ commands = {envpython} -b -m coverage run -m pytest {posargs}
 [testenv:docs]
 # The tox config must match the ReadTheDocs config.
 basepython = python3.11
-extras =
+dependency_groups =
     docs
+extras =
     crypto
 commands =
     sphinx-build -n -T -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
@@ -58,8 +60,9 @@ commands =
 
 
 [testenv:py{39,310,311,312,313,314}{,-crypto}-mypy]
-extras =
+dependency_groups =
     tests
+extras =
     crypto: crypto
 deps =
     mypy
@@ -69,8 +72,8 @@ commands =
     mypy
 
 [testenv:lint]
-basepython = python3.9
-extras = dev
+basepython = python3.10
+dependency_groups = dev
 passenv = HOMEPATH  # needed on Windows
 commands = pre-commit run --all-files
 


### PR DESCRIPTION
> [!NOTE]
>
> These changes are being introduced because `extras` appear in lock files. When Dependabot opens security vulnerability PRs, the `dev`, `docs`, and `tests` extras also appear in the diff. In addition, having test dependencies as `extras` can affect dependency version resolution.
> 
> This PR will also eliminate the unnecessary `extras` appearing on the PyPI page:
>
> <img width="304" height="245" alt="image" src="https://github.com/user-attachments/assets/7c4386e5-ccd4-490f-9f87-5b6830ae7575" />

----

This introduces the following changes:

* The `dev` extra is moved to a dependency group.
* The `tests` extra is moved to a dependency group.
* The `docs` extra is moved to a dependency group.
* `tox.ini` has been updated to use the dependency groups.
* `main.yml` has been updated to install the `dev` dependency group.
* The Read the Docs config is updated to install the `docs` dependency group.

  This follows the how-to documentation published by Read the Docs. https://docs.readthedocs.com/platform/latest/build-customization.html#install-dependencies-from-dependency-groups

In addition, when tox was run, the `lint` environment failed because pyupgrade doesn't support Python 3.9.
Therefore, one additional change was made:

* The `lint` tox environment's `basepython` is updated to Python 3.10.