### PR TITLE
Fix: include received audience value in InvalidAudienceError message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ This project adheres to `Semantic Versioning <https://semver.org/>`__.
 `Unreleased <https://github.com/jpadilla/pyjwt/compare/2.13.0...HEAD>`__
 ------------------------------------------------------------------------
 
+Fixed
+~~~~~
+
+- Include received and expected audience values in ``InvalidAudienceError``
+  messages for easier debugging (`#1099 <https://github.com/jpadilla/pyjwt/issues/1099>`__).
+
 `v2.13.0 <https://github.com/jpadilla/pyjwt/compare/2.12.1...2.13.0>`__
 -----------------------------------------------------------------------
 

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -563,12 +563,14 @@ class PyJWT:
 
         if isinstance(audience, str):
             audience = [audience]
+        else:
+            audience = list(audience)
 
         if all(aud not in audience_claims for aud in audience):
             raise InvalidAudienceError(
                 f"Audience doesn't match:"
                 f" token has {audience_claims!r},"
-                f" expected {list(audience)!r}"
+                f" expected {audience!r}"
             )
 
     def _validate_iss(

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -522,7 +522,10 @@ class PyJWT:
                 return
             # Application did not specify an audience, but
             # the token has the 'aud' claim
-            raise InvalidAudienceError("Invalid audience")
+            raise InvalidAudienceError(
+                f"Invalid audience: token has {payload['aud']!r},"
+                " but no audience was expected"
+            )
 
         if "aud" not in payload or not payload["aud"]:
             # Application specified an audience, but it could not be
@@ -543,7 +546,11 @@ class PyJWT:
                 raise InvalidAudienceError("Invalid claim format in token (strict)")
 
             if audience != audience_claims:
-                raise InvalidAudienceError("Audience doesn't match (strict)")
+                raise InvalidAudienceError(
+                    f"Audience doesn't match (strict):"
+                    f" token has {audience_claims!r},"
+                    f" expected {audience!r}"
+                )
 
             return
 
@@ -558,7 +565,11 @@ class PyJWT:
             audience = [audience]
 
         if all(aud not in audience_claims for aud in audience):
-            raise InvalidAudienceError("Audience doesn't match")
+            raise InvalidAudienceError(
+                f"Audience doesn't match:"
+                f" token has {audience_claims!r},"
+                f" expected {list(audience)!r}"
+            )
 
     def _validate_iss(
         self, payload: dict[str, Any], issuer: Container[str] | str | None

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -523,16 +523,12 @@ class TestJWT:
         token = jwt.encode(payload, "secret")
 
         with pytest.raises(InvalidAudienceError, match="urn:someone-else") as exc:
-            jwt.decode(
-                token, "secret", audience="urn:me", algorithms=["HS256"]
-            )
+            jwt.decode(token, "secret", audience="urn:me", algorithms=["HS256"])
 
         assert "urn:someone-else" in str(exc.value)
         assert "urn:me" in str(exc.value)
 
-    def test_invalid_audience_error_includes_values_list(
-        self, jwt: PyJWT
-    ) -> None:
+    def test_invalid_audience_error_includes_values_list(self, jwt: PyJWT) -> None:
         payload = {
             "some": "payload",
             "aud": ["urn:someone", "urn:someone-else"],
@@ -540,9 +536,7 @@ class TestJWT:
         token = jwt.encode(payload, "secret")
 
         with pytest.raises(InvalidAudienceError) as exc:
-            jwt.decode(
-                token, "secret", audience="urn:me", algorithms=["HS256"]
-            )
+            jwt.decode(token, "secret", audience="urn:me", algorithms=["HS256"])
 
         assert "urn:someone" in str(exc.value)
         assert "urn:me" in str(exc.value)

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -518,6 +518,44 @@ class TestJWT:
         with pytest.raises(InvalidAudienceError):
             jwt.decode(token, "secret", audience="urn:me", algorithms=["HS256"])
 
+    def test_invalid_audience_error_includes_values(self, jwt: PyJWT) -> None:
+        payload = {"some": "payload", "aud": "urn:someone-else"}
+        token = jwt.encode(payload, "secret")
+
+        with pytest.raises(InvalidAudienceError, match="urn:someone-else") as exc:
+            jwt.decode(
+                token, "secret", audience="urn:me", algorithms=["HS256"]
+            )
+
+        assert "urn:someone-else" in str(exc.value)
+        assert "urn:me" in str(exc.value)
+
+    def test_invalid_audience_error_includes_values_list(
+        self, jwt: PyJWT
+    ) -> None:
+        payload = {
+            "some": "payload",
+            "aud": ["urn:someone", "urn:someone-else"],
+        }
+        token = jwt.encode(payload, "secret")
+
+        with pytest.raises(InvalidAudienceError) as exc:
+            jwt.decode(
+                token, "secret", audience="urn:me", algorithms=["HS256"]
+            )
+
+        assert "urn:someone" in str(exc.value)
+        assert "urn:me" in str(exc.value)
+
+    def test_invalid_audience_error_none_expected(self, jwt: PyJWT) -> None:
+        payload = {"some": "payload", "aud": "urn:someone"}
+        token = jwt.encode(payload, "secret")
+
+        with pytest.raises(InvalidAudienceError) as exc:
+            jwt.decode(token, "secret", algorithms=["HS256"])
+
+        assert "urn:someone" in str(exc.value)
+
     def test_raise_exception_token_without_issuer(self, jwt: PyJWT) -> None:
         issuer = "urn:wrong"
 

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -550,9 +550,7 @@ class TestJWT:
 
         assert "urn:someone" in str(exc.value)
 
-    def test_invalid_audience_error_strict_includes_values(
-        self, jwt: PyJWT
-    ) -> None:
+    def test_invalid_audience_error_strict_includes_values(self, jwt: PyJWT) -> None:
         payload = {"some": "payload", "aud": "urn:someone-else"}
         token = jwt.encode(payload, "secret")
 

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -550,6 +550,24 @@ class TestJWT:
 
         assert "urn:someone" in str(exc.value)
 
+    def test_invalid_audience_error_strict_includes_values(
+        self, jwt: PyJWT
+    ) -> None:
+        payload = {"some": "payload", "aud": "urn:someone-else"}
+        token = jwt.encode(payload, "secret")
+
+        with pytest.raises(InvalidAudienceError) as exc:
+            jwt.decode(
+                token,
+                "secret",
+                audience="urn:me",
+                algorithms=["HS256"],
+                options={"strict_aud": True},
+            )
+
+        assert "urn:someone-else" in str(exc.value)
+        assert "urn:me" in str(exc.value)
+
     def test_raise_exception_token_without_issuer(self, jwt: PyJWT) -> None:
         issuer = "urn:wrong"
 


### PR DESCRIPTION
## Summary

When JWT audience validation fails, the `InvalidAudienceError` message did not
indicate what audience was actually received in the token or what was expected,
making debugging difficult in token misconfiguration scenarios.

This change includes the received and expected audience values in the error
message for the three mismatch cases (normal mode, strict mode, and unexpected
audience present).

**Before:**
jwt.exceptions.InvalidAudienceError: Audience doesn't match



**After:**
jwt.exceptions.InvalidAudienceError: Audience doesn't match: token has ['api.staging.example.com'], expected ['api.example.com']



## Changes

- `jwt/api_jwt.py`: Updated `_validate_aud` to include received and expected audience values in error messages
- `tests/test_api_jwt.py`: Added 3 tests covering string audience, list audience, and unexpected audience scenarios
- `CHANGELOG.rst`: Added entry under `[Unreleased] > Fixed`

## How to test

pytest tests/test_api_jwt.py::TestJWT::test_invalid_audience_error_includes_values -v
pytest tests/test_api_jwt.py::TestJWT::test_invalid_audience_error_includes_values_list -v
pytest tests/test_api_jwt.py::TestJWT::test_invalid_audience_error_none_expected -v



Closes #1099