### PR TITLE
fix: report all missing required claims at once

### DIFF
--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -426,9 +426,9 @@ class PyJWT:
         payload: dict[str, Any],
         claims: Iterable[str],
     ) -> None:
-        for claim in claims:
-            if payload.get(claim) is None:
-                raise MissingRequiredClaimError(claim)
+        missing = [claim for claim in claims if payload.get(claim) is None]
+        if missing:
+            raise MissingRequiredClaimError(missing[0], claims=missing)
 
     def _validate_sub(
         self, payload: dict[str, Any], subject: str | None = None

--- a/jwt/exceptions.py
+++ b/jwt/exceptions.py
@@ -72,11 +72,17 @@ class MissingRequiredClaimError(InvalidTokenError):
     """Raised when a claim that is required to be present is not contained
     in the claimset"""
 
-    def __init__(self, claim: str) -> None:
+    def __init__(self, claim: str, claims: list[str] | None = None) -> None:
+        # `.claim` remains the first missing claim for backward compatibility.
+        # `.claims` lists every missing required claim (issue #1189).
         self.claim = claim
+        self.claims = list(claims) if claims is not None else [claim]
 
     def __str__(self) -> str:
-        return f'Token is missing the "{self.claim}" claim'
+        if len(self.claims) == 1:
+            return f'Token is missing the "{self.claim}" claim'
+        missing = ", ".join(f'"{c}"' for c in self.claims)
+        return f"Token is missing the required claims: {missing}"
 
 
 class PyJWKError(PyJWTError):


### PR DESCRIPTION
## Summary
With `options={"require": [...]}`, only the first missing claim was reported, forcing a fix-and-retry loop.

## Change
Collect all missing required claims. Keep `.claim` as the first missing claim for compatibility; add `.claims` and list every missing claim in the message.

## Test plan
- [x] Token missing `sub`/`exp`/`aud` → one exception mentioning all three; `.claim == "sub"`

Fixes #1189
