### PR TITLE
docs/conf: drop duplicate 'and' from read() docstring

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ import re
 
 def read(*parts) -> str:
     """
-    Build an absolute path from *parts* and and return the contents of the
+    Build an absolute path from *parts* and return the contents of the
     resulting file.  Assume UTF-8 encoding.
     """
     here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Tiny doc-only fix: the read() helper in docs/conf.py says "from *parts* and and return". One `and` is enough.