### PR TITLE
fix: crash when decoding JWTs with null 'kid' header

### DIFF
--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -423,7 +423,10 @@ class PyJWS:
         self, headers: dict[str, Any], *, encoding: bool = False
     ) -> None:
         if "kid" in headers:
-            self._validate_kid(headers["kid"])
+            # When decoding, treat a null-valued 'kid' header parameter
+            # the same as if the parameter was omitted entirely.
+            if encoding or headers["kid"] is not None:
+                self._validate_kid(headers["kid"])
         if not encoding and "crit" in headers:
             self._validate_crit(headers)
 

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -305,6 +305,16 @@ class TestJWT:
         decoded = jwt.decode(example_jwt, "secret", algorithms=["HS256"])
         assert decoded["aud"] is None
 
+    def test_decode_accepts_null_kid(self, jwt: PyJWT) -> None:
+        # >>> jwt.encode({"iss": "teebee"}, "secret", headers={"kid": None})
+        example_jwt = (
+            "eyJhbGciOiJIUzI1NiIsImtpZCI6bnVsbCwidHlwIjoiSldUIn0."
+            "eyJpc3MiOiJ0ZWViZWUifQ."
+            "8BQajvskzhkMPdxDU7SLYxmlQjjfR36gPLjnR5aS9nQ"
+        )
+
+        jwt.decode(example_jwt, "secret", algorithms=["HS256"])
+
     def test_encode_datetime(self, jwt: PyJWT) -> None:
         secret = "secret"
         current_datetime = datetime.now(tz=timezone.utc)


### PR DESCRIPTION
### Description
This PR fixes a regression introduced in [commit 051ea34](https://github.com/jpadilla/pyjwt/commit/051ea341b5573fe3edcd53042f347929b92c2b92) (#GHSA-752w-5fwx-jx9f) where JWTs containing an explicit `null` value for the `kid` header parameter cause `decode()` to crash with an `InvalidTokenError: Key ID header parameter must be a string`.

According to RFC 7515, the `kid` parameter is optional. While it is usually omitted, some Identity Providers emit `"kid": null` when no specific key ID is assigned. Prior to the `crit` header validation update in v2.12.0, PyJWT safely ignored this during decoding.

### Real-world Impact
This is not just a theoretical RFC edge-case. For example, the **Confluent Kafka Metadata Server (MDS)** issues production-level JWT tokens that explicitly include `"kid": null` in their header. 

Due to the recent regression, any Python-based Kafka client or microservice trying to validate Confluent Kafka MDS tokens using PyJWT will instantly crash.

### Changes
- Updated `_validate_headers` in `jwt/api_jws.py` to only trigger `_validate_kid` if `kid` is present **and** not `None`.
- Added a unit test to `tests/test_api_jwt.py` to ensure tokens with `null` keys are correctly tolerated during decoding without introducing regressions to other components.