### PR TITLE
Reject a bare string for the decode() algorithms argument (#1117)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ This project adheres to `Semantic Versioning <https://semver.org/>`__.
 `Unreleased <https://github.com/jpadilla/pyjwt/compare/2.13.0...HEAD>`__
 ------------------------------------------------------------------------
 
+Changed
+~~~~~~~
+
+- ``decode()`` now raises ``TypeError`` when the ``algorithms`` argument is a
+  bare string instead of a sequence of strings. A string was matched one
+  character at a time, so a token's algorithm only had to be a substring of it,
+  silently weakening the algorithm allow-list.
+
 `v2.13.0 <https://github.com/jpadilla/pyjwt/compare/2.12.1...2.13.0>`__
 -----------------------------------------------------------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -9,7 +9,7 @@ Encoding & Decoding Tokens with HS256
     >>> import jwt
     >>> key = "secret"
     >>> encoded = jwt.encode({"some": "payload"}, key, algorithm="HS256")
-    >>> jwt.decode(encoded, key, algorithms="HS256")
+    >>> jwt.decode(encoded, key, algorithms=["HS256"])
     {'some': 'payload'}
 
 Encoding & Decoding Tokens with RS256 (RSA)

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -233,6 +233,13 @@ class PyJWS:
                 RemovedInPyjwt3Warning,
                 stacklevel=2,
             )
+        if isinstance(algorithms, str):
+            raise TypeError(
+                'The "algorithms" argument must be a sequence of strings '
+                '(e.g. ["HS256"]), not a bare string. A string is matched one '
+                "character at a time, so a token's algorithm only has to be a "
+                "substring of it, which silently weakens the algorithm allow-list."
+            )
         merged_options: SigOptions
         if options is None:
             merged_options = self.options

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -118,9 +118,7 @@ class TestJWS:
         with pytest.raises(InvalidAlgorithmError):
             jws.decode(jws_token, secret, algorithms=["HS384"])
 
-    def test_decode_rejects_str_algorithms(
-        self, jws: PyJWS, payload: bytes
-    ) -> None:
+    def test_decode_rejects_str_algorithms(self, jws: PyJWS, payload: bytes) -> None:
         secret = "secret"
         jws_token = jws.encode(payload, secret, algorithm="HS256")
 

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -118,6 +118,20 @@ class TestJWS:
         with pytest.raises(InvalidAlgorithmError):
             jws.decode(jws_token, secret, algorithms=["HS384"])
 
+    def test_decode_rejects_str_algorithms(
+        self, jws: PyJWS, payload: bytes
+    ) -> None:
+        secret = "secret"
+        jws_token = jws.encode(payload, secret, algorithm="HS256")
+
+        # A bare string used to be silently accepted and matched one character
+        # at a time, which weakens the algorithm allow-list. It must now raise.
+        with pytest.raises(TypeError):
+            jws.decode(jws_token, secret, algorithms="HS256")
+
+        # A proper sequence still works.
+        assert jws.decode(jws_token, secret, algorithms=["HS256"]) == payload
+
     def test_decode_works_with_unicode_token(self, jws: PyJWS) -> None:
         secret = "secret"
         unicode_jws = (


### PR DESCRIPTION
Closes #1117.

## Problem

The `algorithms` argument to `decode()` is documented and typed as `Sequence[str]`, but a bare string is silently accepted:

```python
>>> jwt.decode(token, key, algorithms="HS256")   # "works"
```

It "works" only by accident: the allow-list check is `alg not in algorithms`, and for a string that's a **substring** test rather than membership. So a token's `alg` only has to be a *substring* of the passed string to pass the allow-list, which is a footgun for a value that is a security-critical control (the allow-list is what prevents algorithm-confusion / `alg=none` attacks).

```python
>>> "HS2" in "HS256"     # True  -> substring, not membership
```

## Fix

Raise a clear `TypeError` early in `decode_complete()` when `algorithms` is a `str`, telling the caller to pass a sequence. Proper sequences (`list`, `tuple`, `set`) are unaffected, and the "no algorithms passed" path is unchanged.

```python
>>> jwt.decode(token, key, algorithms="HS256")
TypeError: The "algorithms" argument must be a sequence of strings (e.g. ["HS256"]), ...
>>> jwt.decode(token, key, algorithms=["HS256"])   # still works
```

## Testing

- Added `TestJWS::test_decode_rejects_str_algorithms` — a bare string raises `TypeError`; a list still decodes. It does *not* raise on `main` (`DID NOT RAISE`) and passes with this change.
- Full suite: `366 passed, 4 skipped` (the skips are the pre-existing crypto-optional tests); no existing test relied on passing a bare string. `flake8` and `mypy` are clean on the changed source.
- Added a `CHANGELOG.rst` entry under *Unreleased → Changed*.

## Note

This is a small **breaking** change: code that currently passes a bare string will now raise instead of silently working. Given `algorithms` is a security control, I went with failing loud, but if you'd prefer a softer path (a `DeprecationWarning` now, coercing the string to a single-element list, and the hard error in pyjwt 3), I'm happy to adjust.

---

*Disclosure: this change was prepared with the assistance of an AI tool (Claude Code). I reproduced the issue, implemented and verified the fix and test, ran the suite and linters, and take responsibility for the contribution and will respond to review feedback personally.*
