### PR TITLE
Report all missing claims in MissingRequiredClaimError

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ This project adheres to `Semantic Versioning <https://semver.org/>`__.
 `Unreleased <https://github.com/jpadilla/pyjwt/compare/2.13.0...HEAD>`__
 ------------------------------------------------------------------------
 
+Fixed
+~~~~~
+
+- ``MissingRequiredClaimError`` now reports every missing claim from
+  ``options["require"]`` instead of only the first one encountered. The
+  existing ``claim`` attribute still holds the first missing claim for
+  backward compatibility; a new ``claims`` attribute holds the full list.
+
 `v2.13.0 <https://github.com/jpadilla/pyjwt/compare/2.12.1...2.13.0>`__
 -----------------------------------------------------------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -471,7 +471,11 @@ If you wish to require one or more claims to be present in the claimset, you can
     ... except jwt.MissingRequiredClaimError as e:
     ...     print(e)
     ...
-    Token is missing the "exp" claim
+    Token is missing the following claims: "exp", "iss"
+
+``MissingRequiredClaimError`` also exposes a ``claims`` attribute with the
+full list of missing claims, in addition to the ``claim`` attribute which
+still holds only the first one for backward compatibility.
 
 Retrieve RSA signing keys from a JWKS endpoint
 ----------------------------------------------

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -426,9 +426,10 @@ class PyJWT:
         payload: dict[str, Any],
         claims: Iterable[str],
     ) -> None:
-        for claim in claims:
-            if payload.get(claim) is None:
-                raise MissingRequiredClaimError(claim)
+        missing_claims = [claim for claim in claims if payload.get(claim) is None]
+
+        if missing_claims:
+            raise MissingRequiredClaimError(missing_claims[0], missing_claims)
 
     def _validate_sub(
         self, payload: dict[str, Any], subject: str | None = None

--- a/jwt/exceptions.py
+++ b/jwt/exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class PyJWTError(Exception):
     """
     Base class for all exceptions
@@ -72,10 +75,14 @@ class MissingRequiredClaimError(InvalidTokenError):
     """Raised when a claim that is required to be present is not contained
     in the claimset"""
 
-    def __init__(self, claim: str) -> None:
+    def __init__(self, claim: str, claims: list[str] | None = None) -> None:
         self.claim = claim
+        self.claims = claims if claims is not None else [claim]
 
     def __str__(self) -> str:
+        if len(self.claims) > 1:
+            claims_list = ", ".join(f'"{claim}"' for claim in self.claims)
+            return f"Token is missing the following claims: {claims_list}"
         return f'Token is missing the "{self.claim}" claim'
 
 

--- a/tests/test_api_jwt.py
+++ b/tests/test_api_jwt.py
@@ -672,6 +672,28 @@ class TestJWT:
 
         assert exc.value.claim == "nbf"
 
+    def test_decode_should_raise_error_with_all_missing_claims(
+        self, jwt: PyJWT
+    ) -> None:
+        payload = {
+            "some": "payload",
+            # sub, exp, and aud not present
+        }
+        token = jwt.encode(payload, "secret")
+
+        with pytest.raises(MissingRequiredClaimError) as exc:
+            jwt.decode(
+                token,
+                "secret",
+                options={"require": ["sub", "exp", "aud"]},
+                algorithms=["HS256"],
+            )
+
+        # `claim` keeps reporting the first missing claim for backward compatibility
+        assert exc.value.claim == "sub"
+        # `claims` reports every missing claim
+        assert exc.value.claims == ["sub", "exp", "aud"]
+
     def test_skip_check_signature(self, jwt: PyJWT) -> None:
         token = (
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,3 +5,18 @@ def test_missing_required_claim_error_has_proper_str() -> None:
     exc = MissingRequiredClaimError("abc")
 
     assert str(exc) == 'Token is missing the "abc" claim'
+
+
+def test_missing_required_claim_error_defaults_claims_to_single_claim() -> None:
+    exc = MissingRequiredClaimError("abc")
+
+    assert exc.claim == "abc"
+    assert exc.claims == ["abc"]
+
+
+def test_missing_required_claim_error_with_multiple_claims() -> None:
+    exc = MissingRequiredClaimError("abc", ["abc", "def", "ghi"])
+
+    assert exc.claim == "abc"
+    assert exc.claims == ["abc", "def", "ghi"]
+    assert str(exc) == 'Token is missing the following claims: "abc", "def", "ghi"'


### PR DESCRIPTION
Fixes #1189

When `options={"require": [...]}` lists several claims, `decode()` currently raises on only the first missing one. Callers have to fix claims one at a time to find out what else is missing.

This makes `_validate_required_claims` collect every missing claim before raising. `MissingRequiredClaimError.claim` still holds the first missing claim, unchanged, so existing code that reads `.claim` keeps working. A new `.claims` attribute holds the full list, and the message includes every missing claim when there's more than one:

```python
>>> jwt.decode(token, key, options={"require": ["sub", "exp", "aud"]}, algorithms=["HS256"])
...
jwt.exceptions.MissingRequiredClaimError: Token is missing the following claims: "sub", "exp", "aud"
```

Updated the doctest in `docs/usage.rst` and added tests covering the single- and multi-claim cases in both `test_api_jwt.py` and `test_exceptions.py`.