### PR TITLE
utils: mention bytes in force_bytes type error

### DIFF
--- a/jwt/utils.py
+++ b/jwt/utils.py
@@ -19,7 +19,7 @@ def force_bytes(value: Union[bytes, str]) -> bytes:
     elif isinstance(value, bytes):
         return value
     else:
-        raise TypeError("Expected a string value")
+        raise TypeError("Expected a string or bytes value")
 
 
 def base64url_decode(input: Union[bytes, str]) -> bytes:

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -65,7 +65,7 @@ class TestAlgorithms:
             algo.prepare_key(object())  # type: ignore[arg-type]
 
         exception = context.value
-        assert str(exception) == "Expected a string value"
+        assert str(exception) == "Expected a string or bytes value"
 
     def test_hmac_should_accept_unicode_key(self) -> None:
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)


### PR DESCRIPTION
`force_bytes` accepts `str` or `bytes` and returns `bytes`, but the
fallback `TypeError` only says "Expected a string value". When the
error fires it reads like the bytes input path is unsupported, even
though it's the second branch in the function itself.

Updated the message to mention both types, and bumped the matching
assertion in `test_hmac_should_reject_nonstring_key`.