### PR TITLE
Set hash_alg on OKPAlgorithm so compute_hash_digest works for EdDSA

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ This project adheres to `Semantic Versioning <https://semver.org/>`__.
 `Unreleased <https://github.com/jpadilla/pyjwt/compare/2.13.0...HEAD>`__
 ------------------------------------------------------------------------
 
+Fixed
+~~~~~
+
+- Set ``hash_alg`` on ``OKPAlgorithm`` so ``compute_hash_digest`` works for
+  ``EdDSA`` instead of raising ``NotImplementedError``. EdDSA (Ed25519) hashes
+  with SHA-512 internally per RFC 8037 / RFC 8032. `#1097
+  <https://github.com/jpadilla/pyjwt/issues/1097>`__
+
 `v2.13.0 <https://github.com/jpadilla/pyjwt/compare/2.12.1...2.13.0>`__
 -----------------------------------------------------------------------
 

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -857,6 +857,8 @@ if has_crypto:
         This class requires ``cryptography>=2.6`` to be installed.
         """
 
+        SHA512: ClassVar[type[hashes.HashAlgorithm]] = hashes.SHA512
+
         _crypto_key_types = cast(
             tuple[type[AllowedKeys], ...],
             get_args(
@@ -870,7 +872,13 @@ if has_crypto:
         )
 
         def __init__(self, **kwargs: Any) -> None:
-            pass
+            # EdDSA (RFC 8037) uses Ed25519 by default, which hashes with
+            # SHA-512 internally (RFC 8032). Expose that here so
+            # compute_hash_digest works (e.g. for OIDC at_hash/c_hash).
+            # Ed448 uses SHAKE256, but the curve is not known at construction
+            # time since "EdDSA" is registered without a key, so SHA-512 is
+            # used as the default.
+            self.hash_alg = self.SHA512
 
         def prepare_key(self, key: AllowedOKPKeys | str | bytes) -> AllowedOKPKeys:
             if not isinstance(key, (str, bytes)):

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -4,6 +4,7 @@ from typing import Union, cast
 
 import pytest
 
+import jwt
 from jwt.algorithms import HMACAlgorithm, NoneAlgorithm, has_crypto
 from jwt.exceptions import InvalidKeyError
 from jwt.utils import base64url_decode
@@ -1211,6 +1212,20 @@ class TestOKPAlgorithms:
         algo = HMACAlgorithm(HMACAlgorithm.SHA256)
         computed_hash = algo.compute_hash_digest(b"foo")
         assert computed_hash == foo_hash
+
+    @crypto_required
+    def test_okp_can_compute_digest(self) -> None:
+        # EdDSA (Ed25519) hashes with SHA-512 internally (RFC 8037 / RFC 8032).
+        # This is the well-known SHA-512 hash of "foo".
+        foo_hash = base64.b64decode(
+            b"9/u6bgY2+JDlb7vzKD5STG+jIErimDgtYkdB0NxmODJuKCxBvl5CVNiCB3LFUYosWowMf3"
+            b"7aGVlKfrU5RT4e1w=="
+        )
+
+        algo = jwt.get_algorithm_by_name("EdDSA")
+        computed_hash = algo.compute_hash_digest(b"foo")
+        assert computed_hash == foo_hash
+        assert len(computed_hash) == 64  # SHA-512 digest length
 
     @crypto_required
     def test_rsa_prepare_key_raises_invalid_key_error_on_invalid_pem(self) -> None:


### PR DESCRIPTION
Fixes #1097

## Problem

`Algorithm.compute_hash_digest()` raises `NotImplementedError` for `EdDSA`:

```python
>>> import jwt
>>> algo = jwt.get_algorithm_by_name('EdDSA')
>>> algo.compute_hash_digest(b'')
NotImplementedError
```

`compute_hash_digest` reads `self.hash_alg` and raises when it is `None`. Every other algorithm class (`HMACAlgorithm`, `RSAAlgorithm`, `ECAlgorithm`) sets `self.hash_alg` in `__init__`, but `OKPAlgorithm.__init__` was just `pass`, so the attribute was never set. This breaks downstream callers that compute OIDC `at_hash` / `c_hash` for EdDSA-signed tokens (see the linked python-social-auth report in the issue).

## Fix

Set `self.hash_alg` on `OKPAlgorithm`, mirroring how `RSAAlgorithm` / `ECAlgorithm` expose their hash via a `ClassVar`. EdDSA defaults to Ed25519, which hashes with SHA-512 internally per RFC 8037 (JOSE registration) and RFC 8032 (Ed25519 = SHA-512). Sign and verify are unchanged.

The `"EdDSA"` algorithm is registered as a single keyless instance (`"EdDSA": OKPAlgorithm()`), so the curve (Ed25519 vs Ed448) is not known at construction time. SHA-512 is therefore used as the default. Ed448 uses SHAKE256 rather than SHA-512; supporting that cleanly would require knowing the curve at the point the digest is computed, which is out of scope here. SHA-512 is correct for the common Ed25519 case.

## Tests

Added `test_okp_can_compute_digest`, which asserts `compute_hash_digest(b"foo")` for `EdDSA` returns the known SHA-512 digest of `"foo"` and is 64 bytes long. On the current code this test fails with `NotImplementedError`; with the fix it passes. The full test suite stays green (`pytest tests/`), and `ruff check` / `ruff format --check` / `mypy jwt/algorithms.py` are clean.
