### PR TITLE
fix(jwks): handle PyJWKSet returned from cache in get_jwk_set

### DIFF
--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -139,6 +139,9 @@ class PyJWKClient:
         if data is None:
             data = self.fetch_data()
 
+        if isinstance(data, PyJWKSet):
+            return data
+
         if not isinstance(data, dict):
             raise PyJWKClientError("The JWKS endpoint did not return a JSON object")
 


### PR DESCRIPTION
When the JWK set cache is populated externally with a `PyJWKSet` instance (e.g. from a pre-fetched JWKS stored externally), `get_jwk_set()` raised `PyJWKClientError` because it only expected `dict` or `None` from the cache.

The `isinstance(data, dict)` guard correctly validates fresh fetch results (which are dicts from JSON), but fails when the cache contains a `PyJWKSet` put there by user code — which is what the type hints for `JWKSetCache.put()` suggest is the intended usage.

**Before this fix:**
```
PyJWKClientError: The JWKS endpoint did not return a JSON object
```

**Fix:** Return cached `PyJWKSet` objects directly, before the dict type check.

Fixes #914