### PR TITLE
Normalize base64 alphabet in base64url_decode to avoid Py3.15 FutureWarning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ This project adheres to `Semantic Versioning <https://semver.org/>`__.
 `Unreleased <https://github.com/jpadilla/pyjwt/compare/2.13.0...HEAD>`__
 ------------------------------------------------------------------------
 
+Fixed
+~~~~~
+
+- Normalise the standard Base64 alphabet (``+`` / ``/``) to the URL-safe
+  alphabet in ``base64url_decode`` so valid URL-safe input no longer trips
+  the Python 3.15 ``FutureWarning: invalid character '/' in URL-safe Base64
+  data`` and standard-alphabet input keeps decoding deterministically once
+  CPython starts discarding those characters. Also corrects the
+  ``test_compressed_jwt`` fixture, which carried a standard-Base64 payload
+  segment instead of a URL-safe one (`#1167 <https://github.com/jpadilla/pyjwt/issues/1167>`__).
+
 `v2.13.0 <https://github.com/jpadilla/pyjwt/compare/2.12.1...2.13.0>`__
 -----------------------------------------------------------------------
 

--- a/jwt/utils.py
+++ b/jwt/utils.py
@@ -22,8 +22,18 @@ def force_bytes(value: Union[bytes, str]) -> bytes:
         raise TypeError("Expected a string value")
 
 
+# Translate the standard Base64 alphabet to the URL-safe alphabet so that
+# callers passing standard-alphabet data (``+`` / ``/``) are normalised before
+# the decode. From Python 3.15 ``base64.urlsafe_b64decode`` emits a
+# ``FutureWarning`` for ``+`` / ``/`` and has announced it will eventually
+# discard those characters, which would silently corrupt the decoded bytes.
+# Normalising up front keeps valid URL-safe input warning-free and keeps the
+# historical lenient handling of standard-alphabet input deterministic.
+_STD_TO_URLSAFE = bytes.maketrans(b"+/", b"-_")
+
+
 def base64url_decode(input: Union[bytes, str]) -> bytes:
-    input_bytes = force_bytes(input)
+    input_bytes = force_bytes(input).translate(_STD_TO_URLSAFE)
 
     rem = len(input_bytes) % 4
 

--- a/tests/test_compressed_jwt.py
+++ b/tests/test_compressed_jwt.py
@@ -19,11 +19,11 @@ def test_decodes_complete_valid_jwt_with_compressed_payload() -> None:
     example_payload = {"hello": "world"}
     example_secret = "secret"
     # payload made with the pako (https://nodeca.github.io/pako/) library in Javascript:
-    # Buffer.from(pako.deflateRaw('{"hello": "world"}')).toString('base64')
+    # Buffer.from(pako.deflateRaw('{"hello": "world"}')).toString('base64url')
     example_jwt = (
         b"eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9"
-        b".q1bKSM3JyVeyUlAqzy/KSVGqBQA="
-        b".08wHYeuh1rJXmcBcMrz6NxmbxAnCQp2rGTKfRNIkxiw="
+        b".q1bKSM3JyVeyUlAqzy_KSVGqBQA"
+        b".AAn1elCJC5MQCYFwTwa2tjjtyLgqLUVU-Y1vFBsU8jo"
     )
     decoded = CompressedPyJWT().decode_complete(
         example_jwt, example_secret, algorithms=["HS256"]
@@ -33,7 +33,7 @@ def test_decodes_complete_valid_jwt_with_compressed_payload() -> None:
         "header": {"alg": "HS256", "typ": "JWT"},
         "payload": example_payload,
         "signature": (
-            b"\xd3\xcc\x07a\xeb\xa1\xd6\xb2W\x99\xc0\\2\xbc\xfa7"
-            b"\x19\x9b\xc4\t\xc2B\x9d\xab\x192\x9fD\xd2$\xc6,"
+            b"\x00\t\xf5zP\x89\x0b\x93\x10\t\x81pO\x06\xb6\xb6"
+            b"8\xed\xc8\xb8*-ET\xf9\x8do\x14\x1b\x14\xf2:"
         ),
     }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,18 @@
+import base64
+import warnings
 from contextlib import nullcontext
 
 import pytest
 
 from contextlib import AbstractContextManager
 
-from jwt.utils import force_bytes, from_base64url_uint, is_ssh_key, to_base64url_uint
+from jwt.utils import (
+    base64url_decode,
+    force_bytes,
+    from_base64url_uint,
+    is_ssh_key,
+    to_base64url_uint,
+)
 
 
 @pytest.mark.parametrize(
@@ -39,6 +47,34 @@ def test_to_base64url_uint(
 def test_from_base64url_uint(inputval: bytes, expected: int) -> None:
     actual = from_base64url_uint(inputval)
     assert actual == expected
+
+
+def test_base64url_decode_handles_standard_alphabet() -> None:
+    # The same bytes encoded with the standard ("+/") and the URL-safe ("-_")
+    # alphabets must decode to the same value. ``base64url_decode`` normalises
+    # the standard alphabet so historical callers keep working.
+    raw = bytes(range(256))
+    standard = base64.b64encode(raw)
+    urlsafe = base64.urlsafe_b64encode(raw).rstrip(b"=")
+
+    assert b"+" in standard or b"/" in standard
+    assert base64url_decode(standard) == raw
+    assert base64url_decode(urlsafe) == raw
+
+
+def test_base64url_decode_does_not_warn_on_urlsafe_input() -> None:
+    # Valid URL-safe input must never trigger the Python 3.15+ FutureWarning
+    # about "+"/"/" in URL-safe Base64 data (jpadilla/pyjwt#1167).
+    raw = bytes(range(256))
+    standard = base64.b64encode(raw)
+    urlsafe = base64.urlsafe_b64encode(raw).rstrip(b"=")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        assert base64url_decode(urlsafe) == raw
+        # A standard-alphabet input is normalised first, so it must also be
+        # decoded without emitting the FutureWarning.
+        assert base64url_decode(standard) == raw
 
 
 def test_force_bytes_raises_error_on_invalid_object() -> None:


### PR DESCRIPTION
Fixes #1167.

## Problem

Under Python 3.15 one test emits:

```
FutureWarning: invalid character '/' in URL-safe Base64 data will be discarded in future Python versions
```

`base64url_decode` in `jwt/utils.py` pads the input and hands it straight to `base64.urlsafe_b64decode`. Historically that decoder has quietly accepted standard-alphabet characters (`+` and `/`). Python 3.15 now warns on them, and CPython has announced it will eventually *discard* those characters, which would silently corrupt the decoded bytes for any caller that still passes standard-Base64 data.

The single input that trips the warning today is the `test_compressed_jwt` fixture. Its payload segment was produced with JavaScript `.toString('base64')` (standard alphabet) and carries a literal `/`, so it is not a valid RFC 7515 JWT segment (which must be base64url, using `_` and no `=` padding).

## Two possible directions

There are two reasonable ways to fix this, and I want to flag both:

1. **Harden the decoder** so valid URL-safe input never warns and standard-alphabet input is handled deterministically.
2. **Fix only the test fixture** so it carries proper base64url, leaving the decoder untouched.

I did both, but I deliberately chose *normalisation* rather than *rejection* for the decoder. Rejecting `+`/`/` would be the strictest reading of the function's contract, but it would be a behaviour change: pyjwt has accepted standard-alphabet input for a long time, and some real-world tokens from non-compliant issuers may rely on that. Normalising (`+`->`-`, `/`->`_`) before the decode keeps every currently-decodable token decodable, produces identical bytes, removes the FutureWarning, and stays correct once CPython starts discarding the characters. If you would rather reject standard-alphabet input outright (stricter, but a behaviour change), I am happy to switch to that.

## Changes

- `jwt/utils.py`: `base64url_decode` now translates the standard alphabet to the URL-safe alphabet (via a module-level `bytes.maketrans`) before padding and decoding. No `+`/`/` ever reaches `urlsafe_b64decode`.
- `tests/test_compressed_jwt.py`: the fixture is rebuilt on the URL-safe alphabet. Because the HMAC signature is computed over the literal `header.payload` signing input, changing the payload segment required recomputing the HS256 signature and the expected signature bytes; both are updated.
- `tests/test_utils.py`: adds coverage that standard- and URL-safe-alphabet inputs decode to the same bytes, and that decoding valid URL-safe (and normalised standard) input raises no `FutureWarning`.
- `CHANGELOG.rst`: entry under Unreleased / Fixed.

## Verification

- `pytest tests/ -q` passes (367 passed, 4 pre-existing `no_crypto_required` skips).
- `pytest tests/ -q -W error::FutureWarning` passes, proving the warning is gone for the suite.
- `ruff check`, `ruff format --check`, and `mypy` (strict) are clean.

I was on Python 3.14, which does not yet emit the 3.15 FutureWarning, so I could not reproduce the exact warning string locally. I confirmed the mechanism instead: the old code path passes `/` straight to `urlsafe_b64decode`, while the new path never does, and the new unit tests fail under `-W error::FutureWarning` on any version that emits it.
