### PR TITLE
Add allowed_schemes to PyJWKClient

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ This project adheres to `Semantic Versioning <https://semver.org/>`__.
 `Unreleased <https://github.com/jpadilla/pyjwt/compare/2.13.0...HEAD>`__
 ------------------------------------------------------------------------
 
+Fixed
+~~~~~
+
+- Callers can define allowed URI schemes in ``PyJWKClient``
+  by @davisjk in `#1176 <https://github.com/jpadilla/pyjwt/pull/1176>`__.
+
 `v2.13.0 <https://github.com/jpadilla/pyjwt/compare/2.12.1...2.13.0>`__
 -----------------------------------------------------------------------
 

--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -69,8 +69,11 @@ class PyJWKClient:
         :type timeout: float
         :param ssl_context: Optional SSL context for the request.
         :type ssl_context: ssl.SSLContext or None
-        :param allowed_schemes: Allowed URI Schemes. "http" and "https" by default.
-        :type allowed_schemes: Iterator[str]
+        :param allowed_schemes: Iterable of allowed URI schemes. Defaults to
+            ``("http", "https")``. The parsed scheme from ``uri`` is normalized
+            to lowercase before comparison, so values should be provided in
+            lowercase.
+        :type allowed_schemes: Iterable[str]
         """
         if headers is None:
             headers = {}

--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -4,7 +4,7 @@ import json
 import urllib.request
 from functools import lru_cache
 from ssl import SSLContext
-from typing import Any
+from typing import Any, Iterable
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 
@@ -25,6 +25,7 @@ class PyJWKClient:
         headers: dict[str, Any] | None = None,
         timeout: float = 30,
         ssl_context: SSLContext | None = None,
+        allowed_schemes: Iterable[str] = ("http", "https"),
     ):
         """A client for retrieving signing keys from a JWKS endpoint.
 
@@ -67,6 +68,8 @@ class PyJWKClient:
         :type timeout: float
         :param ssl_context: Optional SSL context for the request.
         :type ssl_context: ssl.SSLContext or None
+        :param allowed_schemes: Allowed URI Schemes. "http" and "https" by default.
+        :type allowed_schemes: Iterator[str]
         """
         if headers is None:
             headers = {}
@@ -75,10 +78,10 @@ class PyJWKClient:
         # passing an attacker-influenced URL (e.g. taken from a `jku` token
         # header) can't read local files or reach other unintended schemes.
         scheme = urlparse(uri).scheme.lower()
-        if scheme not in ("http", "https"):
+        if scheme not in allowed_schemes:
             raise PyJWKClientError(
-                f"Invalid JWKS URI scheme {scheme!r}: only 'http' and 'https' "
-                f"are supported."
+                f"Invalid JWKS URI scheme {scheme!r}: only "
+                f"{' and '.join(allowed_schemes)} are supported."
             )
         self.uri = uri
         self.jwk_set_cache: JWKSetCache | None = None

--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -4,7 +4,8 @@ import json
 import urllib.request
 from functools import lru_cache
 from ssl import SSLContext
-from typing import Any, Iterable
+from typing import Any
+from collections.abc import Iterable
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 


### PR DESCRIPTION
# Summary
Fixes #1175 
PyJWKClient has the allowed schemes hard coded to "http" and "https". Developers have legitimate reasons to allow other schemes or not allow "http" in order to implement sub-classes for interfacing with other URI schemes such as an S3 bucket.

# Testing
- [x] This doesn't raise an error
```python
from jwt import PyJWKClient
client = PyJWKClient("s3://my-bucket/jwks.json", allowed_schemes=["s3"])
```