### PR TITLE
Use correct type annotation for PyJWK.from_json(algorithm=…) arg

### DIFF
--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -94,7 +94,7 @@ class PyJWK:
         return PyJWK(obj, algorithm)
 
     @staticmethod
-    def from_json(data: str, algorithm: None = None) -> PyJWK:
+    def from_json(data: str, algorithm: str | None = None) -> PyJWK:
         """Create a :class:`PyJWK` object from a JSON string.
         Implicitly calls :meth:`PyJWK.from_dict()`.
 


### PR DESCRIPTION
This fixes a wrong type annotation for PyJWK.from_json().

The docs correctly say the ‘algorithm’ argument can be ‘str | None’, so
annotate the function as such.

The function then delegates to PyJWK.from_json() which already correctly
accepts ‘str | None’.
