### PR TITLE
Feature: add to_dict() and to_json() to PyJWK and PyJWKSet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ This project adheres to `Semantic Versioning <https://semver.org/>`__.
 `Unreleased <https://github.com/jpadilla/pyjwt/compare/2.13.0...HEAD>`__
 ------------------------------------------------------------------------
 
+Added
+~~~~~
+
+- Add ``PyJWK.to_dict()``, ``PyJWK.to_json()``, ``PyJWKSet.to_dict()``, and
+  ``PyJWKSet.to_json()`` for serializing JWK objects back to dictionaries and
+  JSON, preserving all metadata such as ``kid``, ``use``, and ``alg``
+  (`#1106 <https://github.com/jpadilla/pyjwt/issues/1106>`__).
+
 `v2.13.0 <https://github.com/jpadilla/pyjwt/compare/2.12.1...2.13.0>`__
 -----------------------------------------------------------------------
 

--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -131,6 +131,25 @@ class PyJWK:
         """
         return self._jwk_data.get("use", None)
 
+    def to_dict(self) -> JWKDict:
+        """Serialize this key back to a JWK dictionary.
+
+        Returns all original JWK fields including metadata such as
+        ``kid``, ``use``, ``alg``, and ``key_ops``.
+
+        :rtype: dict[str, typing.Any]
+        """
+        return dict(self._jwk_data)
+
+    def to_json(self, **kwargs: Any) -> str:
+        """Serialize this key to a JSON string.
+
+        Any additional keyword arguments are passed to :func:`json.dumps`.
+
+        :rtype: str
+        """
+        return json.dumps(self.to_dict(), **kwargs)
+
 
 class PyJWKSet:
     def __init__(self, keys: list[JWKDict]) -> None:
@@ -174,6 +193,26 @@ class PyJWKSet:
 
     def __iter__(self) -> Iterator[PyJWK]:
         return iter(self.keys)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this key set back to a JWKS dictionary.
+
+        Returns ``{"keys": [...]}``, where each key is serialized via
+        :meth:`PyJWK.to_dict`.  Keys that were skipped during construction
+        (e.g. unsupported algorithms) will not appear in the output.
+
+        :rtype: dict[str, typing.Any]
+        """
+        return {"keys": [key.to_dict() for key in self.keys]}
+
+    def to_json(self, **kwargs: Any) -> str:
+        """Serialize this key set to a JSON string.
+
+        Any additional keyword arguments are passed to :func:`json.dumps`.
+
+        :rtype: str
+        """
+        return json.dumps(self.to_dict(), **kwargs)
 
 
 class PyJWTSetWithTimestamp:

--- a/tests/test_api_jwk.py
+++ b/tests/test_api_jwk.py
@@ -222,6 +222,85 @@ class TestPyJWK:
         with pytest.raises(MissingCryptographyError):
             PyJWK({"kty": "dummy"}, algorithm="RS256")
 
+    @crypto_required
+    def test_to_dict_rsa_public_round_trip(self) -> None:
+        with open(key_path("jwk_rsa_pub.json")) as keyfile:
+            key_data = json.loads(keyfile.read())
+
+        jwk = PyJWK.from_dict(key_data)
+        result = jwk.to_dict()
+
+        assert result == key_data
+        # Ensure it's a copy, not the same object
+        assert result is not jwk._jwk_data
+
+    @crypto_required
+    def test_to_dict_rsa_private_round_trip(self) -> None:
+        with open(key_path("jwk_rsa_key.json")) as keyfile:
+            key_data = json.loads(keyfile.read())
+
+        jwk = PyJWK.from_dict(key_data)
+        result = jwk.to_dict()
+
+        assert result == key_data
+
+    @crypto_required
+    def test_to_dict_ec_p256_round_trip(self) -> None:
+        with open(key_path("jwk_ec_pub_P-256.json")) as keyfile:
+            key_data = json.loads(keyfile.read())
+
+        jwk = PyJWK.from_dict(key_data)
+        result = jwk.to_dict()
+
+        assert result == key_data
+
+    @crypto_required
+    def test_to_dict_hmac_round_trip(self) -> None:
+        with open(key_path("jwk_hmac.json")) as keyfile:
+            key_data = json.loads(keyfile.read())
+
+        jwk = PyJWK.from_dict(key_data)
+        result = jwk.to_dict()
+
+        assert result == key_data
+
+    @crypto_required
+    def test_to_dict_okp_round_trip(self) -> None:
+        with open(key_path("jwk_okp_pub_Ed25519.json")) as keyfile:
+            key_data = json.loads(keyfile.read())
+
+        jwk = PyJWK.from_dict(key_data)
+        result = jwk.to_dict()
+
+        assert result == key_data
+
+    @crypto_required
+    def test_to_dict_preserves_metadata(self) -> None:
+        key_data = {
+            "kty": "oct",
+            "kid": "my-key-id",
+            "use": "sig",
+            "alg": "HS256",
+            "k": "hJtXIZ2uSN5kbQfbtTNWbpdmhkV8FJG-Onbc6mxCcYg",
+        }
+
+        jwk = PyJWK.from_dict(key_data)
+        result = jwk.to_dict()
+
+        assert result["kid"] == "my-key-id"
+        assert result["use"] == "sig"
+        assert result["alg"] == "HS256"
+
+    @crypto_required
+    def test_to_json_rsa_public(self) -> None:
+        with open(key_path("jwk_rsa_pub.json")) as keyfile:
+            key_data = json.loads(keyfile.read())
+
+        jwk = PyJWK.from_dict(key_data)
+        result = json.loads(jwk.to_json())
+
+        assert result == key_data
+
 
 class TestPyJWKSet:
     @crypto_required
@@ -334,6 +413,45 @@ class TestPyJWKSet:
         with pytest.raises(PyJWKSetError) as err:
             PyJWKSet(keys=[])
         assert str(err.value) == "The JWK Set did not contain any keys"
+
+    @crypto_required
+    def test_keyset_to_dict_round_trip(self) -> None:
+        with open(key_path("jwk_rsa_pub.json")) as keyfile:
+            rsa_key_data = json.loads(keyfile.read())
+        with open(key_path("jwk_ec_pub_P-256.json")) as keyfile:
+            ec_key_data = json.loads(keyfile.read())
+
+        original = {"keys": [rsa_key_data, ec_key_data]}
+        jwk_set = PyJWKSet.from_dict(original)
+        result = jwk_set.to_dict()
+
+        assert result == original
+        assert len(result["keys"]) == 2
+
+    @crypto_required
+    def test_keyset_to_dict_skips_unusable_keys(self) -> None:
+        with open(key_path("jwk_keyset_with_unknown_alg.json")) as keyfile:
+            jwks = json.loads(keyfile.read())
+
+        # Input has 2 keys, one unusable
+        assert len(jwks["keys"]) == 2
+
+        keyset = PyJWKSet.from_dict(jwks)
+        result = keyset.to_dict()
+
+        # Output should only have the usable key
+        assert len(result["keys"]) == 1
+
+    @crypto_required
+    def test_keyset_to_json_round_trip(self) -> None:
+        with open(key_path("jwk_rsa_pub.json")) as keyfile:
+            rsa_key_data = json.loads(keyfile.read())
+
+        original = {"keys": [rsa_key_data]}
+        jwk_set = PyJWKSet.from_dict(original)
+        result = json.loads(jwk_set.to_json())
+
+        assert result == original
 
     @no_crypto_required
     def test_missing_crypto_library_raises_when_required(self) -> None:


### PR DESCRIPTION
## Summary

`PyJWK` and `PyJWKSet` can be constructed from dictionaries via `from_dict()`,
but there is no public way to serialize them back. The only workaround is
accessing the private `_jwk_data` attribute or using `Algorithm.to_jwk()`,
which loses metadata like `kid`, `use`, and `alg`.

This adds `to_dict()` and `to_json()` methods to both classes, enabling
lossless round-tripping of JWK objects while preserving all metadata fields.

## Changes

- `jwt/api_jwk.py`: Added `to_dict()` and `to_json()` to `PyJWK` and `PyJWKSet`
- `tests/test_api_jwk.py`: Added 10 tests covering round-trips for RSA (public + private), EC, HMAC, OKP key types, metadata preservation, JSON serialization, keyset round-trips, and unusable key filtering
- `CHANGELOG.rst`: Added entry under `[Unreleased] > Added`

## Design notes

`PyJWK.to_dict()` returns a shallow copy of the internal `_jwk_data`
dictionary that was passed in during construction. This is intentional:
it preserves all original JWK fields (including `kid`, `use`, `alg`,
`key_ops`) that `Algorithm.to_jwk()` would drop.

`PyJWKSet.to_dict()` returns `{"keys": [...]}` containing only the keys
that were successfully parsed during construction. Keys with unsupported
algorithms that were skipped on input will not appear in the output.

## How to test

pytest tests/test_api_jwk.py -v -k "to_dict or to_json"



Closes #1106