### PR TITLE
Fix `get_jwk_set` for `PyJWKSet` values in the JWK Set cache

### DIFF
--- a/jwt/jwks_client.py
+++ b/jwt/jwks_client.py
@@ -195,6 +195,10 @@ class PyJWKClient:
         if data is None:
             data = self.fetch_data()
 
+        # The cache may hold a PyJWKSet (its documented value type, see
+        # JWKSetCache.put) as well as the raw dict stored by fetch_data().
+        if isinstance(data, PyJWKSet):
+            return data
         if not isinstance(data, dict):
             raise PyJWKClientError("The JWKS endpoint did not return a JSON object")
 

--- a/tests/test_jwks_client.py
+++ b/tests/test_jwks_client.py
@@ -15,7 +15,7 @@ import pytest
 import jwt
 from jwt import PyJWKClient
 from jwt.jwks_client import _NoRedirectHandler
-from jwt.api_jwk import PyJWK
+from jwt.api_jwk import PyJWK, PyJWKSet
 from jwt.exceptions import PyJWKClientConnectionError, PyJWKClientError
 
 from .utils import crypto_required
@@ -187,6 +187,22 @@ class TestPyJWKClient:
             jwks_client = PyJWKClient(url)
             jwk_set = jwks_client.get_jwk_set()
 
+        assert len(jwk_set.keys) == 1
+
+    def test_get_jwk_set_with_pyjwkset_in_cache(self) -> None:
+        # gh-914: JWKSetCache.put() documents PyJWKSet as the cached value,
+        # so a cache hit holding a PyJWKSet must be returned, not rejected
+        # as "did not return a JSON object".
+        url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
+
+        jwks_client = PyJWKClient(url)
+        jwks_client.jwk_set_cache.put(
+            PyJWKSet.from_dict(RESPONSE_DATA_WITH_MATCHING_KID)
+        )
+
+        jwk_set = jwks_client.get_jwk_set()
+
+        assert isinstance(jwk_set, PyJWKSet)
         assert len(jwk_set.keys) == 1
 
     def test_get_signing_keys(self) -> None:


### PR DESCRIPTION
Fixes #914.

`JWKSetCache.put()` documents `PyJWKSet` as the cached value, so callers can pre-populate the cache (e.g. with a pre-fetched JWKS to avoid a network round-trip). `get_jwk_set()` only accepted a `dict` from the cache, so a cache hit holding a `PyJWKSet` raised:

```
PyJWKClientError: The JWKS endpoint did not return a JSON object
```

which is misleading, since no endpoint call is involved.

This returns cached `PyJWKSet` values directly, before the `dict` check:

- the internal `fetch_data()` flow (which stores the raw dict) is unchanged
- other invalid cache values still raise `PyJWKClientError` as before
- adds a regression test (fails before the fix, passes after)
