### PR TITLE
fix: correct docstring typo in _validate_jti

### DIFF
--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -453,7 +453,7 @@ class PyJWT:
 
     def _validate_jti(self, payload: dict[str, Any]) -> None:
         """
-        Checks whether "jti" if in the payload is valid or not
+        Checks whether "jti" in the payload is valid or not
         This is an Optional claim
 
         :param payload(dict): The payload which needs to be validated


### PR DESCRIPTION
## Summary

Fixes a small grammar typo in the `_validate_jti()` docstring.

### Change

In `jwt/api_jwt.py`:
```
- Checks whether "jti" if in the payload is valid or not
+ Checks whether "jti" in the payload is valid or not
```

The word "if" is redundant after "whether".

Closes #1063