### PR TITLE
fix(jwks_client): Prevent SSRF by validating URI scheme

### DIFF
--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -6,6 +6,7 @@ from functools import lru_cache
 from ssl import SSLContext
 from typing import Any
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 
 from .api_jwk import PyJWK, PyJWKSet
 from .api_jwt import decode_complete as decode_token
@@ -101,7 +102,16 @@ class PyJWKClient:
 
         :returns: The parsed JWK Set as a dictionary.
         :raises PyJWKClientConnectionError: If the HTTP request fails.
+        :raises PyJWKClientError: If the URI scheme is not supported.
         """
+        # Validate the URI scheme to prevent SSRF attacks via file://, ftp://, etc.
+        parsed = urlparse(self.uri)
+        if parsed.scheme not in ("http", "https"):
+            raise PyJWKClientError(
+                f'Unsupported URI scheme: "{parsed.scheme}". '
+                f'Only "http" and "https" are allowed for JWKS endpoints.'
+            )
+
         jwk_set: Any = None
         try:
             r = urllib.request.Request(url=self.uri, headers=self.headers)

--- a/tests/test_jwks_client.py
+++ b/tests/test_jwks_client.py
@@ -366,6 +366,52 @@ class TestPyJWKClient:
 
         assert jwk_set is not None
 
+    def test_fetch_data_rejects_file_scheme(self) -> None:
+        url = "file:///etc/passwd"
+        jwks_client = PyJWKClient(url)
+
+        with pytest.raises(PyJWKClientError) as exc:
+            jwks_client.fetch_data()
+
+        assert 'Unsupported URI scheme: "file"' in str(exc.value)
+        assert "Only \"http\" and \"https\" are allowed" in str(exc.value)
+
+    def test_fetch_data_rejects_ftp_scheme(self) -> None:
+        url = "ftp://example.com/jwks.json"
+        jwks_client = PyJWKClient(url)
+
+        with pytest.raises(PyJWKClientError) as exc:
+            jwks_client.fetch_data()
+
+        assert 'Unsupported URI scheme: "ftp"' in str(exc.value)
+
+    def test_fetch_data_rejects_dict_scheme(self) -> None:
+        url = "dict://127.0.0.1:80/"
+        jwks_client = PyJWKClient(url)
+
+        with pytest.raises(PyJWKClientError) as exc:
+            jwks_client.fetch_data()
+
+        assert 'Unsupported URI scheme: "dict"' in str(exc.value)
+
+    def test_fetch_data_rejects_gopher_scheme(self) -> None:
+        url = "gopher://example.com/"
+        jwks_client = PyJWKClient(url)
+
+        with pytest.raises(PyJWKClientError) as exc:
+            jwks_client.fetch_data()
+
+        assert 'Unsupported URI scheme: "gopher"' in str(exc.value)
+
+    def test_fetch_data_allows_http_scheme(self) -> None:
+        url = "http://dev-87evx9ru.auth0.com/.well-known/jwks.json"
+
+        with mocked_success_response(RESPONSE_DATA_WITH_MATCHING_KID):
+            jwks_client = PyJWKClient(url)
+            jwk_set = jwks_client.get_jwk_set()
+
+        assert len(jwk_set.keys) == 1
+
     def test_get_jwt_set_sslcontext_no_ca(self) -> None:
         url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
         jwks_client = PyJWKClient(

--- a/tests/test_jwks_client.py
+++ b/tests/test_jwks_client.py
@@ -374,7 +374,7 @@ class TestPyJWKClient:
             jwks_client.fetch_data()
 
         assert 'Unsupported URI scheme: "file"' in str(exc.value)
-        assert "Only \"http\" and \"https\" are allowed" in str(exc.value)
+        assert 'Only "http" and "https" are allowed' in str(exc.value)
 
     def test_fetch_data_rejects_ftp_scheme(self) -> None:
         url = "ftp://example.com/jwks.json"


### PR DESCRIPTION
## Summary

This PR fixes a Server-Side Request Forgery (SSRF) vulnerability in  where attacker-controlled JWKS URIs could use non-HTTP protocols to access unintended resources.

## Problem

 uses  which supports multiple URL schemes including , , , and . When the JWKS URI is attacker-controlled (e.g., via JWT  header in multi-tenant applications), this can be exploited to:

1. Read arbitrary local files (e.g., )
2. Access internal services
3. Load attacker-controlled keys to bypass JWT signature verification

## Solution

Add a scheme whitelist check in  that only allows  and  URIs.

## Changes

- : Added  import and scheme validation
- : Added 5 new tests

## Testing

All 26 tests pass:


## Impact

- **Affected versions:** All versions &lt;= 2.12.1
- **CWE:** CWE-918 (Server-Side Request Forgery)