### PR TITLE
Support Ed25519 and Ed448 fully specified algorithms (RFC 9864)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ This project adheres to `Semantic Versioning <https://semver.org/>`__.
 `Unreleased <https://github.com/jpadilla/pyjwt/compare/2.13.0...HEAD>`__
 ------------------------------------------------------------------------
 
+Added
+~~~~~
+
+- Support fully-specified algorithm identifiers ``Ed25519`` and
+  ``Ed448`` as defined in RFC 9864.
+
 `v2.13.0 <https://github.com/jpadilla/pyjwt/compare/2.12.1...2.13.0>`__
 -----------------------------------------------------------------------
 

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -4,20 +4,35 @@ Digital Signature Algorithms
 The JWT specification supports several algorithms for cryptographic signing.
 This library currently supports:
 
-* HS256 - HMAC using SHA-256 hash algorithm (default)
-* HS384 - HMAC using SHA-384 hash algorithm
-* HS512 - HMAC using SHA-512 hash algorithm
-* ES256 - ECDSA signature algorithm using SHA-256 hash algorithm
-* ES256K - ECDSA signature algorithm with secp256k1 curve using SHA-256 hash algorithm
-* ES384 - ECDSA signature algorithm using SHA-384 hash algorithm
-* ES512 - ECDSA signature algorithm using SHA-512 hash algorithm
-* RS256 - RSASSA-PKCS1-v1_5 signature algorithm using SHA-256 hash algorithm
-* RS384 - RSASSA-PKCS1-v1_5 signature algorithm using SHA-384 hash algorithm
-* RS512 - RSASSA-PKCS1-v1_5 signature algorithm using SHA-512 hash algorithm
-* PS256 - RSASSA-PSS signature using SHA-256 and MGF1 padding with SHA-256
-* PS384 - RSASSA-PSS signature using SHA-384 and MGF1 padding with SHA-384
-* PS512 - RSASSA-PSS signature using SHA-512 and MGF1 padding with SHA-512
-* EdDSA - Both Ed25519 signature using SHA-512 and Ed448 signature using SHA-3 are supported. Ed25519 and Ed448 provide 128-bit and 224-bit security respectively.
+* HMAC
+
+  * HS256 - HMAC using SHA-256 hash algorithm (default)
+  * HS384 - HMAC using SHA-384 hash algorithm
+  * HS512 - HMAC using SHA-512 hash algorithm
+
+* ECDSA
+
+  * ES256 - ECDSA signature algorithm using SHA-256 hash algorithm
+  * ES256K - ECDSA signature algorithm with secp256k1 curve using SHA-256 hash algorithm
+  * ES384 - ECDSA signature algorithm using SHA-384 hash algorithm
+  * ES512 - ECDSA signature algorithm using SHA-512 hash algorithm
+
+* RSASSA-PKCS1-v1_5
+
+  * RS256 - RSASSA-PKCS1-v1_5 signature algorithm using SHA-256 hash algorithm
+  * RS384 - RSASSA-PKCS1-v1_5 signature algorithm using SHA-384 hash algorithm
+  * RS512 - RSASSA-PKCS1-v1_5 signature algorithm using SHA-512 hash algorithm
+
+* RSASSA-PSS
+
+  * PS256 - RSASSA-PSS signature using SHA-256 and MGF1 padding with SHA-256
+  * PS384 - RSASSA-PSS signature using SHA-384 and MGF1 padding with SHA-384
+  * PS512 - RSASSA-PSS signature using SHA-512 and MGF1 padding with SHA-512
+
+* EdDSA
+
+  * Ed25519 signature using SHA-512 hash algorithm
+  * Ed448 signature using SHAKE256 hash algorithm
 
 Minimum Key Length Requirements
 -------------------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -59,8 +59,8 @@ RSA encoding and decoding require the ``cryptography`` module. See :ref:`install
     >>> jwt.decode(encoded, public_key, algorithms=["PS256"])
     {'some': 'payload'}
 
-Encoding & Decoding Tokens with EdDSA (Ed25519)
------------------------------------------------
+Encoding & Decoding Tokens with EdDSA (Ed25519 and Ed448)
+---------------------------------------------------------
 
 EdDSA encoding and decoding require the ``cryptography`` module. See :ref:`installation_cryptography`.
 
@@ -69,9 +69,21 @@ EdDSA encoding and decoding require the ``cryptography`` module. See :ref:`insta
     >>> import jwt
     >>> private_key = "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIPtUxyxlhjOWetjIYmc98dmB2GxpeaMPP64qBhZmG13r\n-----END PRIVATE KEY-----\n"
     >>> public_key = "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA7p4c1IU6aA65FWn6YZ+Bya5dRbfd4P6d4a6H0u9+gCg=\n-----END PUBLIC KEY-----\n"
-    >>> encoded = jwt.encode({"some": "payload"}, private_key, algorithm="EdDSA")
-    >>> jwt.decode(encoded, public_key, algorithms=["EdDSA"])
+    >>> encoded = jwt.encode({"some": "payload"}, private_key, algorithm="Ed25519")
+    >>> jwt.decode(encoded, public_key, algorithms=["Ed25519"])
     {'some': 'payload'}
+
+The algorithm can be specified using the fully-specified algorithm
+identifiers ``Ed25519`` or ``Ed448`` (`RFC 9864
+<https://www.rfc-editor.org/info/rfc9864/>`_), or using the older
+polymorphic algorithm identifier ``EdDSA`` (`RFC 8037
+<https://www.rfc-editor.org/info/rfc8037/>`_), which will infer the key
+type (either Ed25519 or Ed448) automatically.
+
+Note that RFC 9864 deprecates the generic identifier ``EdDSA`` specified
+in RFC 8037 in favor of the more specific identifiers. Unless
+compatibility is a concern, new applications should prefer
+fully-specified identifiers.
 
 Encoding & Decoding Tokens with ES256 (ECDSA)
 ---------------------------------------------

--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -133,6 +133,8 @@ requires_cryptography = {
     "PS256",
     "PS384",
     "PS512",
+    "Ed25519",
+    "Ed448",
     "EdDSA",
 }
 
@@ -164,6 +166,8 @@ def get_default_algorithms() -> dict[str, Algorithm]:
                 "PS256": RSAPSSAlgorithm(RSAPSSAlgorithm.SHA256),
                 "PS384": RSAPSSAlgorithm(RSAPSSAlgorithm.SHA384),
                 "PS512": RSAPSSAlgorithm(RSAPSSAlgorithm.SHA512),
+                "Ed25519": OKPAlgorithm("Ed25519"),
+                "Ed448": OKPAlgorithm("Ed448"),
                 "EdDSA": OKPAlgorithm(),
             }
         )
@@ -869,30 +873,47 @@ if has_crypto:
             ),
         )
 
-        def __init__(self, **kwargs: Any) -> None:
-            pass
+        def __init__(
+            self, expected_curve: Literal["Ed25519", "Ed448"] | None = None
+        ) -> None:
+            self.expected_curve = expected_curve
 
         def prepare_key(self, key: AllowedOKPKeys | str | bytes) -> AllowedOKPKeys:
-            if not isinstance(key, (str, bytes)):
-                self.check_crypto_key_type(key)
-                return key
-
-            key_str = key.decode("utf-8") if isinstance(key, bytes) else key
-            key_bytes = key.encode("utf-8") if isinstance(key, str) else key
-
-            loaded_key: PublicKeyTypes | PrivateKeyTypes
-            if "-----BEGIN PUBLIC" in key_str:
-                loaded_key = load_pem_public_key(key_bytes)
-            elif "-----BEGIN PRIVATE" in key_str:
-                loaded_key = load_pem_private_key(key_bytes, password=None)
-            elif key_str[0:4] == "ssh-":
-                loaded_key = load_ssh_public_key(key_bytes)
+            prepared_key: PublicKeyTypes | PrivateKeyTypes
+            if isinstance(key, (str, bytes)):
+                key_str = key.decode("utf-8") if isinstance(key, bytes) else key
+                key_bytes = key.encode("utf-8") if isinstance(key, str) else key
+                if "-----BEGIN PUBLIC" in key_str:
+                    prepared_key = load_pem_public_key(key_bytes)
+                elif "-----BEGIN PRIVATE" in key_str:
+                    prepared_key = load_pem_private_key(key_bytes, password=None)
+                elif key_str[0:4] == "ssh-":
+                    prepared_key = load_ssh_public_key(key_bytes)
+                else:
+                    raise InvalidKeyError("Not a public or private key")
             else:
-                raise InvalidKeyError("Not a public or private key")
+                prepared_key = key
 
-            # Explicit check the key to prevent confusing errors from cryptography
-            self.check_crypto_key_type(loaded_key)
-            return cast("AllowedOKPKeys", loaded_key)
+            # Explicitly check the key to prevent confusing errors from cryptography
+            self.check_crypto_key_type(prepared_key)
+            okp_key = cast("AllowedOKPKeys", prepared_key)
+
+            if self.expected_curve is not None:
+                if isinstance(okp_key, (Ed25519PrivateKey, Ed25519PublicKey)):
+                    actual_curve = "Ed25519"
+                elif isinstance(okp_key, (Ed448PrivateKey, Ed448PublicKey)):
+                    actual_curve = "Ed448"
+                else:
+                    # Unreachable in practice because of check_crypto_key_type() above
+                    raise InvalidKeyError(f"Unsupported key type: {type(okp_key)}")
+
+                if actual_curve != self.expected_curve:
+                    raise InvalidKeyError(
+                        f"The key's curve '{actual_curve}' does not match the expected "
+                        f"curve '{self.expected_curve}' for this algorithm"
+                    )
+
+            return okp_key
 
         def sign(
             self, msg: str | bytes, key: Ed25519PrivateKey | Ed448PrivateKey

--- a/jwt/api_jwk.py
+++ b/jwt/api_jwk.py
@@ -37,9 +37,9 @@ class PyJWK:
         if not algorithm and isinstance(self._jwk_data, dict):
             algorithm = self._jwk_data.get("alg", None)
 
+        crv = self._jwk_data.get("crv", None)
         if not algorithm:
             # Determine alg with kty (and crv).
-            crv = self._jwk_data.get("crv", None)
             if kty == "EC":
                 if crv == "P-256" or not crv:
                     algorithm = "ES256"
@@ -58,7 +58,7 @@ class PyJWK:
             elif kty == "OKP":
                 if not crv:
                     raise InvalidKeyError(f"crv is not found: {self._jwk_data}")
-                if crv == "Ed25519":
+                if crv in ("Ed25519", "Ed448"):
                     algorithm = "EdDSA"
                 else:
                     raise InvalidKeyError(f"Unsupported crv: {crv}")
@@ -69,6 +69,14 @@ class PyJWK:
             raise MissingCryptographyError(
                 f"{algorithm} requires 'cryptography' to be installed."
             )
+
+        # For the OKP key type, the optional ‘alg’ can be either a polymorphic
+        # algorithm identifier (EdDSA), or a fully-specified algorithm
+        # identifier (Ed25519 or Ed448), in which case it must match the value
+        # in the required curve field. (This check cannot be done above because
+        # the OKP inference branch above only runs when the ‘alg’ is missing.)
+        if kty == "OKP" and algorithm in ("Ed25519", "Ed448") and algorithm != crv:
+            raise InvalidKeyError(f"Unsupported crv for {algorithm}: {crv}")
 
         self.algorithm_name = algorithm
 

--- a/tests/keys/jwk_okp_key_Ed25519.json
+++ b/tests/keys/jwk_okp_key_Ed25519.json
@@ -1,5 +1,6 @@
 {
   "kty":"OKP",
+  "alg":"Ed25519",
   "crv":"Ed25519",
   "d":"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",
   "x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"

--- a/tests/keys/jwk_okp_key_Ed448.json
+++ b/tests/keys/jwk_okp_key_Ed448.json
@@ -5,5 +5,5 @@
   "use": "sig",
   "x": "kvqP7TzMosCQCpNcW8qY2HmVmpPYUEIGn-sQWQgoWlAZbWpnXpXqAT6yMoYA08pkJm7P_HKZoHwA",
   "d": "Zh5xx0r_0tq39xj-8jGuCwAA6wsDim2ME7cX_iXzqDRgPN8lsZZHu60AO7m31Fa4NtHO07eU63q8",
-  "alg": "EdDSA"
+  "alg": "Ed448"
 }

--- a/tests/keys/jwk_okp_pub_Ed25519.json
+++ b/tests/keys/jwk_okp_pub_Ed25519.json
@@ -1,5 +1,6 @@
 {
   "kty":"OKP",
+  "alg":"Ed25519",
   "crv":"Ed25519",
   "x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
 }

--- a/tests/keys/jwk_okp_pub_Ed448.json
+++ b/tests/keys/jwk_okp_pub_Ed448.json
@@ -4,5 +4,5 @@
   "crv": "Ed448",
   "use": "sig",
   "x": "kvqP7TzMosCQCpNcW8qY2HmVmpPYUEIGn-sQWQgoWlAZbWpnXpXqAT6yMoYA08pkJm7P_HKZoHwA",
-  "alg": "EdDSA"
+  "alg": "Ed448"
 }

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -1195,15 +1195,8 @@ class TestOKPAlgorithms:
         assert algo.verify(b"Hello World!", pub_key_2, signature_1)
         assert algo.verify(b"Hello World!", pub_key_2, signature_2)
 
-    @crypto_required
-    def test_rsa_can_compute_digest(self) -> None:
-        # this is the well-known sha256 hash of "foo"
-        foo_hash = base64.b64decode(b"LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564=")
 
-        algo = RSAAlgorithm(RSAAlgorithm.SHA256)
-        computed_hash = algo.compute_hash_digest(b"foo")
-        assert computed_hash == foo_hash
-
+class TestHMACAlgorithms:
     def test_hmac_can_compute_digest(self) -> None:
         # this is the well-known sha256 hash of "foo"
         foo_hash = base64.b64decode(b"LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564=")
@@ -1212,7 +1205,17 @@ class TestOKPAlgorithms:
         computed_hash = algo.compute_hash_digest(b"foo")
         assert computed_hash == foo_hash
 
-    @crypto_required
+
+@crypto_required
+class TestRSAAlgorithms:
+    def test_rsa_can_compute_digest(self) -> None:
+        # this is the well-known sha256 hash of "foo"
+        foo_hash = base64.b64decode(b"LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564=")
+
+        algo = RSAAlgorithm(RSAAlgorithm.SHA256)
+        computed_hash = algo.compute_hash_digest(b"foo")
+        assert computed_hash == foo_hash
+
     def test_rsa_prepare_key_raises_invalid_key_error_on_invalid_pem(self) -> None:
         algo = RSAAlgorithm(RSAAlgorithm.SHA256)
         invalid_key = "invalid key"

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -1195,6 +1195,20 @@ class TestOKPAlgorithms:
         assert algo.verify(b"Hello World!", pub_key_2, signature_1)
         assert algo.verify(b"Hello World!", pub_key_2, signature_2)
 
+    def test_okp_fully_specified_algorithm_rejects_wrong_curve_key(self) -> None:
+        with open(key_path("jwk_okp_key_Ed25519.json")) as keyfile:
+            ed25519_key = OKPAlgorithm.from_jwk(keyfile.read())
+        assert isinstance(ed25519_key, Ed25519PrivateKey)
+        algorithm = OKPAlgorithm(expected_curve="Ed448")  # different curve
+        with pytest.raises(InvalidKeyError, match="does not match the expected curve"):
+            algorithm.prepare_key(ed25519_key)
+
+    def test_okp_validation_rejects_unknown_key_type(self) -> None:
+        algorithm = OKPAlgorithm(expected_curve="Ed25519")
+        invalid_key = object()
+        with pytest.raises(InvalidKeyError, match="Invalid Key type for OKPAlgorithm"):
+            algorithm.prepare_key(invalid_key)  # type: ignore[arg-type,unused-ignore]
+
 
 class TestHMACAlgorithms:
     def test_hmac_can_compute_digest(self) -> None:

--- a/tests/test_api_jwk.py
+++ b/tests/test_api_jwk.py
@@ -158,15 +158,65 @@ class TestPyJWK:
         assert jwk.algorithm_name == "HS256"
 
     @crypto_required
-    def test_should_load_key_okp_without_alg_from_dict(self) -> None:
-        with open(key_path("jwk_okp_pub_Ed25519.json")) as keyfile:
+    @pytest.mark.parametrize(
+        "key_file",
+        ["jwk_okp_pub_Ed25519.json", "jwk_okp_pub_Ed448.json"],
+    )
+    def test_should_load_key_okp_without_alg_from_dict(self, key_file: str) -> None:
+        with open(key_path(key_file)) as keyfile:
             key_data = json.loads(keyfile.read())
 
+        del key_data["alg"]
         jwk = PyJWK.from_dict(key_data)
 
         assert jwk.key_type == "OKP"
         assert isinstance(jwk.Algorithm, OKPAlgorithm)
         assert jwk.algorithm_name == "EdDSA"
+
+    @crypto_required
+    @pytest.mark.parametrize(
+        ("key_file", "expected_algorithm"),
+        [
+            ("jwk_okp_pub_Ed25519.json", "Ed25519"),
+            ("jwk_okp_pub_Ed448.json", "Ed448"),
+        ],
+    )
+    def test_should_load_key_okp_with_fully_specified_algorithm(
+        self, key_file: str, expected_algorithm: str
+    ) -> None:
+        with open(key_path(key_file)) as keyfile:
+            key_data = json.loads(keyfile.read())
+
+        jwk = PyJWK.from_dict(key_data)
+
+        # For fully-specified algorithm identifiers, the algorithm identifier
+        # is the same as the curve identifier.
+        assert jwk.key_type == "OKP"
+        assert isinstance(jwk.Algorithm, OKPAlgorithm)
+        assert jwk.algorithm_name == jwk.Algorithm.expected_curve == expected_algorithm
+
+    @crypto_required
+    def test_should_load_key_okp_with_alg_eddsa_from_dict(self) -> None:
+        with open(key_path("jwk_okp_pub_Ed448.json")) as keyfile:
+            key_data = json.loads(keyfile.read())
+
+        # The polymorphic algorithm identifier ‘EdDSA’ implicitly allows both
+        # ‘Ed25519’ and ‘Ed448’ keys.
+        key_data["alg"] = "EdDSA"
+        jwk = PyJWK.from_dict(key_data)
+
+        assert jwk.key_type == "OKP"
+        assert isinstance(jwk.Algorithm, OKPAlgorithm)
+        assert jwk.algorithm_name == "EdDSA"
+
+    @crypto_required
+    def test_should_reject_mismatched_okp_algorithm_and_curve(self) -> None:
+        with open(key_path("jwk_okp_pub_Ed25519.json")) as keyfile:
+            key_data = json.loads(keyfile.read())
+        assert key_data["crv"] == "Ed25519"
+        key_data["alg"] = "Ed448"  # overwrite with wrong value
+        with pytest.raises(InvalidKeyError, match="Unsupported crv for Ed448: Ed25519"):
+            PyJWK.from_dict(key_data)
 
     @crypto_required
     def test_from_dict_should_throw_exception_if_arg_is_invalid(self) -> None:

--- a/tests/test_api_jws.py
+++ b/tests/test_api_jws.py
@@ -24,6 +24,7 @@ try:
         load_pem_public_key,
         load_ssh_public_key,
     )
+    from cryptography.hazmat.primitives.asymmetric import ed25519, ed448
     from cryptography.hazmat.primitives.asymmetric.ec import (
         EllipticCurvePrivateKey,
         EllipticCurvePublicKey,
@@ -560,6 +561,37 @@ class TestJWS:
     def test_invalid_crypto_alg(self, jws: PyJWS, payload: bytes) -> None:
         with pytest.raises(NotImplementedError):
             jws.encode(payload, "secret", algorithm="HS1024")
+
+    @crypto_required
+    @pytest.mark.parametrize(
+        ("algorithm", "private_key_file", "public_key_file"),
+        [
+            ("Ed25519", "jwk_okp_key_Ed25519.json", "jwk_okp_pub_Ed25519.json"),
+            ("Ed448", "jwk_okp_key_Ed448.json", "jwk_okp_pub_Ed448.json"),
+        ],
+    )
+    def test_fully_specified_eddsa_algorithms(
+        self,
+        jws: PyJWS,
+        payload: bytes,
+        algorithm: str,
+        private_key_file: str,
+        public_key_file: str,
+    ) -> None:
+        from jwt.algorithms import OKPAlgorithm
+
+        with open(key_path(private_key_file)) as keyfile:
+            priv_key = OKPAlgorithm.from_jwk(keyfile.read())
+        with open(key_path(public_key_file)) as keyfile:
+            pub_key = OKPAlgorithm.from_jwk(keyfile.read())
+
+        assert isinstance(priv_key, (ed25519.Ed25519PrivateKey, ed448.Ed448PrivateKey))
+        assert isinstance(pub_key, (ed25519.Ed25519PublicKey, ed448.Ed448PublicKey))
+
+        token = jws.encode(payload, priv_key, algorithm=algorithm)
+
+        assert jws.get_unverified_header(token)["alg"] == algorithm
+        assert jws.decode(token, pub_key, algorithms=[algorithm]) == payload
 
     @no_crypto_required
     def test_missing_crypto_library_better_error_messages(

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ deps =
 set_env =
     MYPY_FORCE_COLOR=1
 commands =
-    mypy
+    mypy --cache-dir={envtmpdir}/mypy-cache
 
 [testenv:lint]
 basepython = python3.10


### PR DESCRIPTION
This adds support for ‘Ed25519’ and ‘Ed448’ fully-specified algorithms
as specified in RFC 9864 <https://datatracker.ietf.org/doc/html/rfc9864>,
‘Fully-Specified Algorithms for JSON Object Signing and
Encryption (JOSE) and CBOR Object Signing and Encryption (COSE)’.

Technically these are the same as the already supported ‘EdDSA’
algorithm, but with the used curve made explicit. When a fully-specified
algorithm value is used, the actual key is validated against the
expected curve type.

The original polymorphic ‘EdDSA’ identifier (which doesn't specify the
exact curve but is otherwise the same) keeps working as before.

Updated docs accordingly, and organised the overview of supported
algorithms per ‘family’ to make it easier to read.

Implementation notes:

- OKPAlgorithm now takes an optional ‘expected_curve’ argument, similar
  to ECAlgorithm.

- OKPAlgorithm.prepare_key() now checks the expected curve. This method
  now uses a single code path for validation, and curve validation is
  just a few if/else statements, without a separate helper (cf.
  ECAlgorithm._validate_curve() for EC keys which has a more complex
  control flow).

- The PyJWK constructor only handled ‘crv: Ed25519’ but not ‘crv:
  Ed448’. This seems to be an oversight from when Ed448 was added,
  because before that only Ed25519 was supported. Now it handles both.

- Example EdDSA keys for testing now include the ‘alg’ parameter, as
  recommended by RFC 9864 §7 (Security Considerations). Tests using
  these fixtures cover variants such as correct, incorrect, and missing
  ‘alg’ values.

Closes #1190.